### PR TITLE
Added validation functions to tuple readonly interfaces.

### DIFF
--- a/barghos-core/src/main/java/org/barghos/core/api/color/Color4R.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/color/Color4R.java
@@ -86,4 +86,28 @@ public interface Color4R extends Color3R, Tup4fR
 	 * @since 1.0.0.0
 	 */
 	default float getW() { return getUnityA(); }
+
+	@Override
+	default boolean isValid()
+	{
+		return Tup4fR.super.isValid();
+	}
+
+	@Override
+	default boolean isZero()
+	{
+		return Tup4fR.super.isZero();
+	}
+
+	@Override
+	default boolean isZero(float tolerance)
+	{
+		return Tup4fR.super.isZero(tolerance);
+	}
+
+	@Override
+	default boolean isFinite()
+	{
+		return Tup4fR.super.isFinite();
+	}
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple2/Tup2bR.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple2/Tup2bR.java
@@ -52,4 +52,49 @@ public interface Tup2bR
 	 * @since 1.0.0.0
 	 */
 	byte getY();
+	
+	/**
+	 * Returns true if all components are finite and therefore not NaN or Infinity.
+	 * 
+	 * @return True if all components are finite.
+	 */
+	default boolean isFinite()
+	{
+		return true;
+	}
+	
+	/**
+	 * Returns true if all components are exactly zero.
+	 * 
+	 * @return True if all components are exactly zero.
+	 */
+	default boolean isZero()
+	{
+		return getX() == (byte)0 &&
+				getY() == (byte)0;
+	}
+	
+	/**
+	 * Returns true if all components are zero within inclusive the given tolerance.
+	 * 
+	 * @param tolerance The tolerance around zero, that should still count as zero.
+	 * 
+	 * @return True if all components are technically zero.
+	 */
+	default boolean isZero(byte tolerance)
+	{
+		return Math.abs(getX()) <= tolerance &&
+				Math.abs(getY()) <= tolerance;
+	}
+	
+	/**
+	 * Returns true if all the components are valid.
+	 * What values are considered valid or invalid depends on the tuple type.
+	 * 
+	 * @return True if all the components are valid.
+	 */
+	default boolean isValid()
+	{
+		return true;
+	}
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple2/Tup2bigdR.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple2/Tup2bigdR.java
@@ -54,4 +54,53 @@ public interface Tup2bigdR
 	 * @since 1.0.0.0
 	 */
 	BigDecimal getY();
+	
+	/**
+	 * Returns true if all components are finite and therefore not NaN or Infinity.
+	 * This does not account for validity of the tuple.
+	 * 
+	 * @return True if all components are finite.
+	 */
+	default boolean isFinite()
+	{
+		return true;
+	}
+	
+	/**
+	 * Returns true if all components are exactly zero.
+	 * This does not account for validity of the tuple.
+	 * 
+	 * @return True if all components are exactly zero.
+	 */
+	default boolean isZero()
+	{
+		return getX().compareTo(BigDecimal.ZERO) == 0 &&
+				getY().compareTo(BigDecimal.ZERO) == 0;
+	}
+	
+	/**
+	 * Returns true if all components are zero within inclusive the given tolerance.
+	 * This does not account for validity of the tuple.
+	 * 
+	 * @param tolerance The tolerance around zero, that should still count as zero.
+	 * 
+	 * @return True if all components are technically zero.
+	 */
+	default boolean isZero(BigDecimal tolerance)
+	{
+		return getX().abs().compareTo(tolerance) <= 0 &&
+				getY().abs().compareTo(tolerance) <= 0;
+	}
+	
+	/**
+	 * Returns true if all the components are valid.
+	 * What values are considered valid or invalid depends on the tuple type.
+	 * 
+	 * @return True if all the components are valid.
+	 */
+	default boolean isValid()
+	{
+		return getX() != null &&
+				getY() != null;
+	}
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple2/Tup2bigiR.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple2/Tup2bigiR.java
@@ -54,4 +54,53 @@ public interface Tup2bigiR
 	 * @since 1.0.0.0
 	 */
 	BigInteger getY();
+	
+	/**
+	 * Returns true if all components are finite and therefore not NaN or Infinity.
+	 * This does not account for validity of the tuple.
+	 * 
+	 * @return True if all components are finite.
+	 */
+	default boolean isFinite()
+	{
+		return true;
+	}
+	
+	/**
+	 * Returns true if all components are exactly zero.
+	 * This does not account for validity of the tuple.
+	 * 
+	 * @return True if all components are exactly zero.
+	 */
+	default boolean isZero()
+	{
+		return getX().compareTo(BigInteger.ZERO) == 0 &&
+				getY().compareTo(BigInteger.ZERO) == 0;
+	}
+	
+	/**
+	 * Returns true if all components are zero within inclusive the given tolerance.
+	 * This does not account for validity of the tuple.
+	 * 
+	 * @param tolerance The tolerance around zero, that should still count as zero.
+	 * 
+	 * @return True if all components are technically zero.
+	 */
+	default boolean isZero(BigInteger tolerance)
+	{
+		return getX().abs().compareTo(tolerance) <= 0 &&
+				getY().abs().compareTo(tolerance) <= 0;
+	}
+	
+	/**
+	 * Returns true if all the components are valid.
+	 * What values are considered valid or invalid depends on the tuple type.
+	 * 
+	 * @return True if all the components are valid.
+	 */
+	default boolean isValid()
+	{
+		return getX() != null &&
+				getY() != null;
+	}
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple2/Tup2boR.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple2/Tup2boR.java
@@ -52,4 +52,15 @@ public interface Tup2boR
 	 * @since 1.0.0.0
 	 */
 	boolean getY();
+	
+	/**
+	 * Returns true if all the components are valid.
+	 * What values are considered valid or invalid depends on the tuple type.
+	 * 
+	 * @return True if all the components are valid.
+	 */
+	default boolean isValid()
+	{
+		return true;
+	}
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple2/Tup2cR.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple2/Tup2cR.java
@@ -52,4 +52,25 @@ public interface Tup2cR
 	 * @since 1.0.0.0
 	 */
 	char getY();
+	
+	/**
+	 * Returns true if all components are finite and therefore not NaN or Infinity.
+	 * 
+	 * @return True if all components are finite.
+	 */
+	default boolean isFinite()
+	{
+		return true;
+	}
+	
+	/**
+	 * Returns true if all the components are valid.
+	 * What values are considered valid or invalid depends on the tuple type.
+	 * 
+	 * @return True if all the components are valid.
+	 */
+	default boolean isValid()
+	{
+		return true;
+	}		
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple2/Tup2dR.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple2/Tup2dR.java
@@ -52,4 +52,50 @@ public interface Tup2dR
 	 * @since 1.0.0.0
 	 */
 	double getY();
+	
+	/**
+	 * Returns true if all components are finite and therefore not NaN or Infinity.
+	 * 
+	 * @return True if all components are finite.
+	 */
+	default boolean isFinite()
+	{
+		return Double.isFinite(getX()) &&
+				Double.isFinite(getY());
+	}
+	
+	/**
+	 * Returns true if all components are exactly zero.
+	 * 
+	 * @return True if all components are exactly zero.
+	 */
+	default boolean isZero()
+	{
+		return getX() == 0.0 &&
+				getY() == 0.0;
+	}
+	
+	/**
+	 * Returns true if all components are zero within inclusive the given tolerance.
+	 * 
+	 * @param tolerance The tolerance around zero, that should still count as zero.
+	 * 
+	 * @return True if all components are technically zero.
+	 */
+	default boolean isZero(double tolerance)
+	{
+		return Math.abs(getX()) <= tolerance &&
+				Math.abs(getY()) <= tolerance;
+	}
+	
+	/**
+	 * Returns true if all the components are valid.
+	 * What values are considered valid or invalid depends on the tuple type.
+	 * 
+	 * @return True if all the components are valid.
+	 */
+	default boolean isValid()
+	{
+		return true;
+	}
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple2/Tup2fR.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple2/Tup2fR.java
@@ -52,4 +52,50 @@ public interface Tup2fR
 	 * @since 1.0.0.0
 	 */
 	float getY();
+	
+	/**
+	 * Returns true if all components are finite and therefore not NaN or Infinity.
+	 * 
+	 * @return True if all components are finite.
+	 */
+	default boolean isFinite()
+	{
+		return Float.isFinite(getX()) &&
+				Float.isFinite(getY());
+	}
+	
+	/**
+	 * Returns true if all components are exactly zero.
+	 * 
+	 * @return True if all components are exactly zero.
+	 */
+	default boolean isZero()
+	{
+		return getX() == 0.0f &&
+				getY() == 0.0f;
+	}
+	
+	/**
+	 * Returns true if all components are zero within inclusive the given tolerance.
+	 * 
+	 * @param tolerance The tolerance around zero, that should still count as zero.
+	 * 
+	 * @return True if all components are technically zero.
+	 */
+	default boolean isZero(float tolerance)
+	{
+		return Math.abs(getX()) <= tolerance &&
+				Math.abs(getY()) <= tolerance;
+	}
+	
+	/**
+	 * Returns true if all the components are valid.
+	 * What values are considered valid or invalid depends on the tuple type.
+	 * 
+	 * @return True if all the components are valid.
+	 */
+	default boolean isValid()
+	{
+		return true;
+	}
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple2/Tup2iR.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple2/Tup2iR.java
@@ -52,4 +52,49 @@ public interface Tup2iR
 	 * @since 1.0.0.0
 	 */
 	int getY();
+	
+	/**
+	 * Returns true if all components are finite and therefore not NaN or Infinity.
+	 * 
+	 * @return True if all components are finite.
+	 */
+	default boolean isFinite()
+	{
+		return true;
+	}
+	
+	/**
+	 * Returns true if all components are exactly zero.
+	 * 
+	 * @return True if all components are exactly zero.
+	 */
+	default boolean isZero()
+	{
+		return getX() == 0 &&
+				getY() == 0;
+	}
+	
+	/**
+	 * Returns true if all components are zero within inclusive the given tolerance.
+	 * 
+	 * @param tolerance The tolerance around zero, that should still count as zero.
+	 * 
+	 * @return True if all components are technically zero.
+	 */
+	default boolean isZero(int tolerance)
+	{
+		return Math.abs(getX()) <= tolerance &&
+				Math.abs(getY()) <= tolerance;
+	}
+	
+	/**
+	 * Returns true if all the components are valid.
+	 * What values are considered valid or invalid depends on the tuple type.
+	 * 
+	 * @return True if all the components are valid.
+	 */
+	default boolean isValid()
+	{
+		return true;
+	}
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple2/Tup2lR.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple2/Tup2lR.java
@@ -52,4 +52,49 @@ public interface Tup2lR
 	 * @since 1.0.0.0
 	 */
 	long getY();
+	
+	/**
+	 * Returns true if all components are finite and therefore not NaN or Infinity.
+	 * 
+	 * @return True if all components are finite.
+	 */
+	default boolean isFinite()
+	{
+		return true;
+	}
+	
+	/**
+	 * Returns true if all components are exactly zero.
+	 * 
+	 * @return True if all components are exactly zero.
+	 */
+	default boolean isZero()
+	{
+		return getX() == 0l &&
+				getY() == 0l;
+	}
+	
+	/**
+	 * Returns true if all components are zero within inclusive the given tolerance.
+	 * 
+	 * @param tolerance The tolerance around zero, that should still count as zero.
+	 * 
+	 * @return True if all components are technically zero.
+	 */
+	default boolean isZero(long tolerance)
+	{
+		return Math.abs(getX()) <= tolerance &&
+				Math.abs(getY()) <= tolerance;
+	}
+	
+	/**
+	 * Returns true if all the components are valid.
+	 * What values are considered valid or invalid depends on the tuple type.
+	 * 
+	 * @return True if all the components are valid.
+	 */
+	default boolean isValid()
+	{
+		return true;
+	}
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple2/Tup2oR.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple2/Tup2oR.java
@@ -52,4 +52,16 @@ public interface Tup2oR<X,Y>
 	 * @since 1.0.0.0
 	 */
 	Y getY();
+	
+	/**
+	 * Returns true if all the components are valid.
+	 * What values are considered valid or invalid depends on the tuple type.
+	 * 
+	 * @return True if all the components are valid.
+	 */
+	default boolean isValid()
+	{
+		return getX() != null &&
+				getY() != null;
+	}
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple2/Tup2objR.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple2/Tup2objR.java
@@ -52,4 +52,16 @@ public interface Tup2objR
 	 * @since 1.0.0.0
 	 */
 	Object getY();
+	
+	/**
+	 * Returns true if all the components are valid.
+	 * What values are considered valid or invalid depends on the tuple type.
+	 * 
+	 * @return True if all the components are valid.
+	 */
+	default boolean isValid()
+	{
+		return getX() != null &&
+				getY() != null;
+	}
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple2/Tup2sR.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple2/Tup2sR.java
@@ -52,4 +52,49 @@ public interface Tup2sR
 	 * @since 1.0.0.0
 	 */
 	short getY();
+	
+	/**
+	 * Returns true if all components are finite and therefore not NaN or Infinity.
+	 * 
+	 * @return True if all components are finite.
+	 */
+	default boolean isFinite()
+	{
+		return true;
+	}
+	
+	/**
+	 * Returns true if all components are exactly zero.
+	 * 
+	 * @return True if all components are exactly zero.
+	 */
+	default boolean isZero()
+	{
+		return getX() == (short)0 &&
+				getY() == (short)0;
+	}
+	
+	/**
+	 * Returns true if all components are zero within inclusive the given tolerance.
+	 * 
+	 * @param tolerance The tolerance around zero, that should still count as zero.
+	 * 
+	 * @return True if all components are technically zero.
+	 */
+	default boolean isZero(short tolerance)
+	{
+		return Math.abs(getX()) <= tolerance &&
+				Math.abs(getY()) <= tolerance;
+	}
+	
+	/**
+	 * Returns true if all the components are valid.
+	 * What values are considered valid or invalid depends on the tuple type.
+	 * 
+	 * @return True if all the components are valid.
+	 */
+	default boolean isValid()
+	{
+		return true;
+	}
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple2/Tup2strR.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple2/Tup2strR.java
@@ -52,4 +52,16 @@ public interface Tup2strR
 	 * @since 1.0.0.0
 	 */
 	String getY();
+	
+	/**
+	 * Returns true if all the components are valid.
+	 * What values are considered valid or invalid depends on the tuple type.
+	 * 
+	 * @return True if all the components are valid.
+	 */
+	default boolean isValid()
+	{
+		return getX() != null &&
+				getY() != null;
+	}
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple3/Tup3bR.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple3/Tup3bR.java
@@ -61,4 +61,51 @@ public interface Tup3bR
 	 * @since 1.0.0.0
 	 */
 	byte getZ();
+	
+	/**
+	 * Returns true if all components are finite and therefore not NaN or Infinity.
+	 * 
+	 * @return True if all components are finite.
+	 */
+	default boolean isFinite()
+	{
+		return true;
+	}
+	
+	/**
+	 * Returns true if all components are exactly zero.
+	 * 
+	 * @return True if all components are exactly zero.
+	 */
+	default boolean isZero()
+	{
+		return getX() == (byte)0 &&
+				getY() == (byte)0 &&
+				getZ() == (byte)0;
+	}
+	
+	/**
+	 * Returns true if all components are zero within inclusive the given tolerance.
+	 * 
+	 * @param tolerance The tolerance around zero, that should still count as zero.
+	 * 
+	 * @return True if all components are technically zero.
+	 */
+	default boolean isZero(byte tolerance)
+	{
+		return Math.abs(getX()) <= tolerance &&
+				Math.abs(getY()) <= tolerance &&
+				Math.abs(getZ()) <= tolerance;
+	}
+	
+	/**
+	 * Returns true if all the components are valid.
+	 * What values are considered valid or invalid depends on the tuple type.
+	 * 
+	 * @return True if all the components are valid.
+	 */
+	default boolean isValid()
+	{
+		return true;
+	}
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple3/Tup3bigdR.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple3/Tup3bigdR.java
@@ -63,4 +63,56 @@ public interface Tup3bigdR
 	 * @since 1.0.0.0
 	 */
 	BigDecimal getZ();
+	
+	/**
+	 * Returns true if all components are finite and therefore not NaN or Infinity.
+	 * This does not account for validity of the tuple.
+	 * 
+	 * @return True if all components are finite.
+	 */
+	default boolean isFinite()
+	{
+		return true;
+	}
+	
+	/**
+	 * Returns true if all components are exactly zero.
+	 * This does not account for validity of the tuple.
+	 * 
+	 * @return True if all components are exactly zero.
+	 */
+	default boolean isZero()
+	{
+		return getX().compareTo(BigDecimal.ZERO) == 0 &&
+				getY().compareTo(BigDecimal.ZERO) == 0 &&
+				getZ().compareTo(BigDecimal.ZERO) == 0;
+	}
+	
+	/**
+	 * Returns true if all components are zero within inclusive the given tolerance.
+	 * This does not account for validity of the tuple.
+	 * 
+	 * @param tolerance The tolerance around zero, that should still count as zero.
+	 * 
+	 * @return True if all components are technically zero.
+	 */
+	default boolean isZero(BigDecimal tolerance)
+	{
+		return getX().abs().compareTo(tolerance) <= 0 &&
+				getY().abs().compareTo(tolerance) <= 0 &&
+				getZ().abs().compareTo(tolerance) <= 0;
+	}
+	
+	/**
+	 * Returns true if all the components are valid.
+	 * What values are considered valid or invalid depends on the tuple type.
+	 * 
+	 * @return True if all the components are valid.
+	 */
+	default boolean isValid()
+	{
+		return getX() != null &&
+				getY() != null &&
+				getZ() != null;
+	}
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple3/Tup3bigiR.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple3/Tup3bigiR.java
@@ -63,4 +63,56 @@ public interface Tup3bigiR
 	 * @since 1.0.0.0
 	 */
 	BigInteger getZ();
+	
+	/**
+	 * Returns true if all components are finite and therefore not NaN or Infinity.
+	 * This does not account for validity of the tuple.
+	 * 
+	 * @return True if all components are finite.
+	 */
+	default boolean isFinite()
+	{
+		return true;
+	}
+	
+	/**
+	 * Returns true if all components are exactly zero.
+	 * This does not account for validity of the tuple.
+	 * 
+	 * @return True if all components are exactly zero.
+	 */
+	default boolean isZero()
+	{
+		return getX().compareTo(BigInteger.ZERO) == 0 &&
+				getY().compareTo(BigInteger.ZERO) == 0 &&
+				getZ().compareTo(BigInteger.ZERO) == 0;
+	}
+	
+	/**
+	 * Returns true if all components are zero within inclusive the given tolerance.
+	 * This does not account for validity of the tuple.
+	 * 
+	 * @param tolerance The tolerance around zero, that should still count as zero.
+	 * 
+	 * @return True if all components are technically zero.
+	 */
+	default boolean isZero(BigInteger tolerance)
+	{
+		return getX().abs().compareTo(tolerance) <= 0 &&
+				getY().abs().compareTo(tolerance) <= 0 &&
+				getZ().abs().compareTo(tolerance) <= 0;
+	}
+	
+	/**
+	 * Returns true if all the components are valid.
+	 * What values are considered valid or invalid depends on the tuple type.
+	 * 
+	 * @return True if all the components are valid.
+	 */
+	default boolean isValid()
+	{
+		return getX() != null &&
+				getY() != null &&
+				getZ() != null;
+	}
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple3/Tup3boR.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple3/Tup3boR.java
@@ -61,4 +61,15 @@ public interface Tup3boR
 	 * @since 1.0.0.0
 	 */
 	boolean getZ();
+	
+	/**
+	 * Returns true if all the components are valid.
+	 * What values are considered valid or invalid depends on the tuple type.
+	 * 
+	 * @return True if all the components are valid.
+	 */
+	default boolean isValid()
+	{
+		return true;
+	}
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple3/Tup3cR.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple3/Tup3cR.java
@@ -61,4 +61,25 @@ public interface Tup3cR
 	 * @since 1.0.0.0
 	 */
 	char getZ();
+	
+	/**
+	 * Returns true if all components are finite and therefore not NaN or Infinity.
+	 * 
+	 * @return True if all components are finite.
+	 */
+	default boolean isFinite()
+	{
+		return true;
+	}
+	
+	/**
+	 * Returns true if all the components are valid.
+	 * What values are considered valid or invalid depends on the tuple type.
+	 * 
+	 * @return True if all the components are valid.
+	 */
+	default boolean isValid()
+	{
+		return true;
+	}	
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple3/Tup3dR.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple3/Tup3dR.java
@@ -61,4 +61,53 @@ public interface Tup3dR
 	 * @since 1.0.0.0
 	 */
 	double getZ();
+	
+	/**
+	 * Returns true if all components are finite and therefore not NaN or Infinity.
+	 * 
+	 * @return True if all components are finite.
+	 */
+	default boolean isFinite()
+	{
+		return Double.isFinite(getX()) &&
+				Double.isFinite(getY()) &&
+				Double.isFinite(getZ());
+	}
+	
+	/**
+	 * Returns true if all components are exactly zero.
+	 * 
+	 * @return True if all components are exactly zero.
+	 */
+	default boolean isZero()
+	{
+		return getX() == 0.0 &&
+				getY() == 0.0 &&
+				getZ() == 0.0;
+	}
+	
+	/**
+	 * Returns true if all components are zero within inclusive the given tolerance.
+	 * 
+	 * @param tolerance The tolerance around zero, that should still count as zero.
+	 * 
+	 * @return True if all components are technically zero.
+	 */
+	default boolean isZero(double tolerance)
+	{
+		return Math.abs(getX()) <= tolerance &&
+				Math.abs(getY()) <= tolerance &&
+				Math.abs(getZ()) <= tolerance;
+	}
+	
+	/**
+	 * Returns true if all the components are valid.
+	 * What values are considered valid or invalid depends on the tuple type.
+	 * 
+	 * @return True if all the components are valid.
+	 */
+	default boolean isValid()
+	{
+		return true;
+	}
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple3/Tup3fR.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple3/Tup3fR.java
@@ -61,4 +61,53 @@ public interface Tup3fR
 	 * @since 1.0.0.0
 	 */
 	float getZ();
+	
+	/**
+	 * Returns true if all components are finite and therefore not NaN or Infinity.
+	 * 
+	 * @return True if all components are finite.
+	 */
+	default boolean isFinite()
+	{
+		return Float.isFinite(getX()) &&
+				Float.isFinite(getY()) &&
+				Float.isFinite(getZ());
+	}
+	
+	/**
+	 * Returns true if all components are exactly zero.
+	 * 
+	 * @return True if all components are exactly zero.
+	 */
+	default boolean isZero()
+	{
+		return getX() == 0.0f &&
+				getY() == 0.0f &&
+				getZ() == 0.0f;
+	}
+	
+	/**
+	 * Returns true if all components are zero within inclusive the given tolerance.
+	 * 
+	 * @param tolerance The tolerance around zero, that should still count as zero.
+	 * 
+	 * @return True if all components are technically zero.
+	 */
+	default boolean isZero(float tolerance)
+	{
+		return Math.abs(getX()) <= tolerance &&
+				Math.abs(getY()) <= tolerance &&
+				Math.abs(getZ()) <= tolerance;
+	}
+	
+	/**
+	 * Returns true if all the components are valid.
+	 * What values are considered valid or invalid depends on the tuple type.
+	 * 
+	 * @return True if all the components are valid.
+	 */
+	default boolean isValid()
+	{
+		return true;
+	}
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple3/Tup3iR.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple3/Tup3iR.java
@@ -61,4 +61,51 @@ public interface Tup3iR
 	 * @since 1.0.0.0
 	 */
 	int getZ();
+	
+	/**
+	 * Returns true if all components are finite and therefore not NaN or Infinity.
+	 * 
+	 * @return True if all components are finite.
+	 */
+	default boolean isFinite()
+	{
+		return true;
+	}
+	
+	/**
+	 * Returns true if all components are exactly zero.
+	 * 
+	 * @return True if all components are exactly zero.
+	 */
+	default boolean isZero()
+	{
+		return getX() == 0 &&
+				getY() == 0 &&
+				getZ() == 0;
+	}
+	
+	/**
+	 * Returns true if all components are zero within inclusive the given tolerance.
+	 * 
+	 * @param tolerance The tolerance around zero, that should still count as zero.
+	 * 
+	 * @return True if all components are technically zero.
+	 */
+	default boolean isZero(int tolerance)
+	{
+		return Math.abs(getX()) <= tolerance &&
+				Math.abs(getY()) <= tolerance &&
+				Math.abs(getZ()) <= tolerance;
+	}
+	
+	/**
+	 * Returns true if all the components are valid.
+	 * What values are considered valid or invalid depends on the tuple type.
+	 * 
+	 * @return True if all the components are valid.
+	 */
+	default boolean isValid()
+	{
+		return true;
+	}
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple3/Tup3lR.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple3/Tup3lR.java
@@ -61,4 +61,51 @@ public interface Tup3lR
 	 * @since 1.0.0.0
 	 */
 	long getZ();
+	
+	/**
+	 * Returns true if all components are finite and therefore not NaN or Infinity.
+	 * 
+	 * @return True if all components are finite.
+	 */
+	default boolean isFinite()
+	{
+		return true;
+	}
+	
+	/**
+	 * Returns true if all components are exactly zero.
+	 * 
+	 * @return True if all components are exactly zero.
+	 */
+	default boolean isZero()
+	{
+		return getX() == 0l &&
+				getY() == 0l &&
+				getZ() == 0l;
+	}
+	
+	/**
+	 * Returns true if all components are zero within inclusive the given tolerance.
+	 * 
+	 * @param tolerance The tolerance around zero, that should still count as zero.
+	 * 
+	 * @return True if all components are technically zero.
+	 */
+	default boolean isZero(long tolerance)
+	{
+		return Math.abs(getX()) <= tolerance &&
+				Math.abs(getY()) <= tolerance &&
+				Math.abs(getZ()) <= tolerance;
+	}
+	
+	/**
+	 * Returns true if all the components are valid.
+	 * What values are considered valid or invalid depends on the tuple type.
+	 * 
+	 * @return True if all the components are valid.
+	 */
+	default boolean isValid()
+	{
+		return true;
+	}
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple3/Tup3oR.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple3/Tup3oR.java
@@ -61,4 +61,17 @@ public interface Tup3oR<X,Y,Z>
 	 * @since 1.0.0.0
 	 */
 	Z getZ();
+	
+	/**
+	 * Returns true if all the components are valid.
+	 * What values are considered valid or invalid depends on the tuple type.
+	 * 
+	 * @return True if all the components are valid.
+	 */
+	default boolean isValid()
+	{
+		return getX() != null &&
+				getY() != null &&
+				getZ() != null;
+	}
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple3/Tup3objR.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple3/Tup3objR.java
@@ -61,4 +61,17 @@ public interface Tup3objR
 	 * @since 1.0.0.0
 	 */
 	Object getZ();
+	
+	/**
+	 * Returns true if all the components are valid.
+	 * What values are considered valid or invalid depends on the tuple type.
+	 * 
+	 * @return True if all the components are valid.
+	 */
+	default boolean isValid()
+	{
+		return getX() != null &&
+				getY() != null &&
+				getZ() != null;
+	}
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple3/Tup3sR.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple3/Tup3sR.java
@@ -61,4 +61,51 @@ public interface Tup3sR
 	 * @since 1.0.0.0
 	 */
 	short getZ();
+	
+	/**
+	 * Returns true if all components are finite and therefore not NaN or Infinity.
+	 * 
+	 * @return True if all components are finite.
+	 */
+	default boolean isFinite()
+	{
+		return true;
+	}
+	
+	/**
+	 * Returns true if all components are exactly zero.
+	 * 
+	 * @return True if all components are exactly zero.
+	 */
+	default boolean isZero()
+	{
+		return getX() == (short)0 &&
+				getY() == (short)0 &&
+				getZ() == (short)0;
+	}
+	
+	/**
+	 * Returns true if all components are zero within inclusive the given tolerance.
+	 * 
+	 * @param tolerance The tolerance around zero, that should still count as zero.
+	 * 
+	 * @return True if all components are technically zero.
+	 */
+	default boolean isZero(short tolerance)
+	{
+		return Math.abs(getX()) <= tolerance &&
+				Math.abs(getY()) <= tolerance &&
+				Math.abs(getZ()) <= tolerance;
+	}
+	
+	/**
+	 * Returns true if all the components are valid.
+	 * What values are considered valid or invalid depends on the tuple type.
+	 * 
+	 * @return True if all the components are valid.
+	 */
+	default boolean isValid()
+	{
+		return true;
+	}
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple3/Tup3strR.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple3/Tup3strR.java
@@ -61,4 +61,17 @@ public interface Tup3strR
 	 * @since 1.0.0.0
 	 */
 	String getZ();
+	
+	/**
+	 * Returns true if all the components are valid.
+	 * What values are considered valid or invalid depends on the tuple type.
+	 * 
+	 * @return True if all the components are valid.
+	 */
+	default boolean isValid()
+	{
+		return getX() != null &&
+				getY() != null &&
+				getZ() != null;
+	}
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple4/Tup4bR.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple4/Tup4bR.java
@@ -70,4 +70,53 @@ public interface Tup4bR
 	 * @since 1.0.0.0
 	 */
 	byte getW();
+	
+	/**
+	 * Returns true if all components are finite and therefore not NaN or Infinity.
+	 * 
+	 * @return True if all components are finite.
+	 */
+	default boolean isFinite()
+	{
+		return true;
+	}
+	
+	/**
+	 * Returns true if all components are exactly zero.
+	 * 
+	 * @return True if all components are exactly zero.
+	 */
+	default boolean isZero()
+	{
+		return getX() == (byte)0 &&
+				getY() == (byte)0 &&
+				getZ() == (byte)0 &&
+				getW() == (byte)0;
+	}
+	
+	/**
+	 * Returns true if all components are zero within inclusive the given tolerance.
+	 * 
+	 * @param tolerance The tolerance around zero, that should still count as zero.
+	 * 
+	 * @return True if all components are technically zero.
+	 */
+	default boolean isZero(byte tolerance)
+	{
+		return Math.abs(getX()) <= tolerance &&
+				Math.abs(getY()) <= tolerance &&
+				Math.abs(getZ()) <= tolerance &&
+				Math.abs(getW()) <= tolerance;
+	}
+	
+	/**
+	 * Returns true if all the components are valid.
+	 * What values are considered valid or invalid depends on the tuple type.
+	 * 
+	 * @return True if all the components are valid.
+	 */
+	default boolean isValid()
+	{
+		return true;
+	}
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple4/Tup4bigdR.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple4/Tup4bigdR.java
@@ -72,4 +72,59 @@ public interface Tup4bigdR
 	 * @since 1.0.0.0
 	 */
 	BigDecimal getW();
+	
+	/**
+	 * Returns true if all components are finite and therefore not NaN or Infinity.
+	 * This does not account for validity of the tuple.
+	 * 
+	 * @return True if all components are finite.
+	 */
+	default boolean isFinite()
+	{
+		return true;
+	}
+	
+	/**
+	 * Returns true if all components are exactly zero.
+	 * This does not account for validity of the tuple.
+	 * 
+	 * @return True if all components are exactly zero.
+	 */
+	default boolean isZero()
+	{
+		return getX().compareTo(BigDecimal.ZERO) == 0 &&
+				getY().compareTo(BigDecimal.ZERO) == 0 &&
+				getZ().compareTo(BigDecimal.ZERO) == 0 &&
+				getW().compareTo(BigDecimal.ZERO) == 0;
+	}
+	
+	/**
+	 * Returns true if all components are zero within inclusive the given tolerance.
+	 * This does not account for validity of the tuple.
+	 * 
+	 * @param tolerance The tolerance around zero, that should still count as zero.
+	 * 
+	 * @return True if all components are technically zero.
+	 */
+	default boolean isZero(BigDecimal tolerance)
+	{
+		return getX().abs().compareTo(tolerance) <= 0 &&
+				getY().abs().compareTo(tolerance) <= 0 &&
+				getZ().abs().compareTo(tolerance) <= 0 &&
+				getW().abs().compareTo(tolerance) <= 0;
+	}
+	
+	/**
+	 * Returns true if all the components are valid.
+	 * What values are considered valid or invalid depends on the tuple type.
+	 * 
+	 * @return True if all the components are valid.
+	 */
+	default boolean isValid()
+	{
+		return getX() != null &&
+				getY() != null &&
+				getZ() != null &&
+				getW() != null;
+	}
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple4/Tup4bigiR.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple4/Tup4bigiR.java
@@ -72,4 +72,59 @@ public interface Tup4bigiR
 	 * @since 1.0.0.0
 	 */
 	BigInteger getW();
+	
+	/**
+	 * Returns true if all components are finite and therefore not NaN or Infinity.
+	 * This does not account for validity of the tuple.
+	 * 
+	 * @return True if all components are finite.
+	 */
+	default boolean isFinite()
+	{
+		return true;
+	}
+	
+	/**
+	 * Returns true if all components are exactly zero.
+	 * This does not account for validity of the tuple.
+	 * 
+	 * @return True if all components are exactly zero.
+	 */
+	default boolean isZero()
+	{
+		return getX().compareTo(BigInteger.ZERO) == 0 &&
+				getY().compareTo(BigInteger.ZERO) == 0 &&
+				getZ().compareTo(BigInteger.ZERO) == 0 &&
+				getW().compareTo(BigInteger.ZERO) == 0;
+	}
+	
+	/**
+	 * Returns true if all components are zero within inclusive the given tolerance.
+	 * This does not account for validity of the tuple.
+	 * 
+	 * @param tolerance The tolerance around zero, that should still count as zero.
+	 * 
+	 * @return True if all components are technically zero.
+	 */
+	default boolean isZero(BigInteger tolerance)
+	{
+		return getX().abs().compareTo(tolerance) <= 0 &&
+				getY().abs().compareTo(tolerance) <= 0 &&
+				getZ().abs().compareTo(tolerance) <= 0 &&
+				getW().abs().compareTo(tolerance) <= 0;
+	}
+	
+	/**
+	 * Returns true if all the components are valid.
+	 * What values are considered valid or invalid depends on the tuple type.
+	 * 
+	 * @return True if all the components are valid.
+	 */
+	default boolean isValid()
+	{
+		return getX() != null &&
+				getY() != null &&
+				getZ() != null &&
+				getW() != null;
+	}
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple4/Tup4boR.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple4/Tup4boR.java
@@ -70,4 +70,15 @@ public interface Tup4boR
 	 * @since 1.0.0.0
 	 */
 	boolean getW();
+	
+	/**
+	 * Returns true if all the components are valid.
+	 * What values are considered valid or invalid depends on the tuple type.
+	 * 
+	 * @return True if all the components are valid.
+	 */
+	default boolean isValid()
+	{
+		return true;
+	}
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple4/Tup4cR.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple4/Tup4cR.java
@@ -70,4 +70,25 @@ public interface Tup4cR
 	 * @since 1.0.0.0
 	 */
 	char getW();
+	
+	/**
+	 * Returns true if all components are finite and therefore not NaN or Infinity.
+	 * 
+	 * @return True if all components are finite.
+	 */
+	default boolean isFinite()
+	{
+		return true;
+	}
+	
+	/**
+	 * Returns true if all the components are valid.
+	 * What values are considered valid or invalid depends on the tuple type.
+	 * 
+	 * @return True if all the components are valid.
+	 */
+	default boolean isValid()
+	{
+		return true;
+	}	
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple4/Tup4dR.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple4/Tup4dR.java
@@ -70,4 +70,56 @@ public interface Tup4dR
 	 * @since 1.0.0.0
 	 */
 	double getW();
+	
+	/**
+	 * Returns true if all components are finite and therefore not NaN or Infinity.
+	 * 
+	 * @return True if all components are finite.
+	 */
+	default boolean isFinite()
+	{
+		return Double.isFinite(getX()) &&
+				Double.isFinite(getY()) &&
+				Double.isFinite(getZ()) &&
+				Double.isFinite(getW());
+	}
+	
+	/**
+	 * Returns true if all components are exactly zero.
+	 * 
+	 * @return True if all components are exactly zero.
+	 */
+	default boolean isZero()
+	{
+		return getX() == 0.0 &&
+				getY() == 0.0 &&
+				getZ() == 0.0 &&
+				getW() == 0.0;
+	}
+	
+	/**
+	 * Returns true if all components are zero within inclusive the given tolerance.
+	 * 
+	 * @param tolerance The tolerance around zero, that should still count as zero.
+	 * 
+	 * @return True if all components are technically zero.
+	 */
+	default boolean isZero(double tolerance)
+	{
+		return Math.abs(getX()) <= tolerance &&
+				Math.abs(getY()) <= tolerance &&
+				Math.abs(getZ()) <= tolerance &&
+				Math.abs(getW()) <= tolerance;
+	}
+	
+	/**
+	 * Returns true if all the components are valid.
+	 * What values are considered valid or invalid depends on the tuple type.
+	 * 
+	 * @return True if all the components are valid.
+	 */
+	default boolean isValid()
+	{
+		return true;
+	}
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple4/Tup4fR.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple4/Tup4fR.java
@@ -70,4 +70,56 @@ public interface Tup4fR
 	 * @since 1.0.0.0
 	 */
 	float getW();
+	
+	/**
+	 * Returns true if all components are finite and therefore not NaN or Infinity.
+	 * 
+	 * @return True if all components are finite.
+	 */
+	default boolean isFinite()
+	{
+		return Float.isFinite(getX()) &&
+				Float.isFinite(getY()) &&
+				Float.isFinite(getZ()) &&
+				Float.isFinite(getW());
+	}
+	
+	/**
+	 * Returns true if all components are exactly zero.
+	 * 
+	 * @return True if all components are exactly zero.
+	 */
+	default boolean isZero()
+	{
+		return getX() == 0.0f &&
+				getY() == 0.0f &&
+				getZ() == 0.0f &&
+				getW() == 0.0f;
+	}
+	
+	/**
+	 * Returns true if all components are zero within inclusive the given tolerance.
+	 * 
+	 * @param tolerance The tolerance around zero, that should still count as zero.
+	 * 
+	 * @return True if all components are technically zero.
+	 */
+	default boolean isZero(float tolerance)
+	{
+		return Math.abs(getX()) <= tolerance &&
+				Math.abs(getY()) <= tolerance &&
+				Math.abs(getZ()) <= tolerance &&
+				Math.abs(getW()) <= tolerance;
+	}
+	
+	/**
+	 * Returns true if all the components are valid.
+	 * What values are considered valid or invalid depends on the tuple type.
+	 * 
+	 * @return True if all the components are valid.
+	 */
+	default boolean isValid()
+	{
+		return true;
+	}
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple4/Tup4iR.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple4/Tup4iR.java
@@ -70,4 +70,53 @@ public interface Tup4iR
 	 * @since 1.0.0.0
 	 */
 	int getW();
+	
+	/**
+	 * Returns true if all components are finite and therefore not NaN or Infinity.
+	 * 
+	 * @return True if all components are finite.
+	 */
+	default boolean isFinite()
+	{
+		return true;
+	}
+	
+	/**
+	 * Returns true if all components are exactly zero.
+	 * 
+	 * @return True if all components are exactly zero.
+	 */
+	default boolean isZero()
+	{
+		return getX() == 0 &&
+				getY() == 0 &&
+				getZ() == 0 &&
+				getW() == 0;
+	}
+	
+	/**
+	 * Returns true if all components are zero within inclusive the given tolerance.
+	 * 
+	 * @param tolerance The tolerance around zero, that should still count as zero.
+	 * 
+	 * @return True if all components are technically zero.
+	 */
+	default boolean isZero(int tolerance)
+	{
+		return Math.abs(getX()) <= tolerance &&
+				Math.abs(getY()) <= tolerance &&
+				Math.abs(getZ()) <= tolerance &&
+				Math.abs(getW()) <= tolerance;
+	}
+	
+	/**
+	 * Returns true if all the components are valid.
+	 * What values are considered valid or invalid depends on the tuple type.
+	 * 
+	 * @return True if all the components are valid.
+	 */
+	default boolean isValid()
+	{
+		return true;
+	}
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple4/Tup4lR.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple4/Tup4lR.java
@@ -70,4 +70,53 @@ public interface Tup4lR
 	 * @since 1.0.0.0
 	 */
 	long getW();
+	
+	/**
+	 * Returns true if all components are finite and therefore not NaN or Infinity.
+	 * 
+	 * @return True if all components are finite.
+	 */
+	default boolean isFinite()
+	{
+		return true;
+	}
+	
+	/**
+	 * Returns true if all components are exactly zero.
+	 * 
+	 * @return True if all components are exactly zero.
+	 */
+	default boolean isZero()
+	{
+		return getX() == 0l &&
+				getY() == 0l &&
+				getZ() == 0l &&
+				getW() == 0l;
+	}
+	
+	/**
+	 * Returns true if all components are zero within inclusive the given tolerance.
+	 * 
+	 * @param tolerance The tolerance around zero, that should still count as zero.
+	 * 
+	 * @return True if all components are technically zero.
+	 */
+	default boolean isZero(long tolerance)
+	{
+		return Math.abs(getX()) <= tolerance &&
+				Math.abs(getY()) <= tolerance &&
+				Math.abs(getZ()) <= tolerance &&
+				Math.abs(getW()) <= tolerance;
+	}
+	
+	/**
+	 * Returns true if all the components are valid.
+	 * What values are considered valid or invalid depends on the tuple type.
+	 * 
+	 * @return True if all the components are valid.
+	 */
+	default boolean isValid()
+	{
+		return true;
+	}
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple4/Tup4oR.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple4/Tup4oR.java
@@ -70,4 +70,18 @@ public interface Tup4oR<X,Y,Z,W>
 	 * @since 1.0.0.0
 	 */
 	W getW();
+	
+	/**
+	 * Returns true if all the components are valid.
+	 * What values are considered valid or invalid depends on the tuple type.
+	 * 
+	 * @return True if all the components are valid.
+	 */
+	default boolean isValid()
+	{
+		return getX() != null &&
+				getY() != null &&
+				getZ() != null &&
+				getW() != null;
+	}
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple4/Tup4objR.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple4/Tup4objR.java
@@ -70,4 +70,18 @@ public interface Tup4objR
 	 * @since 1.0.0.0
 	 */
 	Object getW();
+	
+	/**
+	 * Returns true if all the components are valid.
+	 * What values are considered valid or invalid depends on the tuple type.
+	 * 
+	 * @return True if all the components are valid.
+	 */
+	default boolean isValid()
+	{
+		return getX() != null &&
+				getY() != null &&
+				getZ() != null &&
+				getW() != null;
+	}
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple4/Tup4sR.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple4/Tup4sR.java
@@ -70,4 +70,53 @@ public interface Tup4sR
 	 * @since 1.0.0.0
 	 */
 	short getW();
+	
+	/**
+	 * Returns true if all components are finite and therefore not NaN or Infinity.
+	 * 
+	 * @return True if all components are finite.
+	 */
+	default boolean isFinite()
+	{
+		return true;
+	}
+	
+	/**
+	 * Returns true if all components are exactly zero.
+	 * 
+	 * @return True if all components are exactly zero.
+	 */
+	default boolean isZero()
+	{
+		return getX() == (short)0 &&
+				getY() == (short)0 &&
+				getZ() == (short)0 &&
+				getW() == (short)0;
+	}
+	
+	/**
+	 * Returns true if all components are zero within inclusive the given tolerance.
+	 * 
+	 * @param tolerance The tolerance around zero, that should still count as zero.
+	 * 
+	 * @return True if all components are technically zero.
+	 */
+	default boolean isZero(short tolerance)
+	{
+		return Math.abs(getX()) <= tolerance &&
+				Math.abs(getY()) <= tolerance &&
+				Math.abs(getZ()) <= tolerance &&
+				Math.abs(getW()) <= tolerance;
+	}
+	
+	/**
+	 * Returns true if all the components are valid.
+	 * What values are considered valid or invalid depends on the tuple type.
+	 * 
+	 * @return True if all the components are valid.
+	 */
+	default boolean isValid()
+	{
+		return true;
+	}
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple4/Tup4strR.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple4/Tup4strR.java
@@ -70,4 +70,18 @@ public interface Tup4strR
 	 * @since 1.0.0.0
 	 */
 	String getW();
+	
+	/**
+	 * Returns true if all the components are valid.
+	 * What values are considered valid or invalid depends on the tuple type.
+	 * 
+	 * @return True if all the components are valid.
+	 */
+	default boolean isValid()
+	{
+		return getX() != null &&
+				getY() != null &&
+				getZ() != null &&
+				getW() != null;
+	}
 }

--- a/barghos-core/src/test/java/org/barghos/core/test/api/tuple2/Tup2bRTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/api/tuple2/Tup2bRTest.java
@@ -1,0 +1,149 @@
+package org.barghos.core.test.api.tuple2;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+import org.barghos.core.api.testing.ValueRelay;
+import org.barghos.core.api.tuple2.Tup2bR;
+
+/**
+ * This class provides component tests for the interface {@link Tup2bR}.
+ * 
+ * @author picatrix1899
+ */
+class Tup2bRTest
+{
+	/**
+	 * This test ensures, that the function {@link Tup2bR#isValid()} returns
+	 * the corrct values for different situations.
+	 */
+	@Test
+	void isValidTest()
+	{
+		Tup2bR t = new Tup2bR() {
+			public byte getX()
+			{
+				ValueRelay.relayCall("getX");
+				return (byte)0;
+			}
+
+			public byte getY()
+			{
+				ValueRelay.relayCall("getY");
+				return (byte)0;
+			}
+		};
+		
+		assertEquals(true, t.isValid());
+		assertEquals(false, ValueRelay.get("getX", false));
+		assertEquals(false, ValueRelay.get("getY", false));
+	}
+	
+	/**
+	 * This test ensures, that the function {@link Tup2bR#isFinite()} returns
+	 * the corrct values for different situations.
+	 */
+	@Test
+	void isFiniteTest()
+	{
+		Tup2bR t = new Tup2bR() {
+			public byte getX()
+			{
+				ValueRelay.relayCall("getX");
+				return (byte)0;
+			}
+
+			public byte getY()
+			{
+				ValueRelay.relayCall("getY");
+				return (byte)0;
+			}
+		};
+		
+		assertEquals(true, t.isFinite());
+		assertEquals(false, ValueRelay.get("getX", false));
+		assertEquals(false, ValueRelay.get("getY", false));
+	}
+	
+	/**
+	 * This test ensures, that the function {@link Tup2bR#isZero()} returns the correct
+	 * value based on the situation.
+	 */
+	@Test
+	void isZeroExactTest()
+	{
+		final byte zero = (byte)0;
+		final byte one = (byte)1;
+		
+		Tup2bR t = new TestTup(zero, zero);
+		assertEquals(true, t.isZero());
+		
+		t = new TestTup(one, zero);
+		assertEquals(false, t.isZero());
+		
+		t = new TestTup(zero, one);
+		assertEquals(false, t.isZero());
+		
+		t = new TestTup(one, one);
+		assertEquals(false, t.isZero());
+	}
+	
+	/**
+	 * This test ensures, that the function {@link Tup2bR#isZero(byte)} returns the correct
+	 * value based on the situation.
+	 */
+	@Test
+	void isZeroTest()
+	{
+		final byte zero = (byte)0;
+		
+		final int tolerance = 2;
+		final byte tol = (byte)tolerance;
+		
+		for(int i = -tolerance - 1; i <= tolerance + 1; i++)
+		{
+			byte v = (byte)i;
+			
+			boolean b = Math.abs(i) <= tolerance;
+			
+			Tup2bR t = new TestTup(v, v);
+			assertEquals(b, t.isZero(tol));
+			
+			t = new TestTup(v, zero);
+			assertEquals(b, t.isZero(tol));
+			
+			t = new TestTup(zero, v);
+			assertEquals(b, t.isZero(tol));
+		}
+	}
+	
+	/**
+	 * This class is a test implementation of the interface {@link Tup2bR}.
+	 * 
+	 * @author picatrix1899
+	 */
+	private static class TestTup implements Tup2bR
+	{
+		private final byte x;
+		private final byte y;
+		
+		public TestTup(byte x, byte y)
+		{
+			this.x = x;
+			this.y = y;
+		}
+		
+		@Override
+		public byte getX()
+		{
+			return this.x;
+		}
+		
+		@Override
+		public byte getY()
+		{
+			return this.y;
+		}
+	}
+}

--- a/barghos-core/src/test/java/org/barghos/core/test/api/tuple2/Tup2bigdRTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/api/tuple2/Tup2bigdRTest.java
@@ -1,0 +1,147 @@
+package org.barghos.core.test.api.tuple2;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+
+import org.barghos.core.api.testing.ValueRelay;
+import org.barghos.core.api.tuple2.Tup2bigdR;
+
+/**
+ * This class provides component tests for the interface {@link Tup2bigdR}.
+ * 
+ * @author picatrix1899
+ */
+class Tup2bigdRTest
+{
+	/**
+	 * This test ensures, that the function {@link Tup2bigdR#isValid()} returns
+	 * the corrct values for different situations.
+	 */
+	@Test
+	void isValidTest()
+	{
+		final BigDecimal one = BigDecimal.ONE;
+		
+		Tup2bigdR t = new TestTup(null, null);
+		assertEquals(false, t.isValid());
+		
+		t = new TestTup(one, null);
+		assertEquals(false, t.isValid());
+		
+		t = new TestTup(null, one);
+		assertEquals(false, t.isValid());
+		
+		t = new TestTup(one, one);
+		assertEquals(true, t.isValid());
+	}
+	
+	/**
+	 * This test ensures, that the function {@link Tup2bigdR#isFinite()} returns
+	 * the corrct values for different situations.
+	 */
+	@Test
+	void isFiniteTest()
+	{
+		Tup2bigdR t = new Tup2bigdR() {
+			public BigDecimal getX()
+			{
+				ValueRelay.relayCall("getX");
+				return null;
+			}
+
+			public BigDecimal getY()
+			{
+				ValueRelay.relayCall("getY");
+				return null;
+			}
+		};
+		
+		assertEquals(true, t.isFinite());
+		assertEquals(false, ValueRelay.get("getX", false));
+		assertEquals(false, ValueRelay.get("getY", false));
+	}
+	
+	/**
+	 * This test ensures, that the function {@link Tup2bigdR#isZero()} returns the correct
+	 * value based on the situation.
+	 */
+	@Test
+	void isZeroExactTest()
+	{
+		final BigDecimal zero = BigDecimal.ZERO;
+		final BigDecimal one = BigDecimal.ONE;
+		
+		Tup2bigdR t = new TestTup(zero, zero);
+		assertEquals(true, t.isZero());
+		
+		t = new TestTup(one, zero);
+		assertEquals(false, t.isZero());
+		
+		t = new TestTup(zero, one);
+		assertEquals(false, t.isZero());
+		
+		t = new TestTup(one, one);
+		assertEquals(false, t.isZero());
+	}
+	
+	/**
+	 * This test ensures, that the function {@link Tup2bigdR#isZero(BigDecimal)} returns the correct
+	 * value based on the situation.
+	 */
+	@Test
+	void isZeroTest()
+	{
+		final BigDecimal zero = BigDecimal.ZERO;
+		
+		final int tolerance = 2;
+		final BigDecimal tol = BigDecimal.valueOf(tolerance);
+		
+		for(int i = -tolerance - 1; i <= tolerance + 1; i++)
+		{
+			BigDecimal v = BigDecimal.valueOf(i);
+			
+			boolean b = Math.abs(i) <= tolerance;
+			
+			Tup2bigdR t = new TestTup(v, v);
+			assertEquals(b, t.isZero(tol));
+			
+			t = new TestTup(v, zero);
+			assertEquals(b, t.isZero(tol));
+			
+			t = new TestTup(zero, v);
+			assertEquals(b, t.isZero(tol));
+		}
+	}
+	
+	/**
+	 * This class is a test implementation of the interface {@link Tup2bigdR}.
+	 * 
+	 * @author picatrix1899
+	 */
+	private static class TestTup implements Tup2bigdR
+	{
+		private final BigDecimal x;
+		private final BigDecimal y;
+		
+		public TestTup(BigDecimal x, BigDecimal y)
+		{
+			this.x = x;
+			this.y = y;
+		}
+		
+		@Override
+		public BigDecimal getX()
+		{
+			return this.x;
+		}
+		
+		@Override
+		public BigDecimal getY()
+		{
+			return this.y;
+		}
+	}
+}

--- a/barghos-core/src/test/java/org/barghos/core/test/api/tuple2/Tup2bigiRTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/api/tuple2/Tup2bigiRTest.java
@@ -1,0 +1,148 @@
+package org.barghos.core.test.api.tuple2;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+import org.barghos.core.api.testing.ValueRelay;
+import org.barghos.core.api.tuple2.Tup2bigiR;
+
+/**
+ * This class provides component tests for the interface {@link Tup2bigiR}.
+ * 
+ * @author picatrix1899
+ */
+class Tup2bigiRTest
+{
+	/**
+	 * This test ensures, that the function {@link Tup2bigiR#isValid()} returns
+	 * the corrct values for different situations.
+	 */
+	@Test
+	void isValidTest()
+	{
+		final BigInteger one = BigInteger.ONE;
+		
+		Tup2bigiR t = new TestTup(null, null);
+		assertEquals(false, t.isValid());
+		
+		t = new TestTup(one, null);
+		assertEquals(false, t.isValid());
+		
+		t = new TestTup(null, one);
+		assertEquals(false, t.isValid());
+		
+		t = new TestTup(one, one);
+		assertEquals(true, t.isValid());
+	}
+	
+	/**
+	 * This test ensures, that the function {@link Tup2bigiR#isFinite()} returns
+	 * the corrct values for different situations.
+	 */
+	@Test
+	void isFiniteTest()
+	{
+		Tup2bigiR t = new Tup2bigiR() {
+			public BigInteger getX()
+			{
+				ValueRelay.relayCall("getX");
+				return null;
+			}
+
+			public BigInteger getY()
+			{
+				ValueRelay.relayCall("getY");
+				return null;
+			}
+		};
+		
+		assertEquals(true, t.isFinite());
+		assertEquals(false, ValueRelay.get("getX", false));
+		assertEquals(false, ValueRelay.get("getY", false));
+	}
+	
+	/**
+	 * This test ensures, that the function {@link Tup2bigiR#isZero()} returns the correct
+	 * value based on the situation.
+	 */
+	@Test
+	void isZeroExactTest()
+	{
+		final BigInteger zero = BigInteger.ZERO;
+		final BigInteger one = BigInteger.ONE;
+		
+		Tup2bigiR t = new TestTup(zero, zero);
+		assertEquals(true, t.isZero());
+		
+		t = new TestTup(one, zero);
+		assertEquals(false, t.isZero());
+		
+		t = new TestTup(zero, one);
+		assertEquals(false, t.isZero());
+		
+		t = new TestTup(one, one);
+		assertEquals(false, t.isZero());
+	}
+	
+	/**
+	 * This test ensures, that the function {@link Tup2bigiR#isZero(BigDecimal)} returns the correct
+	 * value based on the situation.
+	 */
+	@Test
+	void isZeroTest()
+	{
+		final BigInteger zero = BigInteger.ZERO;
+		
+		final int tolerance = 2;
+		final BigInteger tol = BigInteger.valueOf(tolerance);
+		
+		for(int i = -tolerance - 1; i <= tolerance + 1; i++)
+		{
+			BigInteger v = BigInteger.valueOf(i);
+			
+			boolean b = Math.abs(i) <= tolerance;
+			
+			Tup2bigiR t = new TestTup(v, v);
+			assertEquals(b, t.isZero(tol));
+			
+			t = new TestTup(v, zero);
+			assertEquals(b, t.isZero(tol));
+			
+			t = new TestTup(zero, v);
+			assertEquals(b, t.isZero(tol));
+		}
+	}
+	
+	/**
+	 * This class is a test implementation of the interface {@link Tup2bigiR}.
+	 * 
+	 * @author picatrix1899
+	 */
+	private static class TestTup implements Tup2bigiR
+	{
+		private final BigInteger x;
+		private final BigInteger y;
+		
+		public TestTup(BigInteger x, BigInteger y)
+		{
+			this.x = x;
+			this.y = y;
+		}
+		
+		@Override
+		public BigInteger getX()
+		{
+			return this.x;
+		}
+		
+		@Override
+		public BigInteger getY()
+		{
+			return this.y;
+		}
+	}
+}

--- a/barghos-core/src/test/java/org/barghos/core/test/api/tuple2/Tup2boRTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/api/tuple2/Tup2boRTest.java
@@ -1,0 +1,52 @@
+package org.barghos.core.test.api.tuple2;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import org.barghos.core.api.testing.ValueRelay;
+import org.barghos.core.api.tuple2.Tup2boR;
+
+/**
+ * This claa provides component tests for the interface {@link Tup2boR}.
+ * 
+ * @author picatrix1899
+ */
+class Tup2boRTest
+{
+	/**
+	 * This method is called after each test in this class.
+	 */
+	@AfterEach
+	void cleanup()
+	{
+		ValueRelay.clear();
+	}
+	
+	/**
+	 * This test ensures, that the function {@link Tup2boR#isValid()} returns
+	 * the corrct values for different situations.
+	 */
+	@Test
+	void isValidTest()
+	{
+		Tup2boR t = new Tup2boR() {
+			public boolean getX()
+			{
+				ValueRelay.relayCall("getX");
+				return false;
+			}
+
+			public boolean getY()
+			{
+				ValueRelay.relayCall("getY");
+				return false;
+			}
+		};
+		
+		assertEquals(true, t.isValid());
+		assertEquals(false, ValueRelay.get("getX", false));
+		assertEquals(false, ValueRelay.get("getY", false));
+	}
+}

--- a/barghos-core/src/test/java/org/barghos/core/test/api/tuple2/Tup2cRTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/api/tuple2/Tup2cRTest.java
@@ -1,0 +1,78 @@
+package org.barghos.core.test.api.tuple2;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import org.barghos.core.api.testing.ValueRelay;
+import org.barghos.core.api.tuple2.Tup2cR;
+
+/**
+ * This claa provides component tests for the interface {@link Tup2cR}.
+ * 
+ * @author picatrix1899
+ */
+class Tup2cRTest
+{
+	/**
+	 * This method is called after each test in this class.
+	 */
+	@AfterEach
+	void cleanup()
+	{
+		ValueRelay.clear();
+	}
+	
+	/**
+	 * This test ensures, that the function {@link Tup2cR#isValid()} returns
+	 * the corrct values for different situations.
+	 */
+	@Test
+	void isValidTest()
+	{
+		Tup2cR t = new Tup2cR() {
+			public char getX()
+			{
+				ValueRelay.relayCall("getX");
+				return 'a';
+			}
+
+			public char getY()
+			{
+				ValueRelay.relayCall("getY");
+				return 'a';
+			}
+		};
+		
+		assertEquals(true, t.isValid());
+		assertEquals(false, ValueRelay.get("getX", false));
+		assertEquals(false, ValueRelay.get("getY", false));
+	}
+	
+	/**
+	 * This test ensures, that the function {@link Tup2cR#isFinite()} returns
+	 * the corrct values for different situations.
+	 */
+	@Test
+	void isFiniteTest()
+	{
+		Tup2cR t = new Tup2cR() {
+			public char getX()
+			{
+				ValueRelay.relayCall("getX");
+				return 'a';
+			}
+
+			public char getY()
+			{
+				ValueRelay.relayCall("getY");
+				return 'a';
+			}
+		};
+		
+		assertEquals(true, t.isFinite());
+		assertEquals(false, ValueRelay.get("getX", false));
+		assertEquals(false, ValueRelay.get("getY", false));
+	}
+}

--- a/barghos-core/src/test/java/org/barghos/core/test/api/tuple2/Tup2dRTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/api/tuple2/Tup2dRTest.java
@@ -1,0 +1,144 @@
+package org.barghos.core.test.api.tuple2;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+import org.barghos.core.api.testing.ValueRelay;
+import org.barghos.core.api.tuple2.Tup2dR;
+
+/**
+ * This class provides component tests for the interface {@link Tup2dR}.
+ * 
+ * @author picatrix1899
+ */
+class Tup2dRTest
+{
+	/**
+	 * This test ensures, that the function {@link Tup2dR#isValid()} returns
+	 * the corrct values for different situations.
+	 */
+	@Test
+	void isValidTest()
+	{
+		Tup2dR t = new Tup2dR() {
+			public double getX()
+			{
+				ValueRelay.relayCall("getX");
+				return 0.0;
+			}
+
+			public double getY()
+			{
+				ValueRelay.relayCall("getY");
+				return 0.0;
+			}
+		};
+		
+		assertEquals(true, t.isValid());
+		assertEquals(false, ValueRelay.get("getX", false));
+		assertEquals(false, ValueRelay.get("getY", false));
+	}
+	
+	/**
+	 * This test ensures, that the function {@link Tup2dR#isFinite()} returns
+	 * the corrct values for different situations.
+	 */
+	@Test
+	void isFiniteTest()
+	{
+		final double[] values = new double[] {0.0, Double.NaN, Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY};
+		
+		for(int i = 0; i <= 4; i++)
+		{
+			double v = values[i];
+			
+			boolean b = i == 0;
+			
+			Tup2dR t = new TestTup(v, v);
+			assertEquals(b, t.isFinite());
+			
+			t = new TestTup(v, 0.0);
+			assertEquals(b, t.isFinite());
+			
+			t = new TestTup(0.0, v);
+			assertEquals(b, t.isFinite());
+		}
+	}
+	
+	/**
+	 * This test ensures, that the function {@link Tup2dR#isZero()} returns the correct
+	 * value based on the situation.
+	 */
+	@Test
+	void isZeroExactTest()
+	{
+		Tup2dR t = new TestTup(0.0, 0.0);
+		assertEquals(true, t.isZero());
+		
+		t = new TestTup(1.0, 0.0);
+		assertEquals(false, t.isZero());
+		
+		t = new TestTup(0.0, 1.0);
+		assertEquals(false, t.isZero());
+		
+		t = new TestTup(1.0, 1.0);
+		assertEquals(false, t.isZero());
+	}
+	
+	/**
+	 * This test ensures, that the function {@link Tup2dR#isZero(byte)} returns the correct
+	 * value based on the situation.
+	 */
+	@Test
+	void isZeroTest()
+	{
+		final int tolerance = 2;
+		final double tol = (double)tolerance;
+		
+		for(int i = -tolerance - 1; i <= tolerance + 1; i++)
+		{
+			double v = (double)i;
+			
+			boolean b = Math.abs(i) <= tolerance;
+			
+			Tup2dR t = new TestTup(v, v);
+			assertEquals(b, t.isZero(tol));
+			
+			t = new TestTup(v, 0.0);
+			assertEquals(b, t.isZero(tol));
+			
+			t = new TestTup(0.0, v);
+			assertEquals(b, t.isZero(tol));
+		}
+	}
+	
+	/**
+	 * This class is a test implementation of the interface {@link Tup2dR}.
+	 * 
+	 * @author picatrix1899
+	 */
+	private static class TestTup implements Tup2dR
+	{
+		private final double x;
+		private final double y;
+		
+		public TestTup(double x, double y)
+		{
+			this.x = x;
+			this.y = y;
+		}
+		
+		@Override
+		public double getX()
+		{
+			return this.x;
+		}
+		
+		@Override
+		public double getY()
+		{
+			return this.y;
+		}
+	}
+}

--- a/barghos-core/src/test/java/org/barghos/core/test/api/tuple2/Tup2dRTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/api/tuple2/Tup2dRTest.java
@@ -49,7 +49,7 @@ class Tup2dRTest
 	{
 		final double[] values = new double[] {0.0, Double.NaN, Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY};
 		
-		for(int i = 0; i <= 4; i++)
+		for(int i = 0; i < 4; i++)
 		{
 			double v = values[i];
 			

--- a/barghos-core/src/test/java/org/barghos/core/test/api/tuple2/Tup2fRTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/api/tuple2/Tup2fRTest.java
@@ -1,0 +1,144 @@
+package org.barghos.core.test.api.tuple2;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+import org.barghos.core.api.testing.ValueRelay;
+import org.barghos.core.api.tuple2.Tup2fR;
+
+/**
+ * This class provides component tests for the interface {@link Tup2fR}.
+ * 
+ * @author picatrix1899
+ */
+class Tup2fRTest
+{
+	/**
+	 * This test ensures, that the function {@link Tup2fR#isValid()} returns
+	 * the corrct values for different situations.
+	 */
+	@Test
+	void isValidTest()
+	{
+		Tup2fR t = new Tup2fR() {
+			public float getX()
+			{
+				ValueRelay.relayCall("getX");
+				return 0.0f;
+			}
+
+			public float getY()
+			{
+				ValueRelay.relayCall("getY");
+				return 0.0f;
+			}
+		};
+		
+		assertEquals(true, t.isValid());
+		assertEquals(false, ValueRelay.get("getX", false));
+		assertEquals(false, ValueRelay.get("getY", false));
+	}
+	
+	/**
+	 * This test ensures, that the function {@link Tup2fR#isFinite()} returns
+	 * the corrct values for different situations.
+	 */
+	@Test
+	void isFiniteTest()
+	{
+		final float[] values = new float[] {0.0f, Float.NaN, Float.NEGATIVE_INFINITY, Float.POSITIVE_INFINITY};
+		
+		for(int i = 0; i <= 4; i++)
+		{
+			float v = values[i];
+			
+			boolean b = i == 0;
+			
+			Tup2fR t = new TestTup(v, v);
+			assertEquals(b, t.isFinite());
+			
+			t = new TestTup(v, 0.0f);
+			assertEquals(b, t.isFinite());
+			
+			t = new TestTup(0.0f, v);
+			assertEquals(b, t.isFinite());
+		}
+	}
+	
+	/**
+	 * This test ensures, that the function {@link Tup2fR#isZero()} returns the correct
+	 * value based on the situation.
+	 */
+	@Test
+	void isZeroExactTest()
+	{
+		Tup2fR t = new TestTup(0.0f, 0.0f);
+		assertEquals(true, t.isZero());
+		
+		t = new TestTup(1.0f, 0.0f);
+		assertEquals(false, t.isZero());
+		
+		t = new TestTup(0.0f, 1.0f);
+		assertEquals(false, t.isZero());
+		
+		t = new TestTup(1.0f, 1.0f);
+		assertEquals(false, t.isZero());
+	}
+	
+	/**
+	 * This test ensures, that the function {@link Tup2fR#isZero(byte)} returns the correct
+	 * value based on the situation.
+	 */
+	@Test
+	void isZeroTest()
+	{
+		final int tolerance = 2;
+		final float tol = (float)tolerance;
+		
+		for(int i = -tolerance - 1; i <= tolerance + 1; i++)
+		{
+			float v = (float)i;
+			
+			boolean b = Math.abs(i) <= tolerance;
+			
+			Tup2fR t = new TestTup(v, v);
+			assertEquals(b, t.isZero(tol));
+			
+			t = new TestTup(v, 0.0f);
+			assertEquals(b, t.isZero(tol));
+			
+			t = new TestTup(0.0f, v);
+			assertEquals(b, t.isZero(tol));
+		}
+	}
+	
+	/**
+	 * This class is a test implementation of the interface {@link Tup2fR}.
+	 * 
+	 * @author picatrix1899
+	 */
+	private static class TestTup implements Tup2fR
+	{
+		private final float x;
+		private final float y;
+		
+		public TestTup(float x, float y)
+		{
+			this.x = x;
+			this.y = y;
+		}
+		
+		@Override
+		public float getX()
+		{
+			return this.x;
+		}
+		
+		@Override
+		public float getY()
+		{
+			return this.y;
+		}
+	}
+}

--- a/barghos-core/src/test/java/org/barghos/core/test/api/tuple2/Tup2fRTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/api/tuple2/Tup2fRTest.java
@@ -49,7 +49,7 @@ class Tup2fRTest
 	{
 		final float[] values = new float[] {0.0f, Float.NaN, Float.NEGATIVE_INFINITY, Float.POSITIVE_INFINITY};
 		
-		for(int i = 0; i <= 4; i++)
+		for(int i = 0; i < 4; i++)
 		{
 			float v = values[i];
 			

--- a/barghos-core/src/test/java/org/barghos/core/test/api/tuple2/Tup2iRTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/api/tuple2/Tup2iRTest.java
@@ -1,0 +1,144 @@
+package org.barghos.core.test.api.tuple2;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+import org.barghos.core.api.testing.ValueRelay;
+import org.barghos.core.api.tuple2.Tup2iR;
+
+/**
+ * This class provides component tests for the interface {@link Tup2iR}.
+ * 
+ * @author picatrix1899
+ */
+class Tup2iRTest
+{
+	/**
+	 * This test ensures, that the function {@link Tup2iR#isValid()} returns
+	 * the corrct values for different situations.
+	 */
+	@Test
+	void isValidTest()
+	{
+		Tup2iR t = new Tup2iR() {
+			public int getX()
+			{
+				ValueRelay.relayCall("getX");
+				return 0;
+			}
+
+			public int getY()
+			{
+				ValueRelay.relayCall("getY");
+				return 0;
+			}
+		};
+		
+		assertEquals(true, t.isValid());
+		assertEquals(false, ValueRelay.get("getX", false));
+		assertEquals(false, ValueRelay.get("getY", false));
+	}
+	
+	/**
+	 * This test ensures, that the function {@link Tup2iR#isFinite()} returns
+	 * the corrct values for different situations.
+	 */
+	@Test
+	void isFiniteTest()
+	{
+		Tup2iR t = new Tup2iR() {
+			public int getX()
+			{
+				ValueRelay.relayCall("getX");
+				return 0;
+			}
+
+			public int getY()
+			{
+				ValueRelay.relayCall("getY");
+				return 0;
+			}
+		};
+		
+		assertEquals(true, t.isFinite());
+		assertEquals(false, ValueRelay.get("getX", false));
+		assertEquals(false, ValueRelay.get("getY", false));
+	}
+	
+	/**
+	 * This test ensures, that the function {@link Tup2iR#isZero()} returns the correct
+	 * value based on the situation.
+	 */
+	@Test
+	void isZeroExactTest()
+	{
+		Tup2iR t = new TestTup(0, 0);
+		assertEquals(true, t.isZero());
+		
+		t = new TestTup(1, 0);
+		assertEquals(false, t.isZero());
+		
+		t = new TestTup(0, 1);
+		assertEquals(false, t.isZero());
+		
+		t = new TestTup(1, 1);
+		assertEquals(false, t.isZero());
+	}
+	
+	/**
+	 * This test ensures, that the function {@link Tup2iR#isZero(byte)} returns the correct
+	 * value based on the situation.
+	 */
+	@Test
+	void isZeroTest()
+	{
+		final int tolerance = 2;
+		final int tol = tolerance;
+		
+		for(int i = -tolerance - 1; i <= tolerance + 1; i++)
+		{
+			int v = i;
+			
+			boolean b = Math.abs(i) <= tolerance;
+			
+			Tup2iR t = new TestTup(v, v);
+			assertEquals(b, t.isZero(tol));
+			
+			t = new TestTup(v, 0);
+			assertEquals(b, t.isZero(tol));
+			
+			t = new TestTup(0, v);
+			assertEquals(b, t.isZero(tol));
+		}
+	}
+	
+	/**
+	 * This class is a test implementation of the interface {@link Tup2iR}.
+	 * 
+	 * @author picatrix1899
+	 */
+	private static class TestTup implements Tup2iR
+	{
+		private final int x;
+		private final int y;
+		
+		public TestTup(int x, int y)
+		{
+			this.x = x;
+			this.y = y;
+		}
+		
+		@Override
+		public int getX()
+		{
+			return this.x;
+		}
+		
+		@Override
+		public int getY()
+		{
+			return this.y;
+		}
+	}
+}

--- a/barghos-core/src/test/java/org/barghos/core/test/api/tuple2/Tup2lRTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/api/tuple2/Tup2lRTest.java
@@ -1,0 +1,144 @@
+package org.barghos.core.test.api.tuple2;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+import org.barghos.core.api.testing.ValueRelay;
+import org.barghos.core.api.tuple2.Tup2lR;
+
+/**
+ * This class provides component tests for the interface {@link Tup2lR}.
+ * 
+ * @author picatrix1899
+ */
+class Tup2lRTest
+{
+	/**
+	 * This test ensures, that the function {@link Tup2lR#isValid()} returns
+	 * the corrct values for different situations.
+	 */
+	@Test
+	void isValidTest()
+	{
+		Tup2lR t = new Tup2lR() {
+			public long getX()
+			{
+				ValueRelay.relayCall("getX");
+				return 0l;
+			}
+
+			public long getY()
+			{
+				ValueRelay.relayCall("getY");
+				return 0l;
+			}
+		};
+		
+		assertEquals(true, t.isValid());
+		assertEquals(false, ValueRelay.get("getX", false));
+		assertEquals(false, ValueRelay.get("getY", false));
+	}
+	
+	/**
+	 * This test ensures, that the function {@link Tup2lR#isFinite()} returns
+	 * the corrct values for different situations.
+	 */
+	@Test
+	void isFiniteTest()
+	{
+		Tup2lR t = new Tup2lR() {
+			public long getX()
+			{
+				ValueRelay.relayCall("getX");
+				return 0l;
+			}
+
+			public long getY()
+			{
+				ValueRelay.relayCall("getY");
+				return 0l;
+			}
+		};
+		
+		assertEquals(true, t.isFinite());
+		assertEquals(false, ValueRelay.get("getX", false));
+		assertEquals(false, ValueRelay.get("getY", false));
+	}
+	
+	/**
+	 * This test ensures, that the function {@link Tup2lR#isZero()} returns the correct
+	 * value based on the situation.
+	 */
+	@Test
+	void isZeroExactTest()
+	{
+		Tup2lR t = new TestTup(0l, 0l);
+		assertEquals(true, t.isZero());
+		
+		t = new TestTup(1l, 0l);
+		assertEquals(false, t.isZero());
+		
+		t = new TestTup(0l, 1l);
+		assertEquals(false, t.isZero());
+		
+		t = new TestTup(1l, 1l);
+		assertEquals(false, t.isZero());
+	}
+	
+	/**
+	 * This test ensures, that the function {@link Tup2lR#isZero(byte)} returns the correct
+	 * value based on the situation.
+	 */
+	@Test
+	void isZeroTest()
+	{
+		final int tolerance = 2;
+		final long tol = (long)tolerance;
+		
+		for(int i = -tolerance - 1; i <= tolerance + 1; i++)
+		{
+			long v = (long)i;
+			
+			boolean b = Math.abs(i) <= tolerance;
+			
+			Tup2lR t = new TestTup(v, v);
+			assertEquals(b, t.isZero(tol));
+			
+			t = new TestTup(v, 0l);
+			assertEquals(b, t.isZero(tol));
+			
+			t = new TestTup(0l, v);
+			assertEquals(b, t.isZero(tol));
+		}
+	}
+	
+	/**
+	 * This class is a test implementation of the interface {@link Tup2lR}.
+	 * 
+	 * @author picatrix1899
+	 */
+	private static class TestTup implements Tup2lR
+	{
+		private final long x;
+		private final long y;
+		
+		public TestTup(long x, long y)
+		{
+			this.x = x;
+			this.y = y;
+		}
+		
+		@Override
+		public long getX()
+		{
+			return this.x;
+		}
+		
+		@Override
+		public long getY()
+		{
+			return this.y;
+		}
+	}
+}

--- a/barghos-core/src/test/java/org/barghos/core/test/api/tuple2/Tup2oRTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/api/tuple2/Tup2oRTest.java
@@ -1,0 +1,64 @@
+package org.barghos.core.test.api.tuple2;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+import org.barghos.core.api.tuple2.Tup2oR;
+
+/**
+ * This class provides component tests for the interface {@link Tup2oR}.
+ * 
+ * @author picatrix1899
+ */
+class Tup2oRTest
+{
+	/**
+	 * This test ensures, that the function {@link Tup2oR#isValid()} returns
+	 * the corrct values for different situations.
+	 */
+	@Test
+	void isValidTest()
+	{
+		Tup2oR<Object, Object> t = new TestTup<>(null, null);
+		assertEquals(false, t.isValid());
+		
+		t = new TestTup<>(null, new Object());
+		assertEquals(false, t.isValid());
+		
+		t = new TestTup<>(new Object(), null);
+		assertEquals(false, t.isValid());
+		
+		t = new TestTup<>(new Object(), new Object());
+		assertEquals(true, t.isValid());
+	}
+	
+	/**
+	 * This class is a test implementation of the interface {@link Tup2oR}.
+	 * 
+	 * @author picatrix1899
+	 */
+	private static class TestTup<X,Y> implements Tup2oR<X,Y>
+	{
+		private final X x;
+		private final Y y;
+		
+		public TestTup(X x, Y y)
+		{
+			this.x = x;
+			this.y = y;
+		}
+		
+		@Override
+		public X getX()
+		{
+			return this.x;
+		}
+		
+		@Override
+		public Y getY()
+		{
+			return this.y;
+		}
+	}
+}

--- a/barghos-core/src/test/java/org/barghos/core/test/api/tuple2/Tup2objRTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/api/tuple2/Tup2objRTest.java
@@ -1,0 +1,64 @@
+package org.barghos.core.test.api.tuple2;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+import org.barghos.core.api.tuple2.Tup2objR;
+
+/**
+ * This class provides component tests for the interface {@link Tup2objR}.
+ * 
+ * @author picatrix1899
+ */
+class Tup2objRTest
+{
+	/**
+	 * This test ensures, that the function {@link Tup2objR#isValid()} returns
+	 * the corrct values for different situations.
+	 */
+	@Test
+	void isValidTest()
+	{
+		Tup2objR t = new TestTup(null, null);
+		assertEquals(false, t.isValid());
+		
+		t = new TestTup(null, new Object());
+		assertEquals(false, t.isValid());
+		
+		t = new TestTup(new Object(), null);
+		assertEquals(false, t.isValid());
+		
+		t = new TestTup(new Object(), new Object());
+		assertEquals(true, t.isValid());
+	}
+	
+	/**
+	 * This class is a test implementation of the interface {@link Tup2objR}.
+	 * 
+	 * @author picatrix1899
+	 */
+	private static class TestTup implements Tup2objR
+	{
+		private final Object x;
+		private final Object y;
+		
+		public TestTup(Object x, Object y)
+		{
+			this.x = x;
+			this.y = y;
+		}
+		
+		@Override
+		public Object getX()
+		{
+			return this.x;
+		}
+		
+		@Override
+		public Object getY()
+		{
+			return this.y;
+		}
+	}
+}

--- a/barghos-core/src/test/java/org/barghos/core/test/api/tuple2/Tup2sRTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/api/tuple2/Tup2sRTest.java
@@ -1,0 +1,149 @@
+package org.barghos.core.test.api.tuple2;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+import org.barghos.core.api.testing.ValueRelay;
+import org.barghos.core.api.tuple2.Tup2sR;
+
+/**
+ * This class provides component tests for the interface {@link Tup2sR}.
+ * 
+ * @author picatrix1899
+ */
+class Tup2sRTest
+{
+	/**
+	 * This test ensures, that the function {@link Tup2sR#isValid()} returns
+	 * the corrct values for different situations.
+	 */
+	@Test
+	void isValidTest()
+	{
+		Tup2sR t = new Tup2sR() {
+			public short getX()
+			{
+				ValueRelay.relayCall("getX");
+				return (short)0;
+			}
+
+			public short getY()
+			{
+				ValueRelay.relayCall("getY");
+				return (short)0;
+			}
+		};
+		
+		assertEquals(true, t.isValid());
+		assertEquals(false, ValueRelay.get("getX", false));
+		assertEquals(false, ValueRelay.get("getY", false));
+	}
+	
+	/**
+	 * This test ensures, that the function {@link Tup2sR#isFinite()} returns
+	 * the corrct values for different situations.
+	 */
+	@Test
+	void isFiniteTest()
+	{
+		Tup2sR t = new Tup2sR() {
+			public short getX()
+			{
+				ValueRelay.relayCall("getX");
+				return (short)0;
+			}
+
+			public short getY()
+			{
+				ValueRelay.relayCall("getY");
+				return (short)0;
+			}
+		};
+		
+		assertEquals(true, t.isFinite());
+		assertEquals(false, ValueRelay.get("getX", false));
+		assertEquals(false, ValueRelay.get("getY", false));
+	}
+	
+	/**
+	 * This test ensures, that the function {@link Tup2sR#isZero()} returns the correct
+	 * value based on the situation.
+	 */
+	@Test
+	void isZeroExactTest()
+	{
+		final short zero = (short)0;
+		final short one = (short)1;
+		
+		Tup2sR t = new TestTup(zero, zero);
+		assertEquals(true, t.isZero());
+		
+		t = new TestTup(one, zero);
+		assertEquals(false, t.isZero());
+		
+		t = new TestTup(zero, one);
+		assertEquals(false, t.isZero());
+		
+		t = new TestTup(one, one);
+		assertEquals(false, t.isZero());
+	}
+	
+	/**
+	 * This test ensures, that the function {@link Tup2sR#isZero(byte)} returns the correct
+	 * value based on the situation.
+	 */
+	@Test
+	void isZeroTest()
+	{
+		final short zero = (short)0;
+		
+		final int tolerance = 2;
+		final short tol = (short)tolerance;
+		
+		for(int i = -tolerance - 1; i <= tolerance + 1; i++)
+		{
+			short v = (short)i;
+			
+			boolean b = Math.abs(i) <= tolerance;
+			
+			Tup2sR t = new TestTup(v, v);
+			assertEquals(b, t.isZero(tol));
+			
+			t = new TestTup(v, zero);
+			assertEquals(b, t.isZero(tol));
+			
+			t = new TestTup(zero, v);
+			assertEquals(b, t.isZero(tol));
+		}
+	}
+	
+	/**
+	 * This class is a test implementation of the interface {@link Tup2sR}.
+	 * 
+	 * @author picatrix1899
+	 */
+	private static class TestTup implements Tup2sR
+	{
+		private final short x;
+		private final short y;
+		
+		public TestTup(short x, short y)
+		{
+			this.x = x;
+			this.y = y;
+		}
+		
+		@Override
+		public short getX()
+		{
+			return this.x;
+		}
+		
+		@Override
+		public short getY()
+		{
+			return this.y;
+		}
+	}
+}

--- a/barghos-core/src/test/java/org/barghos/core/test/api/tuple2/Tup2strRTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/api/tuple2/Tup2strRTest.java
@@ -1,0 +1,64 @@
+package org.barghos.core.test.api.tuple2;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+import org.barghos.core.api.tuple2.Tup2strR;
+
+/**
+ * This class provides component tests for the interface {@link Tup2strR}.
+ * 
+ * @author picatrix1899
+ */
+class Tup2strRTest
+{
+	/**
+	 * This test ensures, that the function {@link Tup2strR#isValid()} returns
+	 * the corrct values for different situations.
+	 */
+	@Test
+	void isValidTest()
+	{
+		Tup2strR t = new TestTup(null, null);
+		assertEquals(false, t.isValid());
+		
+		t = new TestTup("", null);
+		assertEquals(false, t.isValid());
+		
+		t = new TestTup(null, "");
+		assertEquals(false, t.isValid());
+		
+		t = new TestTup("", "");
+		assertEquals(true, t.isValid());
+	}
+	
+	/**
+	 * This class is a test implementation of the interface {@link Tup2strR}.
+	 * 
+	 * @author picatrix1899
+	 */
+	private static class TestTup implements Tup2strR
+	{
+		private final String x;
+		private final String y;
+		
+		public TestTup(String x, String y)
+		{
+			this.x = x;
+			this.y = y;
+		}
+		
+		@Override
+		public String getX()
+		{
+			return this.x;
+		}
+		
+		@Override
+		public String getY()
+		{
+			return this.y;
+		}
+	}
+}

--- a/barghos-core/src/test/java/org/barghos/core/test/api/tuple2/package-info.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/api/tuple2/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * This package contains component tests for the API for 2-dimensional tuples.
+ * 
+ * @author picatrix1899
+ */
+package org.barghos.core.test.api.tuple2;

--- a/barghos-core/src/test/java/org/barghos/core/test/api/tuple3/Tup3bRTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/api/tuple3/Tup3bRTest.java
@@ -1,0 +1,177 @@
+package org.barghos.core.test.api.tuple3;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+import org.barghos.core.api.testing.ValueRelay;
+import org.barghos.core.api.tuple3.Tup3bR;
+
+/**
+ * This class provides component tests for the interface {@link Tup3bR}.
+ * 
+ * @author picatrix1899
+ */
+class Tup3bRTest
+{
+	/**
+	 * This test ensures, that the function {@link Tup3bR#isValid()} returns
+	 * the corrct values for different situations.
+	 */
+	@Test
+	void isValidTest()
+	{
+		Tup3bR t = new Tup3bR() {
+			public byte getX()
+			{
+				ValueRelay.relayCall("getX");
+				return (byte)0;
+			}
+
+			public byte getY()
+			{
+				ValueRelay.relayCall("getY");
+				return (byte)0;
+			}
+			
+			public byte getZ()
+			{
+				ValueRelay.relayCall("getZ");
+				return (byte)0;
+			}
+		};
+		
+		assertEquals(true, t.isValid());
+		assertEquals(false, ValueRelay.get("getX", false));
+		assertEquals(false, ValueRelay.get("getY", false));
+		assertEquals(false, ValueRelay.get("getZ", false));
+	}
+	
+	/**
+	 * This test ensures, that the function {@link Tup3bR#isFinite()} returns
+	 * the corrct values for different situations.
+	 */
+	@Test
+	void isFiniteTest()
+	{
+		Tup3bR t = new Tup3bR() {
+			public byte getX()
+			{
+				ValueRelay.relayCall("getX");
+				return (byte)0;
+			}
+
+			public byte getY()
+			{
+				ValueRelay.relayCall("getY");
+				return (byte)0;
+			}
+			
+			public byte getZ()
+			{
+				ValueRelay.relayCall("getZ");
+				return (byte)0;
+			}
+		};
+		
+		assertEquals(true, t.isFinite());
+		assertEquals(false, ValueRelay.get("getX", false));
+		assertEquals(false, ValueRelay.get("getY", false));
+		assertEquals(false, ValueRelay.get("getZ", false));
+	}
+	
+	/**
+	 * This test ensures, that the function {@link Tup3bR#isZero()} returns the correct
+	 * value based on the situation.
+	 */
+	@Test
+	void isZeroExactTest()
+	{
+		final byte zero = (byte)0;
+		final byte one = (byte)1;
+		
+		Tup3bR t = new TestTup(zero, zero, zero);
+		assertEquals(true, t.isZero());
+		
+		t = new TestTup(one, zero, zero);
+		assertEquals(false, t.isZero());
+		
+		t = new TestTup(zero, one, zero);
+		assertEquals(false, t.isZero());
+		
+		t = new TestTup(zero, zero, one);
+		assertEquals(false, t.isZero());
+		
+		t = new TestTup(one, one, one);
+		assertEquals(false, t.isZero());
+	}
+	
+	/**
+	 * This test ensures, that the function {@link Tup3bR#isZero(byte)} returns the correct
+	 * value based on the situation.
+	 */
+	@Test
+	void isZeroTest()
+	{
+		final byte zero = (byte)0;
+		
+		final int tolerance = 2;
+		final byte tol = (byte)tolerance;
+		
+		for(int i = -tolerance - 1; i <= tolerance + 1; i++)
+		{
+			byte v = (byte)i;
+			
+			boolean b = Math.abs(i) <= tolerance;
+			
+			Tup3bR t = new TestTup(v, v, v);
+			assertEquals(b, t.isZero(tol));
+			
+			t = new TestTup(v, zero, zero);
+			assertEquals(b, t.isZero(tol));
+			
+			t = new TestTup(zero, v, zero);
+			assertEquals(b, t.isZero(tol));
+			
+			t = new TestTup(zero, zero, v);
+			assertEquals(b, t.isZero(tol));
+		}
+	}
+	
+	/**
+	 * This class is a test implementation of the interface {@link Tup3bR}.
+	 * 
+	 * @author picatrix1899
+	 */
+	private static class TestTup implements Tup3bR
+	{
+		private final byte x;
+		private final byte y;
+		private final byte z;
+		
+		public TestTup(byte x, byte y, byte z)
+		{
+			this.x = x;
+			this.y = y;
+			this.z = z;
+		}
+		
+		@Override
+		public byte getX()
+		{
+			return this.x;
+		}
+		
+		@Override
+		public byte getY()
+		{
+			return this.y;
+		}
+		
+		@Override
+		public byte getZ()
+		{
+			return this.z;
+		}
+	}
+}

--- a/barghos-core/src/test/java/org/barghos/core/test/api/tuple3/Tup3bigdRTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/api/tuple3/Tup3bigdRTest.java
@@ -1,0 +1,171 @@
+package org.barghos.core.test.api.tuple3;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+
+import org.barghos.core.api.testing.ValueRelay;
+import org.barghos.core.api.tuple3.Tup3bigdR;
+
+/**
+ * This class provides component tests for the interface {@link Tup3bigdR}.
+ * 
+ * @author picatrix1899
+ */
+class Tup3bigdRTest
+{
+	/**
+	 * This test ensures, that the function {@link Tup3bigdR#isValid()} returns
+	 * the corrct values for different situations.
+	 */
+	@Test
+	void isValidTest()
+	{
+		final BigDecimal one = BigDecimal.ONE;
+		
+		Tup3bigdR t = new TestTup(null, null, null);
+		assertEquals(false, t.isValid());
+		
+		t = new TestTup(one, null, null);
+		assertEquals(false, t.isValid());
+		
+		t = new TestTup(null, one, null);
+		assertEquals(false, t.isValid());
+		
+		t = new TestTup(null, null, one);
+		assertEquals(false, t.isValid());
+		
+		t = new TestTup(one, one, one);
+		assertEquals(true, t.isValid());
+	}
+	
+	/**
+	 * This test ensures, that the function {@link Tup3bigdR#isFinite()} returns
+	 * the corrct values for different situations.
+	 */
+	@Test
+	void isFiniteTest()
+	{
+		Tup3bigdR t = new Tup3bigdR() {
+			public BigDecimal getX()
+			{
+				ValueRelay.relayCall("getX");
+				return null;
+			}
+
+			public BigDecimal getY()
+			{
+				ValueRelay.relayCall("getY");
+				return null;
+			}
+			
+			public BigDecimal getZ()
+			{
+				ValueRelay.relayCall("getZ");
+				return null;
+			}
+		};
+		
+		assertEquals(true, t.isFinite());
+		assertEquals(false, ValueRelay.get("getX", false));
+		assertEquals(false, ValueRelay.get("getY", false));
+		assertEquals(false, ValueRelay.get("getZ", false));
+	}
+	
+	/**
+	 * This test ensures, that the function {@link Tup3bigdR#isZero()} returns the correct
+	 * value based on the situation.
+	 */
+	@Test
+	void isZeroExactTest()
+	{
+		final BigDecimal zero = BigDecimal.ZERO;
+		final BigDecimal one = BigDecimal.ONE;
+		
+		Tup3bigdR t = new TestTup(zero, zero, zero);
+		assertEquals(true, t.isZero());
+		
+		t = new TestTup(one, zero, zero);
+		assertEquals(false, t.isZero());
+		
+		t = new TestTup(zero, one, zero);
+		assertEquals(false, t.isZero());
+		
+		t = new TestTup(zero, zero, one);
+		assertEquals(false, t.isZero());
+		
+		t = new TestTup(one, one, one);
+		assertEquals(false, t.isZero());
+	}
+	
+	/**
+	 * This test ensures, that the function {@link Tup3bigdR#isZero(BigDecimal)} returns the correct
+	 * value based on the situation.
+	 */
+	@Test
+	void isZeroTest()
+	{
+		final BigDecimal zero = BigDecimal.ZERO;
+		
+		final int tolerance = 2;
+		final BigDecimal tol = BigDecimal.valueOf(tolerance);
+		
+		for(int i = -tolerance - 1; i <= tolerance + 1; i++)
+		{
+			BigDecimal v = BigDecimal.valueOf(i);
+			
+			boolean b = Math.abs(i) <= tolerance;
+			
+			Tup3bigdR t = new TestTup(v, v, v);
+			assertEquals(b, t.isZero(tol));
+			
+			t = new TestTup(v, zero, zero);
+			assertEquals(b, t.isZero(tol));
+			
+			t = new TestTup(zero, v, zero);
+			assertEquals(b, t.isZero(tol));
+			
+			t = new TestTup(zero, zero, v);
+			assertEquals(b, t.isZero(tol));
+		}
+	}
+	
+	/**
+	 * This class is a test implementation of the interface {@link Tup2bigdR}.
+	 * 
+	 * @author picatrix1899
+	 */
+	private static class TestTup implements Tup3bigdR
+	{
+		private final BigDecimal x;
+		private final BigDecimal y;
+		private final BigDecimal z;
+		
+		public TestTup(BigDecimal x, BigDecimal y, BigDecimal z)
+		{
+			this.x = x;
+			this.y = y;
+			this.z = z;
+		}
+		
+		@Override
+		public BigDecimal getX()
+		{
+			return this.x;
+		}
+		
+		@Override
+		public BigDecimal getY()
+		{
+			return this.y;
+		}
+		
+		@Override
+		public BigDecimal getZ()
+		{
+			return this.z;
+		}
+	}
+}

--- a/barghos-core/src/test/java/org/barghos/core/test/api/tuple3/Tup3bigiRTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/api/tuple3/Tup3bigiRTest.java
@@ -1,0 +1,172 @@
+package org.barghos.core.test.api.tuple3;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+import org.barghos.core.api.testing.ValueRelay;
+import org.barghos.core.api.tuple3.Tup3bigiR;
+
+/**
+ * This class provides component tests for the interface {@link Tup3bigiR}.
+ * 
+ * @author picatrix1899
+ */
+class Tup3bigiRTest
+{
+	/**
+	 * This test ensures, that the function {@link Tup3bigiR#isValid()} returns
+	 * the corrct values for different situations.
+	 */
+	@Test
+	void isValidTest()
+	{
+		final BigInteger one = BigInteger.ONE;
+		
+		Tup3bigiR t = new TestTup(null, null, null);
+		assertEquals(false, t.isValid());
+		
+		t = new TestTup(one, null, null);
+		assertEquals(false, t.isValid());
+		
+		t = new TestTup(null, one, null);
+		assertEquals(false, t.isValid());
+		
+		t = new TestTup(null, null, one);
+		assertEquals(false, t.isValid());
+		
+		t = new TestTup(one, one, one);
+		assertEquals(true, t.isValid());
+	}
+	
+	/**
+	 * This test ensures, that the function {@link Tup3bigiR#isFinite()} returns
+	 * the corrct values for different situations.
+	 */
+	@Test
+	void isFiniteTest()
+	{
+		Tup3bigiR t = new Tup3bigiR() {
+			public BigInteger getX()
+			{
+				ValueRelay.relayCall("getX");
+				return null;
+			}
+
+			public BigInteger getY()
+			{
+				ValueRelay.relayCall("getY");
+				return null;
+			}
+			
+			public BigInteger getZ()
+			{
+				ValueRelay.relayCall("getZ");
+				return null;
+			}
+		};
+		
+		assertEquals(true, t.isFinite());
+		assertEquals(false, ValueRelay.get("getX", false));
+		assertEquals(false, ValueRelay.get("getY", false));
+		assertEquals(false, ValueRelay.get("getZ", false));
+	}
+	
+	/**
+	 * This test ensures, that the function {@link Tup3bigiR#isZero()} returns the correct
+	 * value based on the situation.
+	 */
+	@Test
+	void isZeroExactTest()
+	{
+		final BigInteger zero = BigInteger.ZERO;
+		final BigInteger one = BigInteger.ONE;
+		
+		Tup3bigiR t = new TestTup(zero, zero, zero);
+		assertEquals(true, t.isZero());
+		
+		t = new TestTup(one, zero, zero);
+		assertEquals(false, t.isZero());
+		
+		t = new TestTup(zero, one, zero);
+		assertEquals(false, t.isZero());
+		
+		t = new TestTup(zero, zero, one);
+		assertEquals(false, t.isZero());
+		
+		t = new TestTup(one, one, one);
+		assertEquals(false, t.isZero());
+	}
+	
+	/**
+	 * This test ensures, that the function {@link Tup3bigiR#isZero(BigDecimal)} returns the correct
+	 * value based on the situation.
+	 */
+	@Test
+	void isZeroTest()
+	{
+		final BigInteger zero = BigInteger.ZERO;
+		
+		final int tolerance = 2;
+		final BigInteger tol = BigInteger.valueOf(tolerance);
+		
+		for(int i = -tolerance - 1; i <= tolerance + 1; i++)
+		{
+			BigInteger v = BigInteger.valueOf(i);
+			
+			boolean b = Math.abs(i) <= tolerance;
+			
+			Tup3bigiR t = new TestTup(v, v, v);
+			assertEquals(b, t.isZero(tol));
+			
+			t = new TestTup(v, zero, zero);
+			assertEquals(b, t.isZero(tol));
+			
+			t = new TestTup(zero, v, zero);
+			assertEquals(b, t.isZero(tol));
+			
+			t = new TestTup(zero, zero, v);
+			assertEquals(b, t.isZero(tol));
+		}
+	}
+	
+	/**
+	 * This class is a test implementation of the interface {@link Tup3bigiR}.
+	 * 
+	 * @author picatrix1899
+	 */
+	private static class TestTup implements Tup3bigiR
+	{
+		private final BigInteger x;
+		private final BigInteger y;
+		private final BigInteger z;
+		
+		public TestTup(BigInteger x, BigInteger y, BigInteger z)
+		{
+			this.x = x;
+			this.y = y;
+			this.z = z;
+		}
+		
+		@Override
+		public BigInteger getX()
+		{
+			return this.x;
+		}
+		
+		@Override
+		public BigInteger getY()
+		{
+			return this.y;
+		}
+		
+		@Override
+		public BigInteger getZ()
+		{
+			return this.z;
+		}
+	}
+}

--- a/barghos-core/src/test/java/org/barghos/core/test/api/tuple3/Tup3boRTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/api/tuple3/Tup3boRTest.java
@@ -1,0 +1,59 @@
+package org.barghos.core.test.api.tuple3;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import org.barghos.core.api.testing.ValueRelay;
+import org.barghos.core.api.tuple3.Tup3boR;
+
+/**
+ * This claa provides component tests for the interface {@link Tup3boR}.
+ * 
+ * @author picatrix1899
+ */
+class Tup3boRTest
+{
+	/**
+	 * This method is called after each test in this class.
+	 */
+	@AfterEach
+	void cleanup()
+	{
+		ValueRelay.clear();
+	}
+	
+	/**
+	 * This test ensures, that the function {@link Tup3boR#isValid()} returns
+	 * the corrct values for different situations.
+	 */
+	@Test
+	void isValidTest()
+	{
+		Tup3boR t = new Tup3boR() {
+			public boolean getX()
+			{
+				ValueRelay.relayCall("getX");
+				return false;
+			}
+
+			public boolean getY()
+			{
+				ValueRelay.relayCall("getY");
+				return false;
+			}
+			
+			public boolean getZ()
+			{
+				ValueRelay.relayCall("getZ");
+				return false;
+			}
+		};
+		
+		assertEquals(true, t.isValid());
+		assertEquals(false, ValueRelay.get("getX", false));
+		assertEquals(false, ValueRelay.get("getY", false));
+		assertEquals(false, ValueRelay.get("getZ", false));
+	}
+}

--- a/barghos-core/src/test/java/org/barghos/core/test/api/tuple3/Tup3cRTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/api/tuple3/Tup3cRTest.java
@@ -1,0 +1,92 @@
+package org.barghos.core.test.api.tuple3;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import org.barghos.core.api.testing.ValueRelay;
+import org.barghos.core.api.tuple3.Tup3cR;
+
+/**
+ * This claa provides component tests for the interface {@link Tup3cR}.
+ * 
+ * @author picatrix1899
+ */
+class Tup3cRTest
+{
+	/**
+	 * This method is called after each test in this class.
+	 */
+	@AfterEach
+	void cleanup()
+	{
+		ValueRelay.clear();
+	}
+	
+	/**
+	 * This test ensures, that the function {@link Tup3cR#isValid()} returns
+	 * the corrct values for different situations.
+	 */
+	@Test
+	void isValidTest()
+	{
+		Tup3cR t = new Tup3cR() {
+			public char getX()
+			{
+				ValueRelay.relayCall("getX");
+				return 'a';
+			}
+
+			public char getY()
+			{
+				ValueRelay.relayCall("getY");
+				return 'a';
+			}
+			
+			public char getZ()
+			{
+				ValueRelay.relayCall("getZ");
+				return 'a';
+			}
+		};
+		
+		assertEquals(true, t.isValid());
+		assertEquals(false, ValueRelay.get("getX", false));
+		assertEquals(false, ValueRelay.get("getY", false));
+		assertEquals(false, ValueRelay.get("getZ", false));
+	}
+	
+	/**
+	 * This test ensures, that the function {@link Tup3cR#isFinite()} returns
+	 * the corrct values for different situations.
+	 */
+	@Test
+	void isFiniteTest()
+	{
+		Tup3cR t = new Tup3cR() {
+			public char getX()
+			{
+				ValueRelay.relayCall("getX");
+				return 'a';
+			}
+
+			public char getY()
+			{
+				ValueRelay.relayCall("getY");
+				return 'a';
+			}
+			
+			public char getZ()
+			{
+				ValueRelay.relayCall("getZ");
+				return 'a';
+			}
+		};
+		
+		assertEquals(true, t.isFinite());
+		assertEquals(false, ValueRelay.get("getX", false));
+		assertEquals(false, ValueRelay.get("getY", false));
+		assertEquals(false, ValueRelay.get("getZ", false));
+	}
+}

--- a/barghos-core/src/test/java/org/barghos/core/test/api/tuple3/Tup3dRTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/api/tuple3/Tup3dRTest.java
@@ -1,0 +1,168 @@
+package org.barghos.core.test.api.tuple3;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+import org.barghos.core.api.testing.ValueRelay;
+import org.barghos.core.api.tuple3.Tup3dR;
+
+/**
+ * This class provides component tests for the interface {@link Tup3dR}.
+ * 
+ * @author picatrix1899
+ */
+class Tup3dRTest
+{
+	/**
+	 * This test ensures, that the function {@link Tup3dR#isValid()} returns
+	 * the corrct values for different situations.
+	 */
+	@Test
+	void isValidTest()
+	{
+		Tup3dR t = new Tup3dR() {
+			public double getX()
+			{
+				ValueRelay.relayCall("getX");
+				return 0.0;
+			}
+
+			public double getY()
+			{
+				ValueRelay.relayCall("getY");
+				return 0.0;
+			}
+			
+			public double getZ()
+			{
+				ValueRelay.relayCall("getZ");
+				return 0.0;
+			}
+		};
+		
+		assertEquals(true, t.isValid());
+		assertEquals(false, ValueRelay.get("getX", false));
+		assertEquals(false, ValueRelay.get("getY", false));
+		assertEquals(false, ValueRelay.get("getZ", false));
+	}
+	
+	/**
+	 * This test ensures, that the function {@link Tup3dR#isFinite()} returns
+	 * the corrct values for different situations.
+	 */
+	@Test
+	void isFiniteTest()
+	{
+		final double[] values = new double[] {0.0, Double.NaN, Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY};
+		
+		for(int i = 0; i <= 4; i++)
+		{
+			double v = values[i];
+			
+			boolean b = i == 0;
+			
+			Tup3dR t = new TestTup(v, v, v);
+			assertEquals(b, t.isFinite());
+			
+			t = new TestTup(v, 0.0, 0.0);
+			assertEquals(b, t.isFinite());
+			
+			t = new TestTup(0.0, v, 0.0);
+			assertEquals(b, t.isFinite());
+			
+			t = new TestTup(0.0, 0.0, v);
+			assertEquals(b, t.isFinite());
+		}
+	}
+	
+	/**
+	 * This test ensures, that the function {@link Tup3dR#isZero()} returns the correct
+	 * value based on the situation.
+	 */
+	@Test
+	void isZeroExactTest()
+	{
+		Tup3dR t = new TestTup(0.0, 0.0, 0.0);
+		assertEquals(true, t.isZero());
+		
+		t = new TestTup(1.0, 0.0, 0.0);
+		assertEquals(false, t.isZero());
+		
+		t = new TestTup(0.0, 1.0, 0.0);
+		assertEquals(false, t.isZero());
+		
+		t = new TestTup(0.0, 0.0, 1.0);
+		assertEquals(false, t.isZero());
+		
+		t = new TestTup(1.0, 1.0, 1.0);
+		assertEquals(false, t.isZero());
+	}
+	
+	/**
+	 * This test ensures, that the function {@link Tup3dR#isZero(byte)} returns the correct
+	 * value based on the situation.
+	 */
+	@Test
+	void isZeroTest()
+	{
+		final int tolerance = 2;
+		final double tol = (double)tolerance;
+		
+		for(int i = -tolerance - 1; i <= tolerance + 1; i++)
+		{
+			double v = (double)i;
+			
+			boolean b = Math.abs(i) <= tolerance;
+			
+			Tup3dR t = new TestTup(v, v, v);
+			assertEquals(b, t.isZero(tol));
+			
+			t = new TestTup(v, 0.0, 0.0);
+			assertEquals(b, t.isZero(tol));
+			
+			t = new TestTup(0.0, v, 0.0);
+			assertEquals(b, t.isZero(tol));
+			
+			t = new TestTup(0.0, 0.0, v);
+			assertEquals(b, t.isZero(tol));
+		}
+	}
+	
+	/**
+	 * This class is a test implementation of the interface {@link Tup3dR}.
+	 * 
+	 * @author picatrix1899
+	 */
+	private static class TestTup implements Tup3dR
+	{
+		private final double x;
+		private final double y;
+		private final double z;
+		
+		public TestTup(double x, double y , double z)
+		{
+			this.x = x;
+			this.y = y;
+			this.z = z;
+		}
+		
+		@Override
+		public double getX()
+		{
+			return this.x;
+		}
+		
+		@Override
+		public double getY()
+		{
+			return this.y;
+		}
+		
+		@Override
+		public double getZ()
+		{
+			return this.z;
+		}
+	}
+}

--- a/barghos-core/src/test/java/org/barghos/core/test/api/tuple3/Tup3dRTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/api/tuple3/Tup3dRTest.java
@@ -56,7 +56,7 @@ class Tup3dRTest
 	{
 		final double[] values = new double[] {0.0, Double.NaN, Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY};
 		
-		for(int i = 0; i <= 4; i++)
+		for(int i = 0; i < 4; i++)
 		{
 			double v = values[i];
 			

--- a/barghos-core/src/test/java/org/barghos/core/test/api/tuple3/Tup3fRTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/api/tuple3/Tup3fRTest.java
@@ -63,7 +63,7 @@ class Tup3fRTest
 	{
 		final float[] values = new float[] {0.0f, Float.NaN, Float.NEGATIVE_INFINITY, Float.POSITIVE_INFINITY};
 		
-		for(int i = 0; i <= 4; i++)
+		for(int i = 0; i < 4; i++)
 		{
 			float v = values[i];
 			

--- a/barghos-core/src/test/java/org/barghos/core/test/api/tuple3/Tup3fRTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/api/tuple3/Tup3fRTest.java
@@ -1,0 +1,192 @@
+package org.barghos.core.test.api.tuple3;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+import org.barghos.core.api.testing.ValueRelay;
+import org.barghos.core.api.tuple4.Tup4fR;
+
+/**
+ * This class provides component tests for the interface {@link Tup4fR}.
+ * 
+ * @author picatrix1899
+ */
+class Tup3fRTest
+{
+	/**
+	 * This test ensures, that the function {@link Tup4fR#isValid()} returns
+	 * the corrct values for different situations.
+	 */
+	@Test
+	void isValidTest()
+	{
+		Tup4fR t = new Tup4fR() {
+			public float getX()
+			{
+				ValueRelay.relayCall("getX");
+				return 0.0f;
+			}
+
+			public float getY()
+			{
+				ValueRelay.relayCall("getY");
+				return 0.0f;
+			}
+			
+			public float getZ()
+			{
+				ValueRelay.relayCall("getZ");
+				return 0.0f;
+			}
+			
+			public float getW()
+			{
+				ValueRelay.relayCall("getW");
+				return 0.0f;
+			}
+		};
+		
+		assertEquals(true, t.isValid());
+		assertEquals(false, ValueRelay.get("getX", false));
+		assertEquals(false, ValueRelay.get("getY", false));
+		assertEquals(false, ValueRelay.get("getZ", false));
+		assertEquals(false, ValueRelay.get("getW", false));
+	}
+	
+	/**
+	 * This test ensures, that the function {@link Tup4fR#isFinite()} returns
+	 * the corrct values for different situations.
+	 */
+	@Test
+	void isFiniteTest()
+	{
+		final float[] values = new float[] {0.0f, Float.NaN, Float.NEGATIVE_INFINITY, Float.POSITIVE_INFINITY};
+		
+		for(int i = 0; i <= 4; i++)
+		{
+			float v = values[i];
+			
+			boolean b = i == 0;
+			
+			Tup4fR t = new TestTup(v, v, v, v);
+			assertEquals(b, t.isFinite());
+			
+			t = new TestTup(v, 0.0f, 0.0f, 0.0f);
+			assertEquals(b, t.isFinite());
+			
+			t = new TestTup(0.0f, v, 0.0f, 0.0f);
+			assertEquals(b, t.isFinite());
+			
+			t = new TestTup(0.0f, 0.0f, v, 0.0f);
+			assertEquals(b, t.isFinite());
+			
+			t = new TestTup(0.0f, 0.0f, 0.0f, v);
+			assertEquals(b, t.isFinite());
+		}
+	}
+	
+	/**
+	 * This test ensures, that the function {@link Tup4fR#isZero()} returns the correct
+	 * value based on the situation.
+	 */
+	@Test
+	void isZeroExactTest()
+	{
+		Tup4fR t = new TestTup(0.0f, 0.0f, 0.0f, 0.0f);
+		assertEquals(true, t.isZero());
+		
+		t = new TestTup(1.0f, 0.0f, 0.0f, 0.0f);
+		assertEquals(false, t.isZero());
+		
+		t = new TestTup(0.0f, 1.0f, 0.0f, 0.0f);
+		assertEquals(false, t.isZero());
+		
+		t = new TestTup(0.0f, 0.0f, 1.0f, 0.0f);
+		assertEquals(false, t.isZero());
+		
+		t = new TestTup(0.0f, 0.0f, 0.0f, 1.0f);
+		assertEquals(false, t.isZero());
+		
+		t = new TestTup(1.0f, 1.0f, 1.0f, 1.0f);
+		assertEquals(false, t.isZero());
+	}
+	
+	/**
+	 * This test ensures, that the function {@link Tup4fR#isZero(byte)} returns the correct
+	 * value based on the situation.
+	 */
+	@Test
+	void isZeroTest()
+	{
+		final int tolerance = 2;
+		final float tol = (float)tolerance;
+		
+		for(int i = -tolerance - 1; i <= tolerance + 1; i++)
+		{
+			float v = (float)i;
+			
+			boolean b = Math.abs(i) <= tolerance;
+			
+			Tup4fR t = new TestTup(v, v, v, v);
+			assertEquals(b, t.isZero(tol));
+			
+			t = new TestTup(v, 0.0f, 0.0f, 0.0f);
+			assertEquals(b, t.isZero(tol));
+			
+			t = new TestTup(0.0f, v, 0.0f, 0.0f);
+			assertEquals(b, t.isZero(tol));
+			
+			t = new TestTup(0.0f, 0.0f, v, 0.0f);
+			assertEquals(b, t.isZero(tol));
+			
+			t = new TestTup(0.0f, 0.0f, 0.0f, v);
+			assertEquals(b, t.isZero(tol));
+		}
+	}
+	
+	/**
+	 * This class is a test implementation of the interface {@link Tup4fR}.
+	 * 
+	 * @author picatrix1899
+	 */
+	private static class TestTup implements Tup4fR
+	{
+		private final float x;
+		private final float y;
+		private final float z;
+		private final float w;
+		
+		public TestTup(float x, float y, float z, float w)
+		{
+			this.x = x;
+			this.y = y;
+			this.z = z;
+			this.w = w;
+		}
+		
+		@Override
+		public float getX()
+		{
+			return this.x;
+		}
+		
+		@Override
+		public float getY()
+		{
+			return this.y;
+		}
+		
+		@Override
+		public float getZ()
+		{
+			return this.z;
+		}
+		
+		@Override
+		public float getW()
+		{
+			return this.w;
+		}
+	}
+}

--- a/barghos-core/src/test/java/org/barghos/core/test/api/tuple3/Tup3iRTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/api/tuple3/Tup3iRTest.java
@@ -1,0 +1,169 @@
+package org.barghos.core.test.api.tuple3;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+import org.barghos.core.api.testing.ValueRelay;
+import org.barghos.core.api.tuple3.Tup3iR;
+
+/**
+ * This class provides component tests for the interface {@link Tup3iR}.
+ * 
+ * @author picatrix1899
+ */
+class Tup3iRTest
+{
+	/**
+	 * This test ensures, that the function {@link Tup3iR#isValid()} returns
+	 * the corrct values for different situations.
+	 */
+	@Test
+	void isValidTest()
+	{
+		Tup3iR t = new Tup3iR() {
+			public int getX()
+			{
+				ValueRelay.relayCall("getX");
+				return 0;
+			}
+
+			public int getY()
+			{
+				ValueRelay.relayCall("getY");
+				return 0;
+			}
+			
+			public int getZ()
+			{
+				ValueRelay.relayCall("getZ");
+				return 0;
+			}
+		};
+		
+		assertEquals(true, t.isValid());
+		assertEquals(false, ValueRelay.get("getX", false));
+		assertEquals(false, ValueRelay.get("getY", false));
+		assertEquals(false, ValueRelay.get("getZ", false));
+	}
+	
+	/**
+	 * This test ensures, that the function {@link Tup3iR#isFinite()} returns
+	 * the corrct values for different situations.
+	 */
+	@Test
+	void isFiniteTest()
+	{
+		Tup3iR t = new Tup3iR() {
+			public int getX()
+			{
+				ValueRelay.relayCall("getX");
+				return 0;
+			}
+
+			public int getY()
+			{
+				ValueRelay.relayCall("getY");
+				return 0;
+			}
+			
+			public int getZ()
+			{
+				ValueRelay.relayCall("getZ");
+				return 0;
+			}
+		};
+		
+		assertEquals(true, t.isFinite());
+		assertEquals(false, ValueRelay.get("getX", false));
+		assertEquals(false, ValueRelay.get("getY", false));
+		assertEquals(false, ValueRelay.get("getZ", false));
+	}
+	
+	/**
+	 * This test ensures, that the function {@link Tup3iR#isZero()} returns the correct
+	 * value based on the situation.
+	 */
+	@Test
+	void isZeroExactTest()
+	{
+		Tup3iR t = new TestTup(0, 0, 0);
+		assertEquals(true, t.isZero());
+		
+		t = new TestTup(1, 0, 0);
+		assertEquals(false, t.isZero());
+		
+		t = new TestTup(0, 1, 0);
+		assertEquals(false, t.isZero());
+		
+		t = new TestTup(1, 1, 1);
+		assertEquals(false, t.isZero());
+	}
+	
+	/**
+	 * This test ensures, that the function {@link Tup3iR#isZero(byte)} returns the correct
+	 * value based on the situation.
+	 */
+	@Test
+	void isZeroTest()
+	{
+		final int tolerance = 2;
+		final int tol = tolerance;
+		
+		for(int i = -tolerance - 1; i <= tolerance + 1; i++)
+		{
+			int v = i;
+			
+			boolean b = Math.abs(i) <= tolerance;
+			
+			Tup3iR t = new TestTup(v, v, v);
+			assertEquals(b, t.isZero(tol));
+			
+			t = new TestTup(v, 0, 0);
+			assertEquals(b, t.isZero(tol));
+			
+			t = new TestTup(0, v, 0);
+			assertEquals(b, t.isZero(tol));
+			
+			t = new TestTup(0, 0, v);
+			assertEquals(b, t.isZero(tol));
+		}
+	}
+	
+	/**
+	 * This class is a test implementation of the interface {@link Tup3iR}.
+	 * 
+	 * @author picatrix1899
+	 */
+	private static class TestTup implements Tup3iR
+	{
+		private final int x;
+		private final int y;
+		private final int z;
+		
+		public TestTup(int x, int y, int z)
+		{
+			this.x = x;
+			this.y = y;
+			this.z = z;
+		}
+		
+		@Override
+		public int getX()
+		{
+			return this.x;
+		}
+		
+		@Override
+		public int getY()
+		{
+			return this.y;
+		}
+		
+		@Override
+		public int getZ()
+		{
+			return this.z;
+		}
+	}
+}

--- a/barghos-core/src/test/java/org/barghos/core/test/api/tuple3/Tup3lRTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/api/tuple3/Tup3lRTest.java
@@ -1,0 +1,172 @@
+package org.barghos.core.test.api.tuple3;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+import org.barghos.core.api.testing.ValueRelay;
+import org.barghos.core.api.tuple3.Tup3lR;
+
+/**
+ * This class provides component tests for the interface {@link Tup3lR}.
+ * 
+ * @author picatrix1899
+ */
+class Tup3lRTest
+{
+	/**
+	 * This test ensures, that the function {@link Tup3lR#isValid()} returns
+	 * the corrct values for different situations.
+	 */
+	@Test
+	void isValidTest()
+	{
+		Tup3lR t = new Tup3lR() {
+			public long getX()
+			{
+				ValueRelay.relayCall("getX");
+				return 0l;
+			}
+
+			public long getY()
+			{
+				ValueRelay.relayCall("getY");
+				return 0l;
+			}
+			
+			public long getZ()
+			{
+				ValueRelay.relayCall("getZ");
+				return 0l;
+			}
+		};
+		
+		assertEquals(true, t.isValid());
+		assertEquals(false, ValueRelay.get("getX", false));
+		assertEquals(false, ValueRelay.get("getY", false));
+		assertEquals(false, ValueRelay.get("getZ", false));
+	}
+	
+	/**
+	 * This test ensures, that the function {@link Tup3lR#isFinite()} returns
+	 * the corrct values for different situations.
+	 */
+	@Test
+	void isFiniteTest()
+	{
+		Tup3lR t = new Tup3lR() {
+			public long getX()
+			{
+				ValueRelay.relayCall("getX");
+				return 0l;
+			}
+
+			public long getY()
+			{
+				ValueRelay.relayCall("getY");
+				return 0l;
+			}
+			
+			public long getZ()
+			{
+				ValueRelay.relayCall("getZ");
+				return 0l;
+			}
+		};
+		
+		assertEquals(true, t.isFinite());
+		assertEquals(false, ValueRelay.get("getX", false));
+		assertEquals(false, ValueRelay.get("getY", false));
+		assertEquals(false, ValueRelay.get("getZ", false));
+	}
+	
+	/**
+	 * This test ensures, that the function {@link Tup3lR#isZero()} returns the correct
+	 * value based on the situation.
+	 */
+	@Test
+	void isZeroExactTest()
+	{
+		Tup3lR t = new TestTup(0l, 0l, 0l);
+		assertEquals(true, t.isZero());
+		
+		t = new TestTup(1l, 0l, 0l);
+		assertEquals(false, t.isZero());
+		
+		t = new TestTup(0l, 1l, 0l);
+		assertEquals(false, t.isZero());
+		
+		t = new TestTup(0l, 0l, 1l);
+		assertEquals(false, t.isZero());
+		
+		t = new TestTup(1l, 1l, 1l);
+		assertEquals(false, t.isZero());
+	}
+	
+	/**
+	 * This test ensures, that the function {@link Tup3lR#isZero(byte)} returns the correct
+	 * value based on the situation.
+	 */
+	@Test
+	void isZeroTest()
+	{
+		final int tolerance = 2;
+		final long tol = (long)tolerance;
+		
+		for(int i = -tolerance - 1; i <= tolerance + 1; i++)
+		{
+			long v = (long)i;
+			
+			boolean b = Math.abs(i) <= tolerance;
+			
+			Tup3lR t = new TestTup(v, v, v);
+			assertEquals(b, t.isZero(tol));
+			
+			t = new TestTup(v, 0l, 0l);
+			assertEquals(b, t.isZero(tol));
+			
+			t = new TestTup(0l, v, 0l);
+			assertEquals(b, t.isZero(tol));
+			
+			t = new TestTup(0l, 0l, v);
+			assertEquals(b, t.isZero(tol));
+		}
+	}
+	
+	/**
+	 * This class is a test implementation of the interface {@link Tup3lR}.
+	 * 
+	 * @author picatrix1899
+	 */
+	private static class TestTup implements Tup3lR
+	{
+		private final long x;
+		private final long y;
+		private final long z;
+		
+		public TestTup(long x, long y, long z)
+		{
+			this.x = x;
+			this.y = y;
+			this.z = z;
+		}
+		
+		@Override
+		public long getX()
+		{
+			return this.x;
+		}
+		
+		@Override
+		public long getY()
+		{
+			return this.y;
+		}
+		
+		@Override
+		public long getZ()
+		{
+			return this.z;
+		}
+	}
+}

--- a/barghos-core/src/test/java/org/barghos/core/test/api/tuple3/Tup3oRTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/api/tuple3/Tup3oRTest.java
@@ -1,0 +1,75 @@
+package org.barghos.core.test.api.tuple3;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+import org.barghos.core.api.tuple3.Tup3oR;
+
+/**
+ * This class provides component tests for the interface {@link Tup3oR}.
+ * 
+ * @author picatrix1899
+ */
+class Tup3oRTest
+{
+	/**
+	 * This test ensures, that the function {@link Tup3oR#isValid()} returns
+	 * the corrct values for different situations.
+	 */
+	@Test
+	void isValidTest()
+	{
+		Tup3oR<Object, Object, Object> t = new TestTup<>(null, null, null);
+		assertEquals(false, t.isValid());
+		
+		t = new TestTup<>(new Object(), null, null);
+		assertEquals(false, t.isValid());
+		
+		t = new TestTup<>(null, new Object(), null);
+		assertEquals(false, t.isValid());
+		
+		t = new TestTup<>(null, null, new Object());
+		assertEquals(false, t.isValid());
+		
+		t = new TestTup<>(new Object(), new Object(), new Object());
+		assertEquals(true, t.isValid());
+	}
+	
+	/**
+	 * This class is a test implementation of the interface {@link Tup3oR}.
+	 * 
+	 * @author picatrix1899
+	 */
+	private static class TestTup<X,Y,Z> implements Tup3oR<X,Y,Z>
+	{
+		private final X x;
+		private final Y y;
+		private final Z z;
+		
+		public TestTup(X x, Y y, Z z)
+		{
+			this.x = x;
+			this.y = y;
+			this.z = z;
+		}
+		
+		@Override
+		public X getX()
+		{
+			return this.x;
+		}
+		
+		@Override
+		public Y getY()
+		{
+			return this.y;
+		}
+		
+		@Override
+		public Z getZ()
+		{
+			return this.z;
+		}
+	}
+}

--- a/barghos-core/src/test/java/org/barghos/core/test/api/tuple3/Tup3objRTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/api/tuple3/Tup3objRTest.java
@@ -1,0 +1,75 @@
+package org.barghos.core.test.api.tuple3;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+import org.barghos.core.api.tuple3.Tup3objR;
+
+/**
+ * This class provides component tests for the interface {@link Tup3objR}.
+ * 
+ * @author picatrix1899
+ */
+class Tup3objRTest
+{
+	/**
+	 * This test ensures, that the function {@link Tup3objR#isValid()} returns
+	 * the corrct values for different situations.
+	 */
+	@Test
+	void isValidTest()
+	{
+		Tup3objR t = new TestTup(null, null, null);
+		assertEquals(false, t.isValid());
+		
+		t = new TestTup(new Object(), null, null);
+		assertEquals(false, t.isValid());
+		
+		t = new TestTup(null, new Object(), null);
+		assertEquals(false, t.isValid());
+		
+		t = new TestTup(null, null, new Object());
+		assertEquals(false, t.isValid());
+		
+		t = new TestTup(new Object(), new Object(), new Object());
+		assertEquals(true, t.isValid());
+	}
+	
+	/**
+	 * This class is a test implementation of the interface {@link Tup3objR}.
+	 * 
+	 * @author picatrix1899
+	 */
+	private static class TestTup implements Tup3objR
+	{
+		private final Object x;
+		private final Object y;
+		private final Object z;
+		
+		public TestTup(Object x, Object y, Object z)
+		{
+			this.x = x;
+			this.y = y;
+			this.z = z;
+		}
+		
+		@Override
+		public Object getX()
+		{
+			return this.x;
+		}
+		
+		@Override
+		public Object getY()
+		{
+			return this.y;
+		}
+		
+		@Override
+		public Object getZ()
+		{
+			return this.z;
+		}
+	}
+}

--- a/barghos-core/src/test/java/org/barghos/core/test/api/tuple3/Tup3sRTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/api/tuple3/Tup3sRTest.java
@@ -1,0 +1,177 @@
+package org.barghos.core.test.api.tuple3;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+import org.barghos.core.api.testing.ValueRelay;
+import org.barghos.core.api.tuple3.Tup3sR;
+
+/**
+ * This class provides component tests for the interface {@link Tup3sR}.
+ * 
+ * @author picatrix1899
+ */
+class Tup3sRTest
+{
+	/**
+	 * This test ensures, that the function {@link Tup3sR#isValid()} returns
+	 * the corrct values for different situations.
+	 */
+	@Test
+	void isValidTest()
+	{
+		Tup3sR t = new Tup3sR() {
+			public short getX()
+			{
+				ValueRelay.relayCall("getX");
+				return (short)0;
+			}
+
+			public short getY()
+			{
+				ValueRelay.relayCall("getY");
+				return (short)0;
+			}
+			
+			public short getZ()
+			{
+				ValueRelay.relayCall("getZ");
+				return (short)0;
+			}
+		};
+		
+		assertEquals(true, t.isValid());
+		assertEquals(false, ValueRelay.get("getX", false));
+		assertEquals(false, ValueRelay.get("getY", false));
+		assertEquals(false, ValueRelay.get("getZ", false));
+	}
+	
+	/**
+	 * This test ensures, that the function {@link Tup3sR#isFinite()} returns
+	 * the corrct values for different situations.
+	 */
+	@Test
+	void isFiniteTest()
+	{
+		Tup3sR t = new Tup3sR() {
+			public short getX()
+			{
+				ValueRelay.relayCall("getX");
+				return (short)0;
+			}
+
+			public short getY()
+			{
+				ValueRelay.relayCall("getY");
+				return (short)0;
+			}
+			
+			public short getZ()
+			{
+				ValueRelay.relayCall("getZ");
+				return (short)0;
+			}
+		};
+		
+		assertEquals(true, t.isFinite());
+		assertEquals(false, ValueRelay.get("getX", false));
+		assertEquals(false, ValueRelay.get("getY", false));
+		assertEquals(false, ValueRelay.get("getZ", false));
+	}
+	
+	/**
+	 * This test ensures, that the function {@link Tup3sR#isZero()} returns the correct
+	 * value based on the situation.
+	 */
+	@Test
+	void isZeroExactTest()
+	{
+		final short zero = (short)0;
+		final short one = (short)1;
+		
+		Tup3sR t = new TestTup(zero, zero, zero);
+		assertEquals(true, t.isZero());
+		
+		t = new TestTup(one, zero, zero);
+		assertEquals(false, t.isZero());
+		
+		t = new TestTup(zero, one, zero);
+		assertEquals(false, t.isZero());
+		
+		t = new TestTup(zero, zero, one);
+		assertEquals(false, t.isZero());
+		
+		t = new TestTup(one, one, one);
+		assertEquals(false, t.isZero());
+	}
+	
+	/**
+	 * This test ensures, that the function {@link Tup3sR#isZero(byte)} returns the correct
+	 * value based on the situation.
+	 */
+	@Test
+	void isZeroTest()
+	{
+		final short zero = (short)0;
+		
+		final int tolerance = 2;
+		final short tol = (short)tolerance;
+		
+		for(int i = -tolerance - 1; i <= tolerance + 1; i++)
+		{
+			short v = (short)i;
+			
+			boolean b = Math.abs(i) <= tolerance;
+			
+			Tup3sR t = new TestTup(v, v, v);
+			assertEquals(b, t.isZero(tol));
+			
+			t = new TestTup(v, zero, zero);
+			assertEquals(b, t.isZero(tol));
+			
+			t = new TestTup(zero, v, zero);
+			assertEquals(b, t.isZero(tol));
+			
+			t = new TestTup(zero, zero, v);
+			assertEquals(b, t.isZero(tol));
+		}
+	}
+	
+	/**
+	 * This class is a test implementation of the interface {@link Tup3sR}.
+	 * 
+	 * @author picatrix1899
+	 */
+	private static class TestTup implements Tup3sR
+	{
+		private final short x;
+		private final short y;
+		private final short z;
+		
+		public TestTup(short x, short y, short z)
+		{
+			this.x = x;
+			this.y = y;
+			this.z = z;
+		}
+		
+		@Override
+		public short getX()
+		{
+			return this.x;
+		}
+		
+		@Override
+		public short getY()
+		{
+			return this.y;
+		}
+		
+		@Override
+		public short getZ()
+		{
+			return this.z;
+		}
+	}
+}

--- a/barghos-core/src/test/java/org/barghos/core/test/api/tuple3/Tup3strRTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/api/tuple3/Tup3strRTest.java
@@ -1,0 +1,75 @@
+package org.barghos.core.test.api.tuple3;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+import org.barghos.core.api.tuple3.Tup3strR;
+
+/**
+ * This class provides component tests for the interface {@link Tup3strR}.
+ * 
+ * @author picatrix1899
+ */
+class Tup3strRTest
+{
+	/**
+	 * This test ensures, that the function {@link Tup3strR#isValid()} returns
+	 * the corrct values for different situations.
+	 */
+	@Test
+	void isValidTest()
+	{
+		Tup3strR t = new TestTup(null, null, null);
+		assertEquals(false, t.isValid());
+		
+		t = new TestTup("", null, null);
+		assertEquals(false, t.isValid());
+		
+		t = new TestTup(null, "", null);
+		assertEquals(false, t.isValid());
+		
+		t = new TestTup(null, null, "");
+		assertEquals(false, t.isValid());
+		
+		t = new TestTup("", "", "");
+		assertEquals(true, t.isValid());
+	}
+	
+	/**
+	 * This class is a test implementation of the interface {@link Tup3strR}.
+	 * 
+	 * @author picatrix1899
+	 */
+	private static class TestTup implements Tup3strR
+	{
+		private final String x;
+		private final String y;
+		private final String z;
+		
+		public TestTup(String x, String y, String z)
+		{
+			this.x = x;
+			this.y = y;
+			this.z = z;
+		}
+		
+		@Override
+		public String getX()
+		{
+			return this.x;
+		}
+		
+		@Override
+		public String getY()
+		{
+			return this.y;
+		}
+		
+		@Override
+		public String getZ()
+		{
+			return this.z;
+		}
+	}
+}

--- a/barghos-core/src/test/java/org/barghos/core/test/api/tuple3/package-info.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/api/tuple3/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * This package contains component tests for the API for 3-dimensional tuples.
+ * 
+ * @author picatrix1899
+ */
+package org.barghos.core.test.api.tuple3;

--- a/barghos-core/src/test/java/org/barghos/core/test/api/tuple4/Tup4bRTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/api/tuple4/Tup4bRTest.java
@@ -1,0 +1,205 @@
+package org.barghos.core.test.api.tuple4;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+import org.barghos.core.api.testing.ValueRelay;
+import org.barghos.core.api.tuple4.Tup4bR;
+
+/**
+ * This class provides component tests for the interface {@link Tup4bR}.
+ * 
+ * @author picatrix1899
+ */
+class Tup4bRTest
+{
+	/**
+	 * This test ensures, that the function {@link Tup4bR#isValid()} returns
+	 * the corrct values for different situations.
+	 */
+	@Test
+	void isValidTest()
+	{
+		Tup4bR t = new Tup4bR() {
+			public byte getX()
+			{
+				ValueRelay.relayCall("getX");
+				return (byte)0;
+			}
+
+			public byte getY()
+			{
+				ValueRelay.relayCall("getY");
+				return (byte)0;
+			}
+			
+			public byte getZ()
+			{
+				ValueRelay.relayCall("getZ");
+				return (byte)0;
+			}
+			
+			public byte getW()
+			{
+				ValueRelay.relayCall("getW");
+				return (byte)0;
+			}
+		};
+		
+		assertEquals(true, t.isValid());
+		assertEquals(false, ValueRelay.get("getX", false));
+		assertEquals(false, ValueRelay.get("getY", false));
+		assertEquals(false, ValueRelay.get("getZ", false));
+		assertEquals(false, ValueRelay.get("getW", false));
+	}
+	
+	/**
+	 * This test ensures, that the function {@link Tup4bR#isFinite()} returns
+	 * the corrct values for different situations.
+	 */
+	@Test
+	void isFiniteTest()
+	{
+		Tup4bR t = new Tup4bR() {
+			public byte getX()
+			{
+				ValueRelay.relayCall("getX");
+				return (byte)0;
+			}
+
+			public byte getY()
+			{
+				ValueRelay.relayCall("getY");
+				return (byte)0;
+			}
+			
+			public byte getZ()
+			{
+				ValueRelay.relayCall("getZ");
+				return (byte)0;
+			}
+			
+			public byte getW()
+			{
+				ValueRelay.relayCall("getW");
+				return (byte)0;
+			}
+		};
+		
+		assertEquals(true, t.isFinite());
+		assertEquals(false, ValueRelay.get("getX", false));
+		assertEquals(false, ValueRelay.get("getY", false));
+		assertEquals(false, ValueRelay.get("getZ", false));
+		assertEquals(false, ValueRelay.get("getW", false));
+	}
+	
+	/**
+	 * This test ensures, that the function {@link Tup4bR#isZero()} returns the correct
+	 * value based on the situation.
+	 */
+	@Test
+	void isZeroExactTest()
+	{
+		final byte zero = (byte)0;
+		final byte one = (byte)1;
+		
+		Tup4bR t = new TestTup(zero, zero, zero, zero);
+		assertEquals(true, t.isZero());
+		
+		t = new TestTup(one, zero, zero, zero);
+		assertEquals(false, t.isZero());
+		
+		t = new TestTup(zero, one, zero, zero);
+		assertEquals(false, t.isZero());
+		
+		t = new TestTup(zero, zero, one, zero);
+		assertEquals(false, t.isZero());
+		
+		t = new TestTup(zero, zero, zero, one);
+		assertEquals(false, t.isZero());
+		
+		t = new TestTup(one, one, one, one);
+		assertEquals(false, t.isZero());
+	}
+	
+	/**
+	 * This test ensures, that the function {@link Tup4bR#isZero(byte)} returns the correct
+	 * value based on the situation.
+	 */
+	@Test
+	void isZeroTest()
+	{
+		final byte zero = (byte)0;
+		
+		final int tolerance = 2;
+		final byte tol = (byte)tolerance;
+		
+		for(int i = -tolerance - 1; i <= tolerance + 1; i++)
+		{
+			byte v = (byte)i;
+			
+			boolean b = Math.abs(i) <= tolerance;
+			
+			Tup4bR t = new TestTup(v, v, v, v);
+			assertEquals(b, t.isZero(tol));
+			
+			t = new TestTup(v, zero, zero, zero);
+			assertEquals(b, t.isZero(tol));
+			
+			t = new TestTup(zero, v, zero, zero);
+			assertEquals(b, t.isZero(tol));
+			
+			t = new TestTup(zero, zero, v, zero);
+			assertEquals(b, t.isZero(tol));
+			
+			t = new TestTup(zero, zero, zero, v);
+			assertEquals(b, t.isZero(tol));
+		}
+	}
+	
+	/**
+	 * This class is a test implementation of the interface {@link Tup4bR}.
+	 * 
+	 * @author picatrix1899
+	 */
+	private static class TestTup implements Tup4bR
+	{
+		private final byte x;
+		private final byte y;
+		private final byte z;
+		private final byte w;
+		
+		public TestTup(byte x, byte y, byte z, byte w)
+		{
+			this.x = x;
+			this.y = y;
+			this.z = z;
+			this.w = w;
+		}
+		
+		@Override
+		public byte getX()
+		{
+			return this.x;
+		}
+		
+		@Override
+		public byte getY()
+		{
+			return this.y;
+		}
+		
+		@Override
+		public byte getZ()
+		{
+			return this.z;
+		}
+		
+		@Override
+		public byte getW()
+		{
+			return this.w;
+		}
+	}
+}

--- a/barghos-core/src/test/java/org/barghos/core/test/api/tuple4/Tup4bigdRTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/api/tuple4/Tup4bigdRTest.java
@@ -1,0 +1,195 @@
+package org.barghos.core.test.api.tuple4;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+
+import org.barghos.core.api.testing.ValueRelay;
+import org.barghos.core.api.tuple4.Tup4bigdR;
+
+/**
+ * This class provides component tests for the interface {@link Tup4bigdR}.
+ * 
+ * @author picatrix1899
+ */
+class Tup4bigdRTest
+{
+	/**
+	 * This test ensures, that the function {@link Tup4bigdR#isValid()} returns
+	 * the corrct values for different situations.
+	 */
+	@Test
+	void isValidTest()
+	{
+		final BigDecimal one = BigDecimal.ONE;
+		
+		Tup4bigdR t = new TestTup(null, null, null, null);
+		assertEquals(false, t.isValid());
+		
+		t = new TestTup(one, null, null, null);
+		assertEquals(false, t.isValid());
+		
+		t = new TestTup(null, one, null, null);
+		assertEquals(false, t.isValid());
+		
+		t = new TestTup(null, null, one, null);
+		assertEquals(false, t.isValid());
+		
+		t = new TestTup(null, null, null, one);
+		assertEquals(false, t.isValid());
+		
+		t = new TestTup(one, one, one, one);
+		assertEquals(true, t.isValid());
+	}
+	
+	/**
+	 * This test ensures, that the function {@link Tup4bigdR#isFinite()} returns
+	 * the corrct values for different situations.
+	 */
+	@Test
+	void isFiniteTest()
+	{
+		Tup4bigdR t = new Tup4bigdR() {
+			public BigDecimal getX()
+			{
+				ValueRelay.relayCall("getX");
+				return null;
+			}
+
+			public BigDecimal getY()
+			{
+				ValueRelay.relayCall("getY");
+				return null;
+			}
+			
+			public BigDecimal getZ()
+			{
+				ValueRelay.relayCall("getZ");
+				return null;
+			}
+			
+			public BigDecimal getW()
+			{
+				ValueRelay.relayCall("getW");
+				return null;
+			}
+		};
+		
+		assertEquals(true, t.isFinite());
+		assertEquals(false, ValueRelay.get("getX", false));
+		assertEquals(false, ValueRelay.get("getY", false));
+		assertEquals(false, ValueRelay.get("getZ", false));
+		assertEquals(false, ValueRelay.get("getW", false));
+	}
+	
+	/**
+	 * This test ensures, that the function {@link Tup3bigdR#isZero()} returns the correct
+	 * value based on the situation.
+	 */
+	@Test
+	void isZeroExactTest()
+	{
+		final BigDecimal zero = BigDecimal.ZERO;
+		final BigDecimal one = BigDecimal.ONE;
+		
+		Tup4bigdR t = new TestTup(zero, zero, zero, zero);
+		assertEquals(true, t.isZero());
+		
+		t = new TestTup(one, zero, zero, zero);
+		assertEquals(false, t.isZero());
+		
+		t = new TestTup(zero, one, zero, zero);
+		assertEquals(false, t.isZero());
+		
+		t = new TestTup(zero, zero, one, zero);
+		assertEquals(false, t.isZero());
+		
+		t = new TestTup(zero, zero, zero, one);
+		assertEquals(false, t.isZero());
+		
+		t = new TestTup(one, one, one, one);
+		assertEquals(false, t.isZero());
+	}
+	
+	/**
+	 * This test ensures, that the function {@link Tup4bigdR#isZero(BigDecimal)} returns the correct
+	 * value based on the situation.
+	 */
+	@Test
+	void isZeroTest()
+	{
+		final BigDecimal zero = BigDecimal.ZERO;
+		
+		final int tolerance = 2;
+		final BigDecimal tol = BigDecimal.valueOf(tolerance);
+		
+		for(int i = -tolerance - 1; i <= tolerance + 1; i++)
+		{
+			BigDecimal v = BigDecimal.valueOf(i);
+			
+			boolean b = Math.abs(i) <= tolerance;
+			
+			Tup4bigdR t = new TestTup(v, v, v, v);
+			assertEquals(b, t.isZero(tol));
+			
+			t = new TestTup(v, zero, zero, zero);
+			assertEquals(b, t.isZero(tol));
+			
+			t = new TestTup(zero, v, zero, zero);
+			assertEquals(b, t.isZero(tol));
+			
+			t = new TestTup(zero, zero, v, zero);
+			assertEquals(b, t.isZero(tol));
+			
+			t = new TestTup(zero, zero, zero, v);
+			assertEquals(b, t.isZero(tol));
+		}
+	}
+	
+	/**
+	 * This class is a test implementation of the interface {@link Tup4bigdR}.
+	 * 
+	 * @author picatrix1899
+	 */
+	private static class TestTup implements Tup4bigdR
+	{
+		private final BigDecimal x;
+		private final BigDecimal y;
+		private final BigDecimal z;
+		private final BigDecimal w;
+		
+		public TestTup(BigDecimal x, BigDecimal y, BigDecimal z, BigDecimal w)
+		{
+			this.x = x;
+			this.y = y;
+			this.z = z;
+			this.w = w;
+		}
+		
+		@Override
+		public BigDecimal getX()
+		{
+			return this.x;
+		}
+		
+		@Override
+		public BigDecimal getY()
+		{
+			return this.y;
+		}
+		
+		@Override
+		public BigDecimal getZ()
+		{
+			return this.z;
+		}
+		
+		@Override
+		public BigDecimal getW()
+		{
+			return this.w;
+		}
+	}
+}

--- a/barghos-core/src/test/java/org/barghos/core/test/api/tuple4/Tup4bigiRTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/api/tuple4/Tup4bigiRTest.java
@@ -1,0 +1,196 @@
+package org.barghos.core.test.api.tuple4;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+import org.barghos.core.api.testing.ValueRelay;
+import org.barghos.core.api.tuple4.Tup4bigiR;
+
+/**
+ * This class provides component tests for the interface {@link Tup4bigiR}.
+ * 
+ * @author picatrix1899
+ */
+class Tup4bigiRTest
+{
+	/**
+	 * This test ensures, that the function {@link Tup4bigiR#isValid()} returns
+	 * the corrct values for different situations.
+	 */
+	@Test
+	void isValidTest()
+	{
+		final BigInteger one = BigInteger.ONE;
+		
+		Tup4bigiR t = new TestTup(null, null, null, null);
+		assertEquals(false, t.isValid());
+		
+		t = new TestTup(one, null, null, null);
+		assertEquals(false, t.isValid());
+		
+		t = new TestTup(null, one, null, null);
+		assertEquals(false, t.isValid());
+		
+		t = new TestTup(null, null, one, null);
+		assertEquals(false, t.isValid());
+		
+		t = new TestTup(null, null, null, one);
+		assertEquals(false, t.isValid());
+		
+		t = new TestTup(one, one, one, one);
+		assertEquals(true, t.isValid());
+	}
+	
+	/**
+	 * This test ensures, that the function {@link Tup4bigiR#isFinite()} returns
+	 * the corrct values for different situations.
+	 */
+	@Test
+	void isFiniteTest()
+	{
+		Tup4bigiR t = new Tup4bigiR() {
+			public BigInteger getX()
+			{
+				ValueRelay.relayCall("getX");
+				return null;
+			}
+
+			public BigInteger getY()
+			{
+				ValueRelay.relayCall("getY");
+				return null;
+			}
+			
+			public BigInteger getZ()
+			{
+				ValueRelay.relayCall("getZ");
+				return null;
+			}
+			
+			public BigInteger getW()
+			{
+				ValueRelay.relayCall("getW");
+				return null;
+			}
+		};
+		
+		assertEquals(true, t.isFinite());
+		assertEquals(false, ValueRelay.get("getX", false));
+		assertEquals(false, ValueRelay.get("getY", false));
+		assertEquals(false, ValueRelay.get("getZ", false));
+		assertEquals(false, ValueRelay.get("getW", false));
+	}
+	
+	/**
+	 * This test ensures, that the function {@link Tup4bigiR#isZero()} returns the correct
+	 * value based on the situation.
+	 */
+	@Test
+	void isZeroExactTest()
+	{
+		final BigInteger zero = BigInteger.ZERO;
+		final BigInteger one = BigInteger.ONE;
+		
+		Tup4bigiR t = new TestTup(zero, zero, zero, zero);
+		assertEquals(true, t.isZero());
+		
+		t = new TestTup(one, zero, zero, zero);
+		assertEquals(false, t.isZero());
+		
+		t = new TestTup(zero, one, zero, zero);
+		assertEquals(false, t.isZero());
+		
+		t = new TestTup(zero, zero, one, zero);
+		assertEquals(false, t.isZero());
+		
+		t = new TestTup(zero, zero, zero, one);
+		assertEquals(false, t.isZero());
+		
+		t = new TestTup(one, one, one, one);
+		assertEquals(false, t.isZero());
+	}
+	
+	/**
+	 * This test ensures, that the function {@link Tup4bigiR#isZero(BigDecimal)} returns the correct
+	 * value based on the situation.
+	 */
+	@Test
+	void isZeroTest()
+	{
+		final BigInteger zero = BigInteger.ZERO;
+		
+		final int tolerance = 2;
+		final BigInteger tol = BigInteger.valueOf(tolerance);
+		
+		for(int i = -tolerance - 1; i <= tolerance + 1; i++)
+		{
+			BigInteger v = BigInteger.valueOf(i);
+			
+			boolean b = Math.abs(i) <= tolerance;
+			
+			Tup4bigiR t = new TestTup(v, v, v, v);
+			assertEquals(b, t.isZero(tol));
+			
+			t = new TestTup(v, zero, zero, zero);
+			assertEquals(b, t.isZero(tol));
+			
+			t = new TestTup(zero, v, zero, zero);
+			assertEquals(b, t.isZero(tol));
+			
+			t = new TestTup(zero, zero, v, zero);
+			assertEquals(b, t.isZero(tol));
+			
+			t = new TestTup(zero, zero, zero, v);
+			assertEquals(b, t.isZero(tol));
+		}
+	}
+	
+	/**
+	 * This class is a test implementation of the interface {@link Tup4bigiR}.
+	 * 
+	 * @author picatrix1899
+	 */
+	private static class TestTup implements Tup4bigiR
+	{
+		private final BigInteger x;
+		private final BigInteger y;
+		private final BigInteger z;
+		private final BigInteger w;
+		
+		public TestTup(BigInteger x, BigInteger y, BigInteger z, BigInteger w)
+		{
+			this.x = x;
+			this.y = y;
+			this.z = z;
+			this.w = w;
+		}
+		
+		@Override
+		public BigInteger getX()
+		{
+			return this.x;
+		}
+		
+		@Override
+		public BigInteger getY()
+		{
+			return this.y;
+		}
+		
+		@Override
+		public BigInteger getZ()
+		{
+			return this.z;
+		}
+		
+		@Override
+		public BigInteger getW()
+		{
+			return this.w;
+		}
+	}
+}

--- a/barghos-core/src/test/java/org/barghos/core/test/api/tuple4/Tup4boRTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/api/tuple4/Tup4boRTest.java
@@ -1,0 +1,66 @@
+package org.barghos.core.test.api.tuple4;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import org.barghos.core.api.testing.ValueRelay;
+import org.barghos.core.api.tuple4.Tup4boR;
+
+/**
+ * This claa provides component tests for the interface {@link Tup4boR}.
+ * 
+ * @author picatrix1899
+ */
+class Tup4boRTest
+{
+	/**
+	 * This method is called after each test in this class.
+	 */
+	@AfterEach
+	void cleanup()
+	{
+		ValueRelay.clear();
+	}
+	
+	/**
+	 * This test ensures, that the function {@link Tup4boR#isValid()} returns
+	 * the corrct values for different situations.
+	 */
+	@Test
+	void isValidTest()
+	{
+		Tup4boR t = new Tup4boR() {
+			public boolean getX()
+			{
+				ValueRelay.relayCall("getX");
+				return false;
+			}
+
+			public boolean getY()
+			{
+				ValueRelay.relayCall("getY");
+				return false;
+			}
+			
+			public boolean getZ()
+			{
+				ValueRelay.relayCall("getZ");
+				return false;
+			}
+			
+			public boolean getW()
+			{
+				ValueRelay.relayCall("getW");
+				return false;
+			}
+		};
+		
+		assertEquals(true, t.isValid());
+		assertEquals(false, ValueRelay.get("getX", false));
+		assertEquals(false, ValueRelay.get("getY", false));
+		assertEquals(false, ValueRelay.get("getZ", false));
+		assertEquals(false, ValueRelay.get("getW", false));
+	}
+}

--- a/barghos-core/src/test/java/org/barghos/core/test/api/tuple4/Tup4cRTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/api/tuple4/Tup4cRTest.java
@@ -1,0 +1,106 @@
+package org.barghos.core.test.api.tuple4;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import org.barghos.core.api.testing.ValueRelay;
+import org.barghos.core.api.tuple4.Tup4cR;
+
+/**
+ * This claa provides component tests for the interface {@link Tup4cR}.
+ * 
+ * @author picatrix1899
+ */
+class Tup4cRTest
+{
+	/**
+	 * This method is called after each test in this class.
+	 */
+	@AfterEach
+	void cleanup()
+	{
+		ValueRelay.clear();
+	}
+	
+	/**
+	 * This test ensures, that the function {@link Tup4cR#isValid()} returns
+	 * the corrct values for different situations.
+	 */
+	@Test
+	void isValidTest()
+	{
+		Tup4cR t = new Tup4cR() {
+			public char getX()
+			{
+				ValueRelay.relayCall("getX");
+				return 'a';
+			}
+
+			public char getY()
+			{
+				ValueRelay.relayCall("getY");
+				return 'a';
+			}
+			
+			public char getZ()
+			{
+				ValueRelay.relayCall("getZ");
+				return 'a';
+			}
+			
+			public char getW()
+			{
+				ValueRelay.relayCall("getW");
+				return 'a';
+			}
+		};
+		
+		assertEquals(true, t.isValid());
+		assertEquals(false, ValueRelay.get("getX", false));
+		assertEquals(false, ValueRelay.get("getY", false));
+		assertEquals(false, ValueRelay.get("getZ", false));
+		assertEquals(false, ValueRelay.get("getW", false));
+	}
+	
+	/**
+	 * This test ensures, that the function {@link Tup4cR#isFinite()} returns
+	 * the corrct values for different situations.
+	 */
+	@Test
+	void isFiniteTest()
+	{
+		Tup4cR t = new Tup4cR() {
+			public char getX()
+			{
+				ValueRelay.relayCall("getX");
+				return 'a';
+			}
+
+			public char getY()
+			{
+				ValueRelay.relayCall("getY");
+				return 'a';
+			}
+			
+			public char getZ()
+			{
+				ValueRelay.relayCall("getZ");
+				return 'a';
+			}
+			
+			public char getW()
+			{
+				ValueRelay.relayCall("getW");
+				return 'a';
+			}
+		};
+		
+		assertEquals(true, t.isFinite());
+		assertEquals(false, ValueRelay.get("getX", false));
+		assertEquals(false, ValueRelay.get("getY", false));
+		assertEquals(false, ValueRelay.get("getZ", false));
+		assertEquals(false, ValueRelay.get("getW", false));
+	}
+}

--- a/barghos-core/src/test/java/org/barghos/core/test/api/tuple4/Tup4dRTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/api/tuple4/Tup4dRTest.java
@@ -1,0 +1,192 @@
+package org.barghos.core.test.api.tuple4;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+import org.barghos.core.api.testing.ValueRelay;
+import org.barghos.core.api.tuple4.Tup4dR;
+
+/**
+ * This class provides component tests for the interface {@link Tup4dR}.
+ * 
+ * @author picatrix1899
+ */
+class Tup4dRTest
+{
+	/**
+	 * This test ensures, that the function {@link Tup4dR#isValid()} returns
+	 * the corrct values for different situations.
+	 */
+	@Test
+	void isValidTest()
+	{
+		Tup4dR t = new Tup4dR() {
+			public double getX()
+			{
+				ValueRelay.relayCall("getX");
+				return 0.0;
+			}
+
+			public double getY()
+			{
+				ValueRelay.relayCall("getY");
+				return 0.0;
+			}
+			
+			public double getZ()
+			{
+				ValueRelay.relayCall("getZ");
+				return 0.0;
+			}
+			
+			public double getW()
+			{
+				ValueRelay.relayCall("getW");
+				return 0.0;
+			}
+		};
+		
+		assertEquals(true, t.isValid());
+		assertEquals(false, ValueRelay.get("getX", false));
+		assertEquals(false, ValueRelay.get("getY", false));
+		assertEquals(false, ValueRelay.get("getZ", false));
+		assertEquals(false, ValueRelay.get("getW", false));
+	}
+	
+	/**
+	 * This test ensures, that the function {@link Tup4dR#isFinite()} returns
+	 * the corrct values for different situations.
+	 */
+	@Test
+	void isFiniteTest()
+	{
+		final double[] values = new double[] {0.0, Double.NaN, Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY};
+		
+		for(int i = 0; i <= 4; i++)
+		{
+			double v = values[i];
+			
+			boolean b = i == 0;
+			
+			Tup4dR t = new TestTup(v, v, v, v);
+			assertEquals(b, t.isFinite());
+			
+			t = new TestTup(v, 0.0, 0.0, 0.0);
+			assertEquals(b, t.isFinite());
+			
+			t = new TestTup(0.0, v, 0.0, 0.0);
+			assertEquals(b, t.isFinite());
+			
+			t = new TestTup(0.0, 0.0, v, 0.0);
+			assertEquals(b, t.isFinite());
+			
+			t = new TestTup(0.0, 0.0, 0.0, v);
+			assertEquals(b, t.isFinite());
+		}
+	}
+	
+	/**
+	 * This test ensures, that the function {@link Tup4dR#isZero()} returns the correct
+	 * value based on the situation.
+	 */
+	@Test
+	void isZeroExactTest()
+	{
+		Tup4dR t = new TestTup(0.0, 0.0, 0.0, 0.0);
+		assertEquals(true, t.isZero());
+		
+		t = new TestTup(1.0, 0.0, 0.0, 0.0);
+		assertEquals(false, t.isZero());
+		
+		t = new TestTup(0.0, 1.0, 0.0, 0.0);
+		assertEquals(false, t.isZero());
+		
+		t = new TestTup(0.0, 0.0, 1.0, 0.0);
+		assertEquals(false, t.isZero());
+		
+		t = new TestTup(0.0, 0.0, 0.0, 1.0);
+		assertEquals(false, t.isZero());
+		
+		t = new TestTup(1.0, 1.0, 1.0, 1.0);
+		assertEquals(false, t.isZero());
+	}
+	
+	/**
+	 * This test ensures, that the function {@link Tup4dR#isZero(byte)} returns the correct
+	 * value based on the situation.
+	 */
+	@Test
+	void isZeroTest()
+	{
+		final int tolerance = 2;
+		final double tol = (double)tolerance;
+		
+		for(int i = -tolerance - 1; i <= tolerance + 1; i++)
+		{
+			double v = (double)i;
+			
+			boolean b = Math.abs(i) <= tolerance;
+			
+			Tup4dR t = new TestTup(v, v, v, v);
+			assertEquals(b, t.isZero(tol));
+			
+			t = new TestTup(v, 0.0, 0.0, 0.0);
+			assertEquals(b, t.isZero(tol));
+			
+			t = new TestTup(0.0, v, 0.0, 0.0);
+			assertEquals(b, t.isZero(tol));
+			
+			t = new TestTup(0.0, 0.0, v, 0.0);
+			assertEquals(b, t.isZero(tol));
+			
+			t = new TestTup(0.0, 0.0, 0.0, v);
+			assertEquals(b, t.isZero(tol));
+		}
+	}
+	
+	/**
+	 * This class is a test implementation of the interface {@link Tup4dR}.
+	 * 
+	 * @author picatrix1899
+	 */
+	private static class TestTup implements Tup4dR
+	{
+		private final double x;
+		private final double y;
+		private final double z;
+		private final double w;
+		
+		public TestTup(double x, double y , double z, double w)
+		{
+			this.x = x;
+			this.y = y;
+			this.z = z;
+			this.w = w;
+		}
+		
+		@Override
+		public double getX()
+		{
+			return this.x;
+		}
+		
+		@Override
+		public double getY()
+		{
+			return this.y;
+		}
+		
+		@Override
+		public double getZ()
+		{
+			return this.z;
+		}
+		
+		@Override
+		public double getW()
+		{
+			return this.w;
+		}
+	}
+}

--- a/barghos-core/src/test/java/org/barghos/core/test/api/tuple4/Tup4dRTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/api/tuple4/Tup4dRTest.java
@@ -63,7 +63,7 @@ class Tup4dRTest
 	{
 		final double[] values = new double[] {0.0, Double.NaN, Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY};
 		
-		for(int i = 0; i <= 4; i++)
+		for(int i = 0; i < 4; i++)
 		{
 			double v = values[i];
 			

--- a/barghos-core/src/test/java/org/barghos/core/test/api/tuple4/Tup4fRTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/api/tuple4/Tup4fRTest.java
@@ -63,7 +63,7 @@ class Tup4fRTest
 	{
 		final float[] values = new float[] {0.0f, Float.NaN, Float.NEGATIVE_INFINITY, Float.POSITIVE_INFINITY};
 		
-		for(int i = 0; i <= 4; i++)
+		for(int i = 0; i < 4; i++)
 		{
 			float v = values[i];
 			

--- a/barghos-core/src/test/java/org/barghos/core/test/api/tuple4/Tup4fRTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/api/tuple4/Tup4fRTest.java
@@ -1,0 +1,192 @@
+package org.barghos.core.test.api.tuple4;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+import org.barghos.core.api.testing.ValueRelay;
+import org.barghos.core.api.tuple4.Tup4fR;
+
+/**
+ * This class provides component tests for the interface {@link Tup4fR}.
+ * 
+ * @author picatrix1899
+ */
+class Tup4fRTest
+{
+	/**
+	 * This test ensures, that the function {@link Tup4fR#isValid()} returns
+	 * the corrct values for different situations.
+	 */
+	@Test
+	void isValidTest()
+	{
+		Tup4fR t = new Tup4fR() {
+			public float getX()
+			{
+				ValueRelay.relayCall("getX");
+				return 0.0f;
+			}
+
+			public float getY()
+			{
+				ValueRelay.relayCall("getY");
+				return 0.0f;
+			}
+			
+			public float getZ()
+			{
+				ValueRelay.relayCall("getZ");
+				return 0.0f;
+			}
+			
+			public float getW()
+			{
+				ValueRelay.relayCall("getW");
+				return 0.0f;
+			}
+		};
+		
+		assertEquals(true, t.isValid());
+		assertEquals(false, ValueRelay.get("getX", false));
+		assertEquals(false, ValueRelay.get("getY", false));
+		assertEquals(false, ValueRelay.get("getZ", false));
+		assertEquals(false, ValueRelay.get("getW", false));
+	}
+	
+	/**
+	 * This test ensures, that the function {@link Tup4fR#isFinite()} returns
+	 * the corrct values for different situations.
+	 */
+	@Test
+	void isFiniteTest()
+	{
+		final float[] values = new float[] {0.0f, Float.NaN, Float.NEGATIVE_INFINITY, Float.POSITIVE_INFINITY};
+		
+		for(int i = 0; i <= 4; i++)
+		{
+			float v = values[i];
+			
+			boolean b = i == 0;
+			
+			Tup4fR t = new TestTup(v, v, v, v);
+			assertEquals(b, t.isFinite());
+			
+			t = new TestTup(v, 0.0f, 0.0f, 0.0f);
+			assertEquals(b, t.isFinite());
+			
+			t = new TestTup(0.0f, v, 0.0f, 0.0f);
+			assertEquals(b, t.isFinite());
+			
+			t = new TestTup(0.0f, 0.0f, v, 0.0f);
+			assertEquals(b, t.isFinite());
+			
+			t = new TestTup(0.0f, 0.0f, 0.0f, v);
+			assertEquals(b, t.isFinite());
+		}
+	}
+	
+	/**
+	 * This test ensures, that the function {@link Tup4fR#isZero()} returns the correct
+	 * value based on the situation.
+	 */
+	@Test
+	void isZeroExactTest()
+	{
+		Tup4fR t = new TestTup(0.0f, 0.0f, 0.0f, 0.0f);
+		assertEquals(true, t.isZero());
+		
+		t = new TestTup(1.0f, 0.0f, 0.0f, 0.0f);
+		assertEquals(false, t.isZero());
+		
+		t = new TestTup(0.0f, 1.0f, 0.0f, 0.0f);
+		assertEquals(false, t.isZero());
+		
+		t = new TestTup(0.0f, 0.0f, 1.0f, 0.0f);
+		assertEquals(false, t.isZero());
+		
+		t = new TestTup(0.0f, 0.0f, 0.0f, 1.0f);
+		assertEquals(false, t.isZero());
+		
+		t = new TestTup(1.0f, 1.0f, 1.0f, 1.0f);
+		assertEquals(false, t.isZero());
+	}
+	
+	/**
+	 * This test ensures, that the function {@link Tup4fR#isZero(byte)} returns the correct
+	 * value based on the situation.
+	 */
+	@Test
+	void isZeroTest()
+	{
+		final int tolerance = 2;
+		final float tol = (float)tolerance;
+		
+		for(int i = -tolerance - 1; i <= tolerance + 1; i++)
+		{
+			float v = (float)i;
+			
+			boolean b = Math.abs(i) <= tolerance;
+			
+			Tup4fR t = new TestTup(v, v, v, v);
+			assertEquals(b, t.isZero(tol));
+			
+			t = new TestTup(v, 0.0f, 0.0f, 0.0f);
+			assertEquals(b, t.isZero(tol));
+			
+			t = new TestTup(0.0f, v, 0.0f, 0.0f);
+			assertEquals(b, t.isZero(tol));
+			
+			t = new TestTup(0.0f, 0.0f, v, 0.0f);
+			assertEquals(b, t.isZero(tol));
+			
+			t = new TestTup(0.0f, 0.0f, 0.0f, v);
+			assertEquals(b, t.isZero(tol));
+		}
+	}
+	
+	/**
+	 * This class is a test implementation of the interface {@link Tup4fR}.
+	 * 
+	 * @author picatrix1899
+	 */
+	private static class TestTup implements Tup4fR
+	{
+		private final float x;
+		private final float y;
+		private final float z;
+		private final float w;
+		
+		public TestTup(float x, float y, float z, float w)
+		{
+			this.x = x;
+			this.y = y;
+			this.z = z;
+			this.w = w;
+		}
+		
+		@Override
+		public float getX()
+		{
+			return this.x;
+		}
+		
+		@Override
+		public float getY()
+		{
+			return this.y;
+		}
+		
+		@Override
+		public float getZ()
+		{
+			return this.z;
+		}
+		
+		@Override
+		public float getW()
+		{
+			return this.w;
+		}
+	}
+}

--- a/barghos-core/src/test/java/org/barghos/core/test/api/tuple4/Tup4lRTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/api/tuple4/Tup4lRTest.java
@@ -1,0 +1,200 @@
+package org.barghos.core.test.api.tuple4;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+import org.barghos.core.api.testing.ValueRelay;
+import org.barghos.core.api.tuple4.Tup4lR;
+
+/**
+ * This class provides component tests for the interface {@link Tup4lR}.
+ * 
+ * @author picatrix1899
+ */
+class Tup4lRTest
+{
+	/**
+	 * This test ensures, that the function {@link Tup4lR#isValid()} returns
+	 * the corrct values for different situations.
+	 */
+	@Test
+	void isValidTest()
+	{
+		Tup4lR t = new Tup4lR() {
+			public long getX()
+			{
+				ValueRelay.relayCall("getX");
+				return 0l;
+			}
+
+			public long getY()
+			{
+				ValueRelay.relayCall("getY");
+				return 0l;
+			}
+			
+			public long getZ()
+			{
+				ValueRelay.relayCall("getZ");
+				return 0l;
+			}
+			
+			public long getW()
+			{
+				ValueRelay.relayCall("getW");
+				return 0l;
+			}
+		};
+		
+		assertEquals(true, t.isValid());
+		assertEquals(false, ValueRelay.get("getX", false));
+		assertEquals(false, ValueRelay.get("getY", false));
+		assertEquals(false, ValueRelay.get("getZ", false));
+		assertEquals(false, ValueRelay.get("getW", false));
+	}
+	
+	/**
+	 * This test ensures, that the function {@link Tup4lR#isFinite()} returns
+	 * the corrct values for different situations.
+	 */
+	@Test
+	void isFiniteTest()
+	{
+		Tup4lR t = new Tup4lR() {
+			public long getX()
+			{
+				ValueRelay.relayCall("getX");
+				return 0l;
+			}
+
+			public long getY()
+			{
+				ValueRelay.relayCall("getY");
+				return 0l;
+			}
+			
+			public long getZ()
+			{
+				ValueRelay.relayCall("getZ");
+				return 0l;
+			}
+			
+			public long getW()
+			{
+				ValueRelay.relayCall("getW");
+				return 0l;
+			}
+		};
+		
+		assertEquals(true, t.isFinite());
+		assertEquals(false, ValueRelay.get("getX", false));
+		assertEquals(false, ValueRelay.get("getY", false));
+		assertEquals(false, ValueRelay.get("getZ", false));
+		assertEquals(false, ValueRelay.get("getW", false));
+	}
+	
+	/**
+	 * This test ensures, that the function {@link Tup4lR#isZero()} returns the correct
+	 * value based on the situation.
+	 */
+	@Test
+	void isZeroExactTest()
+	{
+		Tup4lR t = new TestTup(0l, 0l, 0l, 0l);
+		assertEquals(true, t.isZero());
+		
+		t = new TestTup(1l, 0l, 0l, 0l);
+		assertEquals(false, t.isZero());
+		
+		t = new TestTup(0l, 1l, 0l, 0l);
+		assertEquals(false, t.isZero());
+		
+		t = new TestTup(0l, 0l, 1l, 0l);
+		assertEquals(false, t.isZero());
+		
+		t = new TestTup(0l, 0l, 0l, 1l);
+		assertEquals(false, t.isZero());
+		
+		t = new TestTup(1l, 1l, 1l, 1l);
+		assertEquals(false, t.isZero());
+	}
+	
+	/**
+	 * This test ensures, that the function {@link Tup4lR#isZero(byte)} returns the correct
+	 * value based on the situation.
+	 */
+	@Test
+	void isZeroTest()
+	{
+		final int tolerance = 2;
+		final long tol = (long)tolerance;
+		
+		for(int i = -tolerance - 1; i <= tolerance + 1; i++)
+		{
+			long v = (long)i;
+			
+			boolean b = Math.abs(i) <= tolerance;
+			
+			Tup4lR t = new TestTup(v, v, v, v);
+			assertEquals(b, t.isZero(tol));
+			
+			t = new TestTup(v, 0l, 0l, 0l);
+			assertEquals(b, t.isZero(tol));
+			
+			t = new TestTup(0l, v, 0l, 0l);
+			assertEquals(b, t.isZero(tol));
+			
+			t = new TestTup(0l, 0l, v, 0l);
+			assertEquals(b, t.isZero(tol));
+			
+			t = new TestTup(0l, 0l, 0l, v);
+			assertEquals(b, t.isZero(tol));
+		}
+	}
+	
+	/**
+	 * This class is a test implementation of the interface {@link Tup4lR}.
+	 * 
+	 * @author picatrix1899
+	 */
+	private static class TestTup implements Tup4lR
+	{
+		private final long x;
+		private final long y;
+		private final long z;
+		private final long w;
+		
+		public TestTup(long x, long y, long z, long w)
+		{
+			this.x = x;
+			this.y = y;
+			this.z = z;
+			this.w = w;
+		}
+		
+		@Override
+		public long getX()
+		{
+			return this.x;
+		}
+		
+		@Override
+		public long getY()
+		{
+			return this.y;
+		}
+		
+		@Override
+		public long getZ()
+		{
+			return this.z;
+		}
+		
+		@Override
+		public long getW()
+		{
+			return this.w;
+		}
+	}
+}

--- a/barghos-core/src/test/java/org/barghos/core/test/api/tuple4/Tup4oRTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/api/tuple4/Tup4oRTest.java
@@ -1,0 +1,86 @@
+package org.barghos.core.test.api.tuple4;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+import org.barghos.core.api.tuple4.Tup4oR;
+
+/**
+ * This class provides component tests for the interface {@link Tup4oR}.
+ * 
+ * @author picatrix1899
+ */
+class Tup4oRTest
+{
+	/**
+	 * This test ensures, that the function {@link Tup4oR#isValid()} returns
+	 * the corrct values for different situations.
+	 */
+	@Test
+	void isValidTest()
+	{
+		Tup4oR<Object, Object, Object, Object> t = new TestTup<>(null, null, null, null);
+		assertEquals(false, t.isValid());
+		
+		t = new TestTup<>(new Object(), null, null, null);
+		assertEquals(false, t.isValid());
+		
+		t = new TestTup<>(null, new Object(), null, null);
+		assertEquals(false, t.isValid());
+		
+		t = new TestTup<>(null, null, new Object(), null);
+		assertEquals(false, t.isValid());
+		
+		t = new TestTup<>(null, null, null, new Object());
+		assertEquals(false, t.isValid());
+		
+		t = new TestTup<>(new Object(), new Object(), new Object(), new Object());
+		assertEquals(true, t.isValid());
+	}
+	
+	/**
+	 * This class is a test implementation of the interface {@link Tup4oR}.
+	 * 
+	 * @author picatrix1899
+	 */
+	private static class TestTup<X,Y,Z,W> implements Tup4oR<X,Y,Z,W>
+	{
+		private final X x;
+		private final Y y;
+		private final Z z;
+		private final W w;
+		
+		public TestTup(X x, Y y, Z z, W w)
+		{
+			this.x = x;
+			this.y = y;
+			this.z = z;
+			this.w = w;
+		}
+		
+		@Override
+		public X getX()
+		{
+			return this.x;
+		}
+		
+		@Override
+		public Y getY()
+		{
+			return this.y;
+		}
+		
+		@Override
+		public Z getZ()
+		{
+			return this.z;
+		}
+		
+		@Override
+		public W getW()
+		{
+			return this.w;
+		}
+	}
+}

--- a/barghos-core/src/test/java/org/barghos/core/test/api/tuple4/Tup4objRTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/api/tuple4/Tup4objRTest.java
@@ -1,0 +1,86 @@
+package org.barghos.core.test.api.tuple4;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+import org.barghos.core.api.tuple4.Tup4objR;
+
+/**
+ * This class provides component tests for the interface {@link Tup4objR}.
+ * 
+ * @author picatrix1899
+ */
+class Tup4objRTest
+{
+	/**
+	 * This test ensures, that the function {@link Tup4objR#isValid()} returns
+	 * the corrct values for different situations.
+	 */
+	@Test
+	void isValidTest()
+	{
+		Tup4objR t = new TestTup(null, null, null, null);
+		assertEquals(false, t.isValid());
+		
+		t = new TestTup(new Object(), null, null, null);
+		assertEquals(false, t.isValid());
+		
+		t = new TestTup(null, new Object(), null, null);
+		assertEquals(false, t.isValid());
+		
+		t = new TestTup(null, null, new Object(), null);
+		assertEquals(false, t.isValid());
+		
+		t = new TestTup(null, null, null, new Object());
+		assertEquals(false, t.isValid());
+		
+		t = new TestTup(new Object(), new Object(), new Object(), new Object());
+		assertEquals(true, t.isValid());
+	}
+	
+	/**
+	 * This class is a test implementation of the interface {@link Tup4objR}.
+	 * 
+	 * @author picatrix1899
+	 */
+	private static class TestTup implements Tup4objR
+	{
+		private final Object x;
+		private final Object y;
+		private final Object z;
+		private final Object w;
+		
+		public TestTup(Object x, Object y, Object z, Object w)
+		{
+			this.x = x;
+			this.y = y;
+			this.z = z;
+			this.w = w;
+		}
+		
+		@Override
+		public Object getX()
+		{
+			return this.x;
+		}
+		
+		@Override
+		public Object getY()
+		{
+			return this.y;
+		}
+		
+		@Override
+		public Object getZ()
+		{
+			return this.z;
+		}
+		
+		@Override
+		public Object getW()
+		{
+			return this.w;
+		}
+	}
+}

--- a/barghos-core/src/test/java/org/barghos/core/test/api/tuple4/Tup4sRTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/api/tuple4/Tup4sRTest.java
@@ -1,0 +1,205 @@
+package org.barghos.core.test.api.tuple4;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+import org.barghos.core.api.testing.ValueRelay;
+import org.barghos.core.api.tuple4.Tup4sR;
+
+/**
+ * This class provides component tests for the interface {@link Tup4sR}.
+ * 
+ * @author picatrix1899
+ */
+class Tup4sRTest
+{
+	/**
+	 * This test ensures, that the function {@link Tup4sR#isValid()} returns
+	 * the corrct values for different situations.
+	 */
+	@Test
+	void isValidTest()
+	{
+		Tup4sR t = new Tup4sR() {
+			public short getX()
+			{
+				ValueRelay.relayCall("getX");
+				return (short)0;
+			}
+
+			public short getY()
+			{
+				ValueRelay.relayCall("getY");
+				return (short)0;
+			}
+			
+			public short getZ()
+			{
+				ValueRelay.relayCall("getZ");
+				return (short)0;
+			}
+			
+			public short getW()
+			{
+				ValueRelay.relayCall("getW");
+				return (short)0;
+			}
+		};
+		
+		assertEquals(true, t.isValid());
+		assertEquals(false, ValueRelay.get("getX", false));
+		assertEquals(false, ValueRelay.get("getY", false));
+		assertEquals(false, ValueRelay.get("getZ", false));
+		assertEquals(false, ValueRelay.get("getW", false));
+	}
+	
+	/**
+	 * This test ensures, that the function {@link Tup4sR#isFinite()} returns
+	 * the corrct values for different situations.
+	 */
+	@Test
+	void isFiniteTest()
+	{
+		Tup4sR t = new Tup4sR() {
+			public short getX()
+			{
+				ValueRelay.relayCall("getX");
+				return (short)0;
+			}
+
+			public short getY()
+			{
+				ValueRelay.relayCall("getY");
+				return (short)0;
+			}
+			
+			public short getZ()
+			{
+				ValueRelay.relayCall("getZ");
+				return (short)0;
+			}
+			
+			public short getW()
+			{
+				ValueRelay.relayCall("getW");
+				return (short)0;
+			}
+		};
+		
+		assertEquals(true, t.isFinite());
+		assertEquals(false, ValueRelay.get("getX", false));
+		assertEquals(false, ValueRelay.get("getY", false));
+		assertEquals(false, ValueRelay.get("getZ", false));
+		assertEquals(false, ValueRelay.get("getW", false));
+	}
+	
+	/**
+	 * This test ensures, that the function {@link Tup4sR#isZero()} returns the correct
+	 * value based on the situation.
+	 */
+	@Test
+	void isZeroExactTest()
+	{	
+		final short zero = (short)0;
+		final short one = (short)1;
+		
+		Tup4sR t = new TestTup(zero, zero, zero, zero);
+		assertEquals(true, t.isZero());
+		
+		t = new TestTup(one, zero, zero, zero);
+		assertEquals(false, t.isZero());
+		
+		t = new TestTup(zero, one, zero, zero);
+		assertEquals(false, t.isZero());
+		
+		t = new TestTup(zero, zero, one, zero);
+		assertEquals(false, t.isZero());
+		
+		t = new TestTup(zero, zero, zero, one);
+		assertEquals(false, t.isZero());
+		
+		t = new TestTup(one, one, one, one);
+		assertEquals(false, t.isZero());
+	}
+	
+	/**
+	 * This test ensures, that the function {@link Tup4sR#isZero(byte)} returns the correct
+	 * value based on the situation.
+	 */
+	@Test
+	void isZeroTest()
+	{
+		final short zero = (short)0;
+		
+		final int tolerance = 2;
+		final short tol = (short)tolerance;
+		
+		for(int i = -tolerance - 1; i <= tolerance + 1; i++)
+		{
+			short v = (short)i;
+			
+			boolean b = Math.abs(i) <= tolerance;
+			
+			Tup4sR t = new TestTup(v, v, v, v);
+			assertEquals(b, t.isZero(tol));
+			
+			t = new TestTup(v, zero, zero, zero);
+			assertEquals(b, t.isZero(tol));
+			
+			t = new TestTup(zero, v, zero, zero);
+			assertEquals(b, t.isZero(tol));
+			
+			t = new TestTup(zero, zero, v, zero);
+			assertEquals(b, t.isZero(tol));
+			
+			t = new TestTup(zero, zero, zero, v);
+			assertEquals(b, t.isZero(tol));
+		}
+	}
+	
+	/**
+	 * This class is a test implementation of the interface {@link Tup4sR}.
+	 * 
+	 * @author picatrix1899
+	 */
+	private static class TestTup implements Tup4sR
+	{
+		private final short x;
+		private final short y;
+		private final short z;
+		private final short w;
+		
+		public TestTup(short x, short y, short z, short w)
+		{
+			this.x = x;
+			this.y = y;
+			this.z = z;
+			this.w = w;
+		}
+		
+		@Override
+		public short getX()
+		{
+			return this.x;
+		}
+		
+		@Override
+		public short getY()
+		{
+			return this.y;
+		}
+		
+		@Override
+		public short getZ()
+		{
+			return this.z;
+		}
+		
+		@Override
+		public short getW()
+		{
+			return this.w;
+		}
+	}
+}

--- a/barghos-core/src/test/java/org/barghos/core/test/api/tuple4/Tup4strRTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/api/tuple4/Tup4strRTest.java
@@ -1,0 +1,86 @@
+package org.barghos.core.test.api.tuple4;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+import org.barghos.core.api.tuple4.Tup4strR;
+
+/**
+ * This class provides component tests for the interface {@link Tup4strR}.
+ * 
+ * @author picatrix1899
+ */
+class Tup4strRTest
+{
+	/**
+	 * This test ensures, that the function {@link Tup4strR#isValid()} returns
+	 * the corrct values for different situations.
+	 */
+	@Test
+	void isValidTest()
+	{
+		Tup4strR t = new TestTup(null, null, null, null);
+		assertEquals(false, t.isValid());
+		
+		t = new TestTup("", null, null, null);
+		assertEquals(false, t.isValid());
+		
+		t = new TestTup(null, "", null, null);
+		assertEquals(false, t.isValid());
+		
+		t = new TestTup(null, null, "", null);
+		assertEquals(false, t.isValid());
+		
+		t = new TestTup(null, null, null, "");
+		assertEquals(false, t.isValid());
+		
+		t = new TestTup("", "", "", "");
+		assertEquals(true, t.isValid());
+	}
+	
+	/**
+	 * This class is a test implementation of the interface {@link Tup4strR}.
+	 * 
+	 * @author picatrix1899
+	 */
+	private static class TestTup implements Tup4strR
+	{
+		private final String x;
+		private final String y;
+		private final String z;
+		private final String w;
+		
+		public TestTup(String x, String y, String z, String w)
+		{
+			this.x = x;
+			this.y = y;
+			this.z = z;
+			this.w = w;
+		}
+		
+		@Override
+		public String getX()
+		{
+			return this.x;
+		}
+		
+		@Override
+		public String getY()
+		{
+			return this.y;
+		}
+		
+		@Override
+		public String getZ()
+		{
+			return this.z;
+		}
+		
+		@Override
+		public String getW()
+		{
+			return this.w;
+		}
+	}
+}

--- a/barghos-core/src/test/java/org/barghos/core/test/api/tuple4/package-info.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/api/tuple4/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * This package contains component tests for the API for 4-dimensional tuples.
+ * 
+ * @author picatrix1899
+ */
+package org.barghos.core.test.api.tuple4;


### PR DESCRIPTION
- Added a function isValid to all tuple readonly interfaces to provide
an easy way to validate the data in a tuple. By default the BigDecimal,
the BigInteger, the Object, the generic and the String-tuples are only
valid if none of the components is null.

- Added the function isFinite to all numeric tuple readonly interfaces.
By default the isFinite function returns true for all numeric tuples
except the float and double tuples as these types deal with infinity and
NaN. For these tuples the corresponding function isFinite like
Double.isFinite is called for every component. A tuple is only
considered to be finite if all components are finite.

- Added the function isZero to all numeric tuples readonly interfaces.
It returns true if all components are exactly zero.

- Added the alternative function isZero(with tolerance) to all numeric
readonly interfaces. It returns true if all components are within the
tolerance around zero, positive and negative. For example, for a
tolerance of 0.5 a value of 0.4 is considered to be zero, a value of
-0.4 aswell but a value of 0.6 or -0.6 is not considered to be zero.