### PR TITLE
Added getNewInstance functions to tuples for type continuity.

### DIFF
--- a/barghos-core/src/main/java/org/barghos/core/api/color/Color3R.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/color/Color3R.java
@@ -113,4 +113,19 @@ public interface Color3R extends Tup3fR
 	 * @since 1.0.0.0
 	 */
 	default float getZ() { return getUnityB(); }
+	
+	@Override
+	default Color3R getNewInstance(Tup3fR t)
+	{
+		return getNewInstance(t.getX(), t.getY(), t.getZ());
+	}
+	
+	@Override
+	default Color3R getNewInstance(float value)
+	{
+		return getNewInstance(value, value, value);
+	}
+	
+	@Override
+	Color3R getNewInstance(float x, float y, float z);
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/color/Color4R.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/color/Color4R.java
@@ -22,6 +22,7 @@
 
 package org.barghos.core.api.color;
 
+import org.barghos.core.api.tuple3.Tup3fR;
 import org.barghos.core.api.tuple4.Tup4fR;
 
 /**
@@ -110,4 +111,28 @@ public interface Color4R extends Color3R, Tup4fR
 	{
 		return Tup4fR.super.isFinite();
 	}
+	
+	@Override
+	default Color4R getNewInstance(Tup3fR t)
+	{
+		return getNewInstance(t.getX(), t.getY(), t.getZ());
+	}
+	
+	@Override
+	default Color4R getNewInstance(Tup4fR t)
+	{
+		return getNewInstance(t.getX(), t.getY(), t.getZ(), t.getW());
+	}
+	
+	@Override
+	default Color4R getNewInstance(float value)
+	{
+		return getNewInstance(value, value, value, value);
+	}
+	
+	@Override
+	Color4R getNewInstance(float x, float y, float z);
+	
+	@Override
+	Color4R getNewInstance(float x, float y, float z, float w);
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/color/HDRColor3R.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/color/HDRColor3R.java
@@ -22,6 +22,8 @@
 
 package org.barghos.core.api.color;
 
+import org.barghos.core.api.tuple3.Tup3fR;
+
 /**
  * This interface grants selective readonly access for high dynamic range (HDR) RGB-Colors only.
  * 
@@ -31,5 +33,18 @@ package org.barghos.core.api.color;
  */
 public interface HDRColor3R extends Color3R
 {
+	@Override
+	default HDRColor3R getNewInstance(Tup3fR t)
+	{
+		return getNewInstance(t.getX(), t.getY(), t.getZ());
+	}
 	
+	@Override
+	default HDRColor3R getNewInstance(float value)
+	{
+		return getNewInstance(value, value, value);
+	}
+	
+	@Override
+	HDRColor3R getNewInstance(float x, float y, float z);
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/color/HDRColor4R.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/color/HDRColor4R.java
@@ -22,6 +22,9 @@
 
 package org.barghos.core.api.color;
 
+import org.barghos.core.api.tuple3.Tup3fR;
+import org.barghos.core.api.tuple4.Tup4fR;
+
 /**
  * This interface grants selective readonly access for high dynamic range (HDR) RGBA-Colors only.
  * 
@@ -31,5 +34,27 @@ package org.barghos.core.api.color;
  */
 public interface HDRColor4R extends HDRColor3R, Color4R
 {
-
+	@Override
+	default HDRColor4R getNewInstance(Tup3fR t)
+	{
+		return getNewInstance(t.getX(), t.getY(), t.getZ());
+	}
+	
+	@Override
+	default HDRColor4R getNewInstance(Tup4fR t)
+	{
+		return getNewInstance(t.getX(), t.getY(), t.getZ(), t.getW());
+	}
+	
+	@Override
+	default HDRColor4R getNewInstance(float value)
+	{
+		return getNewInstance(value, value, value, value);
+	}
+	
+	@Override
+	HDRColor4R getNewInstance(float x, float y, float z);
+	
+	@Override
+	HDRColor4R getNewInstance(float x, float y, float z, float w);
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/color/LDRColor3R.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/color/LDRColor3R.java
@@ -22,6 +22,8 @@
 
 package org.barghos.core.api.color;
 
+import org.barghos.core.api.tuple3.Tup3fR;
+
 /**
  * This interface grants selective readonly access for low dynamic range (LDR/Standard) RGB-Colors only.
  * 
@@ -31,5 +33,17 @@ package org.barghos.core.api.color;
  */
 public interface LDRColor3R extends Color3R
 {
+	@Override
+	default LDRColor3R getNewInstance(Tup3fR t)
+	{
+		return getNewInstance(t.getX(), t.getY(), t.getZ());
+	}
 	
+	@Override
+	default LDRColor3R getNewInstance(float value)
+	{
+		return getNewInstance(value, value, value);
+	}
+	
+	LDRColor3R getNewInstance(float x, float y, float z);
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/color/LDRColor4R.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/color/LDRColor4R.java
@@ -22,6 +22,9 @@
 
 package org.barghos.core.api.color;
 
+import org.barghos.core.api.tuple3.Tup3fR;
+import org.barghos.core.api.tuple4.Tup4fR;
+
 /**
  * This interface grants selective readonly access for low dynamic range (LDR/Standard) RGBA-Colors only.
  * 
@@ -31,5 +34,27 @@ package org.barghos.core.api.color;
  */
 public interface LDRColor4R extends LDRColor3R, Color4R
 {
-
+	@Override
+	default LDRColor4R getNewInstance(Tup3fR t)
+	{
+		return getNewInstance(t.getX(), t.getY(), t.getZ());
+	}
+	
+	@Override
+	default LDRColor4R getNewInstance(Tup4fR t)
+	{
+		return getNewInstance(t.getX(), t.getY(), t.getZ(), t.getW());
+	}
+	
+	@Override
+	default LDRColor4R getNewInstance(float value)
+	{
+		return getNewInstance(value, value, value, value);
+	}
+	
+	@Override
+	LDRColor4R getNewInstance(float x, float y, float z);
+	
+	@Override
+	LDRColor4R getNewInstance(float x, float y, float z, float w);
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple2/Tup2bR.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple2/Tup2bR.java
@@ -97,4 +97,64 @@ public interface Tup2bR
 	{
 		return true;
 	}
+	
+	/**
+	 * Returns a new instance of the type of the origin instance with the components adopted
+	 * from t.
+	 * 
+	 * <p>
+	 * This can be used for type continuety.
+	 * This way even while only using abstractions it is possible to create
+	 * new instances of the original. It is similar to the {@link #clone()}
+	 * function but the {@link #clone()} function requires the returned instance to be
+	 * writable.
+	 * This function on the other hand allows for example the usage of factories.
+	 * 
+	 * @param t The tuple to adopt the components from.
+	 * 
+	 * @return A new instance of the type of the origin instance
+	 */
+	default Tup2bR getNewInstance(Tup2bR t)
+	{
+		return getNewInstance(t.getX(), t.getY());
+	}
+	
+	/**
+	 * Returns a new instance of the type of the origin instance with the components set to
+	 * value.
+	 * 
+	 * <p>
+	 * This can be used for type continuety.
+	 * This way even while only using abstractions it is possible to create
+	 * new instances of the original. It is similar to the {@link #clone()}
+	 * function but the {@link #clone()} function requires the returned instance to be
+	 * writable.
+	 * This function on the other hand allows for example the usage of factories.
+	 * 
+	 * @param value The value used for all components.
+	 * 
+	 * @return A new instance of the type of the origin instance
+	 */
+	default Tup2bR getNewInstance(byte value)
+	{
+		return getNewInstance(value, value);
+	}
+	
+	/**
+	 * Returns a new instance of the type of the origin instance with the components set to
+	 * the corresponding parameters.
+	 * 
+	 * <p>
+	 * This can be used for type continuety.
+	 * This way even while only using abstractions it is possible to create
+	 * new instances of the original. It is similar to the {@link #clone()}
+	 * function but the {@link #clone()} function requires the returned instance to be
+	 * writable. This function on the other hand allows for example the usage of factories.
+	 * 
+	 * @param x The value used for the x component.
+	 * @param y The value used for the y component.
+	 * 
+	 * @return A new instance of the type of the origin instance
+	 */
+	Tup2bR getNewInstance(byte x, byte y);
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple2/Tup2bR.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple2/Tup2bR.java
@@ -105,8 +105,8 @@ public interface Tup2bR
 	 * <p>
 	 * This can be used for type continuety.
 	 * This way even while only using abstractions it is possible to create
-	 * new instances of the original. It is similar to the {@link #clone()}
-	 * function but the {@link #clone()} function requires the returned instance to be
+	 * new instances of the original. It is similar to the {@link Object#clone()}
+	 * function but the {@link Object#clone()} function requires the returned instance to be
 	 * writable.
 	 * This function on the other hand allows for example the usage of factories.
 	 * 
@@ -126,8 +126,8 @@ public interface Tup2bR
 	 * <p>
 	 * This can be used for type continuety.
 	 * This way even while only using abstractions it is possible to create
-	 * new instances of the original. It is similar to the {@link #clone()}
-	 * function but the {@link #clone()} function requires the returned instance to be
+	 * new instances of the original. It is similar to the {@link Object#clone()}
+	 * function but the {@link Object#clone()} function requires the returned instance to be
 	 * writable.
 	 * This function on the other hand allows for example the usage of factories.
 	 * 
@@ -147,8 +147,8 @@ public interface Tup2bR
 	 * <p>
 	 * This can be used for type continuety.
 	 * This way even while only using abstractions it is possible to create
-	 * new instances of the original. It is similar to the {@link #clone()}
-	 * function but the {@link #clone()} function requires the returned instance to be
+	 * new instances of the original. It is similar to the {@link Object#clone()}
+	 * function but the {@link Object#clone()} function requires the returned instance to be
 	 * writable. This function on the other hand allows for example the usage of factories.
 	 * 
 	 * @param x The value used for the x component.

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple2/Tup2bRW.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple2/Tup2bRW.java
@@ -45,4 +45,19 @@ public interface Tup2bRW extends Tup2bR, Tup2bW
 	
 	@Override
 	Tup2bRW set(byte x, byte y);
+	
+	@Override
+	default Tup2bRW getNewInstance(Tup2bR t)
+	{
+		return getNewInstance(t.getX(), t.getY());
+	}
+	
+	@Override
+	default Tup2bRW getNewInstance(byte value)
+	{
+		return getNewInstance(value, value);
+	}
+	
+	@Override
+	Tup2bRW getNewInstance(byte x, byte y);
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple2/Tup2bigdR.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple2/Tup2bigdR.java
@@ -111,8 +111,8 @@ public interface Tup2bigdR
 	 * <p>
 	 * This can be used for type continuety.
 	 * This way even while only using abstractions it is possible to create
-	 * new instances of the original. It is similar to the {@link #clone()}
-	 * function but the {@link #clone()} function requires the returned instance to be
+	 * new instances of the original. It is similar to the {@link Object#clone()}
+	 * function but the {@link Object#clone()} function requires the returned instance to be
 	 * writable.
 	 * This function on the other hand allows for example the usage of factories.
 	 * 
@@ -132,8 +132,8 @@ public interface Tup2bigdR
 	 * <p>
 	 * This can be used for type continuety.
 	 * This way even while only using abstractions it is possible to create
-	 * new instances of the original. It is similar to the {@link #clone()}
-	 * function but the {@link #clone()} function requires the returned instance to be
+	 * new instances of the original. It is similar to the {@link Object#clone()}
+	 * function but the {@link Object#clone()} function requires the returned instance to be
 	 * writable.
 	 * This function on the other hand allows for example the usage of factories.
 	 * 
@@ -153,8 +153,8 @@ public interface Tup2bigdR
 	 * <p>
 	 * This can be used for type continuety.
 	 * This way even while only using abstractions it is possible to create
-	 * new instances of the original. It is similar to the {@link #clone()}
-	 * function but the {@link #clone()} function requires the returned instance to be
+	 * new instances of the original. It is similar to the {@link Object#clone()}
+	 * function but the {@link Object#clone()} function requires the returned instance to be
 	 * writable. This function on the other hand allows for example the usage of factories.
 	 * 
 	 * @param x The value used for the x component.

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple2/Tup2bigdR.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple2/Tup2bigdR.java
@@ -103,4 +103,64 @@ public interface Tup2bigdR
 		return getX() != null &&
 				getY() != null;
 	}
+	
+	/**
+	 * Returns a new instance of the type of the origin instance with the components adopted
+	 * from t.
+	 * 
+	 * <p>
+	 * This can be used for type continuety.
+	 * This way even while only using abstractions it is possible to create
+	 * new instances of the original. It is similar to the {@link #clone()}
+	 * function but the {@link #clone()} function requires the returned instance to be
+	 * writable.
+	 * This function on the other hand allows for example the usage of factories.
+	 * 
+	 * @param t The tuple to adopt the components from.
+	 * 
+	 * @return A new instance of the type of the origin instance
+	 */
+	default Tup2bigdR getNewInstance(Tup2bigdR t)
+	{
+		return getNewInstance(t.getX(), t.getY());
+	}
+	
+	/**
+	 * Returns a new instance of the type of the origin instance with the components set to
+	 * value.
+	 * 
+	 * <p>
+	 * This can be used for type continuety.
+	 * This way even while only using abstractions it is possible to create
+	 * new instances of the original. It is similar to the {@link #clone()}
+	 * function but the {@link #clone()} function requires the returned instance to be
+	 * writable.
+	 * This function on the other hand allows for example the usage of factories.
+	 * 
+	 * @param value The value used for all components.
+	 * 
+	 * @return A new instance of the type of the origin instance
+	 */
+	default Tup2bigdR getNewInstance(BigDecimal value)
+	{
+		return getNewInstance(value, value);
+	}
+	
+	/**
+	 * Returns a new instance of the type of the origin instance with the components set to
+	 * the corresponding parameters.
+	 * 
+	 * <p>
+	 * This can be used for type continuety.
+	 * This way even while only using abstractions it is possible to create
+	 * new instances of the original. It is similar to the {@link #clone()}
+	 * function but the {@link #clone()} function requires the returned instance to be
+	 * writable. This function on the other hand allows for example the usage of factories.
+	 * 
+	 * @param x The value used for the x component.
+	 * @param y The value used for the y component.
+	 * 
+	 * @return A new instance of the type of the origin instance
+	 */
+	Tup2bigdR getNewInstance(BigDecimal x, BigDecimal y);
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple2/Tup2bigdRW.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple2/Tup2bigdRW.java
@@ -47,4 +47,19 @@ public interface Tup2bigdRW extends Tup2bigdR, Tup2bigdW
 	
 	@Override
 	Tup2bigdRW set(BigDecimal x, BigDecimal y);
+
+	@Override
+	default Tup2bigdRW getNewInstance(Tup2bigdR t)
+	{
+		return getNewInstance(t.getX(), t.getY());
+	}
+	
+	@Override
+	default Tup2bigdRW getNewInstance(BigDecimal value)
+	{
+		return getNewInstance(value, value);
+	}
+	
+	@Override
+	Tup2bigdRW getNewInstance(BigDecimal x, BigDecimal y);
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple2/Tup2bigiR.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple2/Tup2bigiR.java
@@ -111,8 +111,8 @@ public interface Tup2bigiR
 	 * <p>
 	 * This can be used for type continuety.
 	 * This way even while only using abstractions it is possible to create
-	 * new instances of the original. It is similar to the {@link #clone()}
-	 * function but the {@link #clone()} function requires the returned instance to be
+	 * new instances of the original. It is similar to the {@link Object#clone()}
+	 * function but the {@link Object#clone()} function requires the returned instance to be
 	 * writable.
 	 * This function on the other hand allows for example the usage of factories.
 	 * 
@@ -132,8 +132,8 @@ public interface Tup2bigiR
 	 * <p>
 	 * This can be used for type continuety.
 	 * This way even while only using abstractions it is possible to create
-	 * new instances of the original. It is similar to the {@link #clone()}
-	 * function but the {@link #clone()} function requires the returned instance to be
+	 * new instances of the original. It is similar to the {@link Object#clone()}
+	 * function but the {@link Object#clone()} function requires the returned instance to be
 	 * writable.
 	 * This function on the other hand allows for example the usage of factories.
 	 * 
@@ -153,8 +153,8 @@ public interface Tup2bigiR
 	 * <p>
 	 * This can be used for type continuety.
 	 * This way even while only using abstractions it is possible to create
-	 * new instances of the original. It is similar to the {@link #clone()}
-	 * function but the {@link #clone()} function requires the returned instance to be
+	 * new instances of the original. It is similar to the {@link Object#clone()}
+	 * function but the {@link Object#clone()} function requires the returned instance to be
 	 * writable. This function on the other hand allows for example the usage of factories.
 	 * 
 	 * @param x The value used for the x component.

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple2/Tup2bigiR.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple2/Tup2bigiR.java
@@ -103,4 +103,64 @@ public interface Tup2bigiR
 		return getX() != null &&
 				getY() != null;
 	}
+	
+	/**
+	 * Returns a new instance of the type of the origin instance with the components adopted
+	 * from t.
+	 * 
+	 * <p>
+	 * This can be used for type continuety.
+	 * This way even while only using abstractions it is possible to create
+	 * new instances of the original. It is similar to the {@link #clone()}
+	 * function but the {@link #clone()} function requires the returned instance to be
+	 * writable.
+	 * This function on the other hand allows for example the usage of factories.
+	 * 
+	 * @param t The tuple to adopt the components from.
+	 * 
+	 * @return A new instance of the type of the origin instance
+	 */
+	default Tup2bigiR getNewInstance(Tup2bigiR t)
+	{
+		return getNewInstance(t.getX(), t.getY());
+	}
+	
+	/**
+	 * Returns a new instance of the type of the origin instance with the components set to
+	 * value.
+	 * 
+	 * <p>
+	 * This can be used for type continuety.
+	 * This way even while only using abstractions it is possible to create
+	 * new instances of the original. It is similar to the {@link #clone()}
+	 * function but the {@link #clone()} function requires the returned instance to be
+	 * writable.
+	 * This function on the other hand allows for example the usage of factories.
+	 * 
+	 * @param value The value used for all components.
+	 * 
+	 * @return A new instance of the type of the origin instance
+	 */
+	default Tup2bigiR getNewInstance(BigInteger value)
+	{
+		return getNewInstance(value, value);
+	}
+	
+	/**
+	 * Returns a new instance of the type of the origin instance with the components set to
+	 * the corresponding parameters.
+	 * 
+	 * <p>
+	 * This can be used for type continuety.
+	 * This way even while only using abstractions it is possible to create
+	 * new instances of the original. It is similar to the {@link #clone()}
+	 * function but the {@link #clone()} function requires the returned instance to be
+	 * writable. This function on the other hand allows for example the usage of factories.
+	 * 
+	 * @param x The value used for the x component.
+	 * @param y The value used for the y component.
+	 * 
+	 * @return A new instance of the type of the origin instance
+	 */
+	Tup2bigiR getNewInstance(BigInteger x, BigInteger y);
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple2/Tup2bigiRW.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple2/Tup2bigiRW.java
@@ -47,4 +47,19 @@ public interface Tup2bigiRW extends Tup2bigiR, Tup2bigiW
 	
 	@Override
 	Tup2bigiRW set(BigInteger x, BigInteger y);
+	
+	@Override
+	default Tup2bigiRW getNewInstance(Tup2bigiR t)
+	{
+		return getNewInstance(t.getX(), t.getY());
+	}
+	
+	@Override
+	default Tup2bigiRW getNewInstance(BigInteger value)
+	{
+		return getNewInstance(value, value);
+	}
+	
+	@Override
+	Tup2bigiRW getNewInstance(BigInteger x, BigInteger y);
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple2/Tup2boR.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple2/Tup2boR.java
@@ -63,4 +63,64 @@ public interface Tup2boR
 	{
 		return true;
 	}
+	
+	/**
+	 * Returns a new instance of the type of the origin instance with the components adopted
+	 * from t.
+	 * 
+	 * <p>
+	 * This can be used for type continuety.
+	 * This way even while only using abstractions it is possible to create
+	 * new instances of the original. It is similar to the {@link #clone()}
+	 * function but the {@link #clone()} function requires the returned instance to be
+	 * writable.
+	 * This function on the other hand allows for example the usage of factories.
+	 * 
+	 * @param t The tuple to adopt the components from.
+	 * 
+	 * @return A new instance of the type of the origin instance
+	 */
+	default Tup2boR getNewInstance(Tup2boR t)
+	{
+		return getNewInstance(t.getX(), t.getY());
+	}
+	
+	/**
+	 * Returns a new instance of the type of the origin instance with the components set to
+	 * value.
+	 * 
+	 * <p>
+	 * This can be used for type continuety.
+	 * This way even while only using abstractions it is possible to create
+	 * new instances of the original. It is similar to the {@link #clone()}
+	 * function but the {@link #clone()} function requires the returned instance to be
+	 * writable.
+	 * This function on the other hand allows for example the usage of factories.
+	 * 
+	 * @param value The value used for all components.
+	 * 
+	 * @return A new instance of the type of the origin instance
+	 */
+	default Tup2boR getNewInstance(boolean value)
+	{
+		return getNewInstance(value, value);
+	}
+	
+	/**
+	 * Returns a new instance of the type of the origin instance with the components set to
+	 * the corresponding parameters.
+	 * 
+	 * <p>
+	 * This can be used for type continuety.
+	 * This way even while only using abstractions it is possible to create
+	 * new instances of the original. It is similar to the {@link #clone()}
+	 * function but the {@link #clone()} function requires the returned instance to be
+	 * writable. This function on the other hand allows for example the usage of factories.
+	 * 
+	 * @param x The value used for the x component.
+	 * @param y The value used for the y component.
+	 * 
+	 * @return A new instance of the type of the origin instance
+	 */
+	Tup2boR getNewInstance(boolean x, boolean y);
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple2/Tup2boR.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple2/Tup2boR.java
@@ -71,8 +71,8 @@ public interface Tup2boR
 	 * <p>
 	 * This can be used for type continuety.
 	 * This way even while only using abstractions it is possible to create
-	 * new instances of the original. It is similar to the {@link #clone()}
-	 * function but the {@link #clone()} function requires the returned instance to be
+	 * new instances of the original. It is similar to the {@link Object#clone()}
+	 * function but the {@link Object#clone()} function requires the returned instance to be
 	 * writable.
 	 * This function on the other hand allows for example the usage of factories.
 	 * 
@@ -92,8 +92,8 @@ public interface Tup2boR
 	 * <p>
 	 * This can be used for type continuety.
 	 * This way even while only using abstractions it is possible to create
-	 * new instances of the original. It is similar to the {@link #clone()}
-	 * function but the {@link #clone()} function requires the returned instance to be
+	 * new instances of the original. It is similar to the {@link Object#clone()}
+	 * function but the {@link Object#clone()} function requires the returned instance to be
 	 * writable.
 	 * This function on the other hand allows for example the usage of factories.
 	 * 
@@ -113,8 +113,8 @@ public interface Tup2boR
 	 * <p>
 	 * This can be used for type continuety.
 	 * This way even while only using abstractions it is possible to create
-	 * new instances of the original. It is similar to the {@link #clone()}
-	 * function but the {@link #clone()} function requires the returned instance to be
+	 * new instances of the original. It is similar to the {@link Object#clone()}
+	 * function but the {@link Object#clone()} function requires the returned instance to be
 	 * writable. This function on the other hand allows for example the usage of factories.
 	 * 
 	 * @param x The value used for the x component.

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple2/Tup2boRW.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple2/Tup2boRW.java
@@ -45,4 +45,19 @@ public interface Tup2boRW extends Tup2boR, Tup2boW
 	
 	@Override
 	Tup2boRW set(boolean x, boolean y);
+	
+	@Override
+	default Tup2boR getNewInstance(Tup2boR t)
+	{
+		return getNewInstance(t.getX(), t.getY());
+	}
+	
+	@Override
+	default Tup2boR getNewInstance(boolean value)
+	{
+		return getNewInstance(value, value);
+	}
+	
+	@Override
+	Tup2boR getNewInstance(boolean x, boolean y);
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple2/Tup2cR.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple2/Tup2cR.java
@@ -72,5 +72,65 @@ public interface Tup2cR
 	default boolean isValid()
 	{
 		return true;
-	}		
+	}
+	
+	/**
+	 * Returns a new instance of the type of the origin instance with the components adopted
+	 * from t.
+	 * 
+	 * <p>
+	 * This can be used for type continuety.
+	 * This way even while only using abstractions it is possible to create
+	 * new instances of the original. It is similar to the {@link #clone()}
+	 * function but the {@link #clone()} function requires the returned instance to be
+	 * writable.
+	 * This function on the other hand allows for example the usage of factories.
+	 * 
+	 * @param t The tuple to adopt the components from.
+	 * 
+	 * @return A new instance of the type of the origin instance
+	 */
+	default Tup2cR getNewInstance(Tup2cR t)
+	{
+		return getNewInstance(t.getX(), t.getY());
+	}
+	
+	/**
+	 * Returns a new instance of the type of the origin instance with the components set to
+	 * value.
+	 * 
+	 * <p>
+	 * This can be used for type continuety.
+	 * This way even while only using abstractions it is possible to create
+	 * new instances of the original. It is similar to the {@link #clone()}
+	 * function but the {@link #clone()} function requires the returned instance to be
+	 * writable.
+	 * This function on the other hand allows for example the usage of factories.
+	 * 
+	 * @param value The value used for all components.
+	 * 
+	 * @return A new instance of the type of the origin instance
+	 */
+	default Tup2cR getNewInstance(char value)
+	{
+		return getNewInstance(value, value);
+	}
+	
+	/**
+	 * Returns a new instance of the type of the origin instance with the components set to
+	 * the corresponding parameters.
+	 * 
+	 * <p>
+	 * This can be used for type continuety.
+	 * This way even while only using abstractions it is possible to create
+	 * new instances of the original. It is similar to the {@link #clone()}
+	 * function but the {@link #clone()} function requires the returned instance to be
+	 * writable. This function on the other hand allows for example the usage of factories.
+	 * 
+	 * @param x The value used for the x component.
+	 * @param y The value used for the y component.
+	 * 
+	 * @return A new instance of the type of the origin instance
+	 */
+	Tup2cR getNewInstance(char x, char y);
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple2/Tup2cR.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple2/Tup2cR.java
@@ -81,8 +81,8 @@ public interface Tup2cR
 	 * <p>
 	 * This can be used for type continuety.
 	 * This way even while only using abstractions it is possible to create
-	 * new instances of the original. It is similar to the {@link #clone()}
-	 * function but the {@link #clone()} function requires the returned instance to be
+	 * new instances of the original. It is similar to the {@link Object#clone()}
+	 * function but the {@link Object#clone()} function requires the returned instance to be
 	 * writable.
 	 * This function on the other hand allows for example the usage of factories.
 	 * 
@@ -102,8 +102,8 @@ public interface Tup2cR
 	 * <p>
 	 * This can be used for type continuety.
 	 * This way even while only using abstractions it is possible to create
-	 * new instances of the original. It is similar to the {@link #clone()}
-	 * function but the {@link #clone()} function requires the returned instance to be
+	 * new instances of the original. It is similar to the {@link Object#clone()}
+	 * function but the {@link Object#clone()} function requires the returned instance to be
 	 * writable.
 	 * This function on the other hand allows for example the usage of factories.
 	 * 
@@ -123,8 +123,8 @@ public interface Tup2cR
 	 * <p>
 	 * This can be used for type continuety.
 	 * This way even while only using abstractions it is possible to create
-	 * new instances of the original. It is similar to the {@link #clone()}
-	 * function but the {@link #clone()} function requires the returned instance to be
+	 * new instances of the original. It is similar to the {@link Object#clone()}
+	 * function but the {@link Object#clone()} function requires the returned instance to be
 	 * writable. This function on the other hand allows for example the usage of factories.
 	 * 
 	 * @param x The value used for the x component.

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple2/Tup2cRW.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple2/Tup2cRW.java
@@ -45,4 +45,19 @@ public interface Tup2cRW extends Tup2cR, Tup2cW
 	
 	@Override
 	Tup2cRW set(char x, char y);
+	
+	@Override
+	default Tup2cRW getNewInstance(Tup2cR t)
+	{
+		return getNewInstance(t.getX(), t.getY());
+	}
+	
+	@Override
+	default Tup2cRW getNewInstance(char value)
+	{
+		return getNewInstance(value, value);
+	}
+	
+	@Override
+	Tup2cRW getNewInstance(char x, char y);
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple2/Tup2dR.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple2/Tup2dR.java
@@ -106,8 +106,8 @@ public interface Tup2dR
 	 * <p>
 	 * This can be used for type continuety.
 	 * This way even while only using abstractions it is possible to create
-	 * new instances of the original. It is similar to the {@link #clone()}
-	 * function but the {@link #clone()} function requires the returned instance to be
+	 * new instances of the original. It is similar to the {@link Object#clone()}
+	 * function but the {@link Object#clone()} function requires the returned instance to be
 	 * writable.
 	 * This function on the other hand allows for example the usage of factories.
 	 * 
@@ -127,8 +127,8 @@ public interface Tup2dR
 	 * <p>
 	 * This can be used for type continuety.
 	 * This way even while only using abstractions it is possible to create
-	 * new instances of the original. It is similar to the {@link #clone()}
-	 * function but the {@link #clone()} function requires the returned instance to be
+	 * new instances of the original. It is similar to the {@link Object#clone()}
+	 * function but the {@link Object#clone()} function requires the returned instance to be
 	 * writable.
 	 * This function on the other hand allows for example the usage of factories.
 	 * 
@@ -148,8 +148,8 @@ public interface Tup2dR
 	 * <p>
 	 * This can be used for type continuety.
 	 * This way even while only using abstractions it is possible to create
-	 * new instances of the original. It is similar to the {@link #clone()}
-	 * function but the {@link #clone()} function requires the returned instance to be
+	 * new instances of the original. It is similar to the {@link Object#clone()}
+	 * function but the {@link Object#clone()} function requires the returned instance to be
 	 * writable. This function on the other hand allows for example the usage of factories.
 	 * 
 	 * @param x The value used for the x component.

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple2/Tup2dR.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple2/Tup2dR.java
@@ -98,4 +98,64 @@ public interface Tup2dR
 	{
 		return true;
 	}
+	
+	/**
+	 * Returns a new instance of the type of the origin instance with the components adopted
+	 * from t.
+	 * 
+	 * <p>
+	 * This can be used for type continuety.
+	 * This way even while only using abstractions it is possible to create
+	 * new instances of the original. It is similar to the {@link #clone()}
+	 * function but the {@link #clone()} function requires the returned instance to be
+	 * writable.
+	 * This function on the other hand allows for example the usage of factories.
+	 * 
+	 * @param t The tuple to adopt the components from.
+	 * 
+	 * @return A new instance of the type of the origin instance
+	 */
+	default Tup2dR getNewInstance(Tup2dR t)
+	{
+		return getNewInstance(t.getX(), t.getY());
+	}
+	
+	/**
+	 * Returns a new instance of the type of the origin instance with the components set to
+	 * value.
+	 * 
+	 * <p>
+	 * This can be used for type continuety.
+	 * This way even while only using abstractions it is possible to create
+	 * new instances of the original. It is similar to the {@link #clone()}
+	 * function but the {@link #clone()} function requires the returned instance to be
+	 * writable.
+	 * This function on the other hand allows for example the usage of factories.
+	 * 
+	 * @param value The value used for all components.
+	 * 
+	 * @return A new instance of the type of the origin instance
+	 */
+	default Tup2dR getNewInstance(double value)
+	{
+		return getNewInstance(value, value);
+	}
+	
+	/**
+	 * Returns a new instance of the type of the origin instance with the components set to
+	 * the corresponding parameters.
+	 * 
+	 * <p>
+	 * This can be used for type continuety.
+	 * This way even while only using abstractions it is possible to create
+	 * new instances of the original. It is similar to the {@link #clone()}
+	 * function but the {@link #clone()} function requires the returned instance to be
+	 * writable. This function on the other hand allows for example the usage of factories.
+	 * 
+	 * @param x The value used for the x component.
+	 * @param y The value used for the y component.
+	 * 
+	 * @return A new instance of the type of the origin instance
+	 */
+	Tup2dR getNewInstance(double x, double y);
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple2/Tup2dRW.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple2/Tup2dRW.java
@@ -45,4 +45,19 @@ public interface Tup2dRW extends Tup2dR, Tup2dW
 	
 	@Override
 	Tup2dRW set(double x, double y);
+	
+	@Override
+	default Tup2dRW getNewInstance(Tup2dR t)
+	{
+		return getNewInstance(t.getX(), t.getY());
+	}
+	
+	@Override
+	default Tup2dRW getNewInstance(double value)
+	{
+		return getNewInstance(value, value);
+	}
+	
+	@Override
+	Tup2dRW getNewInstance(double x, double y);
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple2/Tup2fR.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple2/Tup2fR.java
@@ -98,4 +98,64 @@ public interface Tup2fR
 	{
 		return true;
 	}
+	
+	/**
+	 * Returns a new instance of the type of the origin instance with the components adopted
+	 * from t.
+	 * 
+	 * <p>
+	 * This can be used for type continuety.
+	 * This way even while only using abstractions it is possible to create
+	 * new instances of the original. It is similar to the {@link #clone()}
+	 * function but the {@link #clone()} function requires the returned instance to be
+	 * writable.
+	 * This function on the other hand allows for example the usage of factories.
+	 * 
+	 * @param t The tuple to adopt the components from.
+	 * 
+	 * @return A new instance of the type of the origin instance
+	 */
+	default Tup2fR getNewInstance(Tup2fR t)
+	{
+		return getNewInstance(t.getX(), t.getY());
+	}
+	
+	/**
+	 * Returns a new instance of the type of the origin instance with the components set to
+	 * value.
+	 * 
+	 * <p>
+	 * This can be used for type continuety.
+	 * This way even while only using abstractions it is possible to create
+	 * new instances of the original. It is similar to the {@link #clone()}
+	 * function but the {@link #clone()} function requires the returned instance to be
+	 * writable.
+	 * This function on the other hand allows for example the usage of factories.
+	 * 
+	 * @param value The value used for all components.
+	 * 
+	 * @return A new instance of the type of the origin instance
+	 */
+	default Tup2fR getNewInstance(float value)
+	{
+		return getNewInstance(value, value);
+	}
+	
+	/**
+	 * Returns a new instance of the type of the origin instance with the components set to
+	 * the corresponding parameters.
+	 * 
+	 * <p>
+	 * This can be used for type continuety.
+	 * This way even while only using abstractions it is possible to create
+	 * new instances of the original. It is similar to the {@link #clone()}
+	 * function but the {@link #clone()} function requires the returned instance to be
+	 * writable. This function on the other hand allows for example the usage of factories.
+	 * 
+	 * @param x The value used for the x component.
+	 * @param y The value used for the y component.
+	 * 
+	 * @return A new instance of the type of the origin instance
+	 */
+	Tup2fR getNewInstance(float x, float y);
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple2/Tup2fR.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple2/Tup2fR.java
@@ -106,8 +106,8 @@ public interface Tup2fR
 	 * <p>
 	 * This can be used for type continuety.
 	 * This way even while only using abstractions it is possible to create
-	 * new instances of the original. It is similar to the {@link #clone()}
-	 * function but the {@link #clone()} function requires the returned instance to be
+	 * new instances of the original. It is similar to the {@link Object#clone()}
+	 * function but the {@link Object#clone()} function requires the returned instance to be
 	 * writable.
 	 * This function on the other hand allows for example the usage of factories.
 	 * 
@@ -127,8 +127,8 @@ public interface Tup2fR
 	 * <p>
 	 * This can be used for type continuety.
 	 * This way even while only using abstractions it is possible to create
-	 * new instances of the original. It is similar to the {@link #clone()}
-	 * function but the {@link #clone()} function requires the returned instance to be
+	 * new instances of the original. It is similar to the {@link Object#clone()}
+	 * function but the {@link Object#clone()} function requires the returned instance to be
 	 * writable.
 	 * This function on the other hand allows for example the usage of factories.
 	 * 
@@ -148,8 +148,8 @@ public interface Tup2fR
 	 * <p>
 	 * This can be used for type continuety.
 	 * This way even while only using abstractions it is possible to create
-	 * new instances of the original. It is similar to the {@link #clone()}
-	 * function but the {@link #clone()} function requires the returned instance to be
+	 * new instances of the original. It is similar to the {@link Object#clone()}
+	 * function but the {@link Object#clone()} function requires the returned instance to be
 	 * writable. This function on the other hand allows for example the usage of factories.
 	 * 
 	 * @param x The value used for the x component.

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple2/Tup2fRW.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple2/Tup2fRW.java
@@ -45,4 +45,19 @@ public interface Tup2fRW extends Tup2fR, Tup2fW
 	
 	@Override
 	Tup2fRW set(float x, float y);
+	
+	@Override
+	default Tup2fRW getNewInstance(Tup2fR t)
+	{
+		return getNewInstance(t.getX(), t.getY());
+	}
+	
+	@Override
+	default Tup2fRW getNewInstance(float value)
+	{
+		return getNewInstance(value, value);
+	}
+	
+	@Override
+	Tup2fRW getNewInstance(float x, float y);
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple2/Tup2iR.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple2/Tup2iR.java
@@ -97,4 +97,64 @@ public interface Tup2iR
 	{
 		return true;
 	}
+	
+	/**
+	 * Returns a new instance of the type of the origin instance with the components adopted
+	 * from t.
+	 * 
+	 * <p>
+	 * This can be used for type continuety.
+	 * This way even while only using abstractions it is possible to create
+	 * new instances of the original. It is similar to the {@link #clone()}
+	 * function but the {@link #clone()} function requires the returned instance to be
+	 * writable.
+	 * This function on the other hand allows for example the usage of factories.
+	 * 
+	 * @param t The tuple to adopt the components from.
+	 * 
+	 * @return A new instance of the type of the origin instance
+	 */
+	default Tup2iR getNewInstance(Tup2iR t)
+	{
+		return getNewInstance(t.getX(), t.getY());
+	}
+	
+	/**
+	 * Returns a new instance of the type of the origin instance with the components set to
+	 * value.
+	 * 
+	 * <p>
+	 * This can be used for type continuety.
+	 * This way even while only using abstractions it is possible to create
+	 * new instances of the original. It is similar to the {@link #clone()}
+	 * function but the {@link #clone()} function requires the returned instance to be
+	 * writable.
+	 * This function on the other hand allows for example the usage of factories.
+	 * 
+	 * @param value The value used for all components.
+	 * 
+	 * @return A new instance of the type of the origin instance
+	 */
+	default Tup2iR getNewInstance(int value)
+	{
+		return getNewInstance(value, value);
+	}
+	
+	/**
+	 * Returns a new instance of the type of the origin instance with the components set to
+	 * the corresponding parameters.
+	 * 
+	 * <p>
+	 * This can be used for type continuety.
+	 * This way even while only using abstractions it is possible to create
+	 * new instances of the original. It is similar to the {@link #clone()}
+	 * function but the {@link #clone()} function requires the returned instance to be
+	 * writable. This function on the other hand allows for example the usage of factories.
+	 * 
+	 * @param x The value used for the x component.
+	 * @param y The value used for the y component.
+	 * 
+	 * @return A new instance of the type of the origin instance
+	 */
+	Tup2iR getNewInstance(int x, int y);
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple2/Tup2iR.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple2/Tup2iR.java
@@ -105,8 +105,8 @@ public interface Tup2iR
 	 * <p>
 	 * This can be used for type continuety.
 	 * This way even while only using abstractions it is possible to create
-	 * new instances of the original. It is similar to the {@link #clone()}
-	 * function but the {@link #clone()} function requires the returned instance to be
+	 * new instances of the original. It is similar to the {@link Object#clone()}
+	 * function but the {@link Object#clone()} function requires the returned instance to be
 	 * writable.
 	 * This function on the other hand allows for example the usage of factories.
 	 * 
@@ -126,8 +126,8 @@ public interface Tup2iR
 	 * <p>
 	 * This can be used for type continuety.
 	 * This way even while only using abstractions it is possible to create
-	 * new instances of the original. It is similar to the {@link #clone()}
-	 * function but the {@link #clone()} function requires the returned instance to be
+	 * new instances of the original. It is similar to the {@link Object#clone()}
+	 * function but the {@link Object#clone()} function requires the returned instance to be
 	 * writable.
 	 * This function on the other hand allows for example the usage of factories.
 	 * 
@@ -147,8 +147,8 @@ public interface Tup2iR
 	 * <p>
 	 * This can be used for type continuety.
 	 * This way even while only using abstractions it is possible to create
-	 * new instances of the original. It is similar to the {@link #clone()}
-	 * function but the {@link #clone()} function requires the returned instance to be
+	 * new instances of the original. It is similar to the {@link Object#clone()}
+	 * function but the {@link Object#clone()} function requires the returned instance to be
 	 * writable. This function on the other hand allows for example the usage of factories.
 	 * 
 	 * @param x The value used for the x component.

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple2/Tup2iRW.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple2/Tup2iRW.java
@@ -45,4 +45,19 @@ public interface Tup2iRW extends Tup2iR, Tup2iW
 	
 	@Override
 	Tup2iRW set(int x, int y);
+	
+	@Override
+	default Tup2iRW getNewInstance(Tup2iR t)
+	{
+		return getNewInstance(t.getX(), t.getY());
+	}
+	
+	@Override
+	default Tup2iRW getNewInstance(int value)
+	{
+		return getNewInstance(value, value);
+	}
+	
+	@Override
+	Tup2iRW getNewInstance(int x, int y);
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple2/Tup2lR.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple2/Tup2lR.java
@@ -97,4 +97,64 @@ public interface Tup2lR
 	{
 		return true;
 	}
+	
+	/**
+	 * Returns a new instance of the type of the origin instance with the components adopted
+	 * from t.
+	 * 
+	 * <p>
+	 * This can be used for type continuety.
+	 * This way even while only using abstractions it is possible to create
+	 * new instances of the original. It is similar to the {@link #clone()}
+	 * function but the {@link #clone()} function requires the returned instance to be
+	 * writable.
+	 * This function on the other hand allows for example the usage of factories.
+	 * 
+	 * @param t The tuple to adopt the components from.
+	 * 
+	 * @return A new instance of the type of the origin instance
+	 */
+	default Tup2lR getNewInstance(Tup2lR t)
+	{
+		return getNewInstance(t.getX(), t.getY());
+	}
+	
+	/**
+	 * Returns a new instance of the type of the origin instance with the components set to
+	 * value.
+	 * 
+	 * <p>
+	 * This can be used for type continuety.
+	 * This way even while only using abstractions it is possible to create
+	 * new instances of the original. It is similar to the {@link #clone()}
+	 * function but the {@link #clone()} function requires the returned instance to be
+	 * writable.
+	 * This function on the other hand allows for example the usage of factories.
+	 * 
+	 * @param value The value used for all components.
+	 * 
+	 * @return A new instance of the type of the origin instance
+	 */
+	default Tup2lR getNewInstance(long value)
+	{
+		return getNewInstance(value, value);
+	}
+	
+	/**
+	 * Returns a new instance of the type of the origin instance with the components set to
+	 * the corresponding parameters.
+	 * 
+	 * <p>
+	 * This can be used for type continuety.
+	 * This way even while only using abstractions it is possible to create
+	 * new instances of the original. It is similar to the {@link #clone()}
+	 * function but the {@link #clone()} function requires the returned instance to be
+	 * writable. This function on the other hand allows for example the usage of factories.
+	 * 
+	 * @param x The value used for the x component.
+	 * @param y The value used for the y component.
+	 * 
+	 * @return A new instance of the type of the origin instance
+	 */
+	Tup2lR getNewInstance(long x, long y);
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple2/Tup2lR.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple2/Tup2lR.java
@@ -105,8 +105,8 @@ public interface Tup2lR
 	 * <p>
 	 * This can be used for type continuety.
 	 * This way even while only using abstractions it is possible to create
-	 * new instances of the original. It is similar to the {@link #clone()}
-	 * function but the {@link #clone()} function requires the returned instance to be
+	 * new instances of the original. It is similar to the {@link Object#clone()}
+	 * function but the {@link Object#clone()} function requires the returned instance to be
 	 * writable.
 	 * This function on the other hand allows for example the usage of factories.
 	 * 
@@ -126,8 +126,8 @@ public interface Tup2lR
 	 * <p>
 	 * This can be used for type continuety.
 	 * This way even while only using abstractions it is possible to create
-	 * new instances of the original. It is similar to the {@link #clone()}
-	 * function but the {@link #clone()} function requires the returned instance to be
+	 * new instances of the original. It is similar to the {@link Object#clone()}
+	 * function but the {@link Object#clone()} function requires the returned instance to be
 	 * writable.
 	 * This function on the other hand allows for example the usage of factories.
 	 * 
@@ -147,8 +147,8 @@ public interface Tup2lR
 	 * <p>
 	 * This can be used for type continuety.
 	 * This way even while only using abstractions it is possible to create
-	 * new instances of the original. It is similar to the {@link #clone()}
-	 * function but the {@link #clone()} function requires the returned instance to be
+	 * new instances of the original. It is similar to the {@link Object#clone()}
+	 * function but the {@link Object#clone()} function requires the returned instance to be
 	 * writable. This function on the other hand allows for example the usage of factories.
 	 * 
 	 * @param x The value used for the x component.

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple2/Tup2lRW.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple2/Tup2lRW.java
@@ -45,4 +45,19 @@ public interface Tup2lRW extends Tup2lR, Tup2lW
 	
 	@Override
 	Tup2lRW set(long x, long y);
+	
+	@Override
+	default Tup2lR getNewInstance(Tup2lR t)
+	{
+		return getNewInstance(t.getX(), t.getY());
+	}
+	
+	@Override
+	default Tup2lR getNewInstance(long value)
+	{
+		return getNewInstance(value, value);
+	}
+	
+	@Override
+	Tup2lR getNewInstance(long x, long y);
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple2/Tup2oR.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple2/Tup2oR.java
@@ -72,8 +72,8 @@ public interface Tup2oR<X,Y>
 	 * <p>
 	 * This can be used for type continuety.
 	 * This way even while only using abstractions it is possible to create
-	 * new instances of the original. It is similar to the {@link #clone()}
-	 * function but the {@link #clone()} function requires the returned instance to be
+	 * new instances of the original. It is similar to the {@link Object#clone()}
+	 * function but the {@link Object#clone()} function requires the returned instance to be
 	 * writable.
 	 * This function on the other hand allows for example the usage of factories.
 	 * 
@@ -93,8 +93,8 @@ public interface Tup2oR<X,Y>
 	 * <p>
 	 * This can be used for type continuety.
 	 * This way even while only using abstractions it is possible to create
-	 * new instances of the original. It is similar to the {@link #clone()}
-	 * function but the {@link #clone()} function requires the returned instance to be
+	 * new instances of the original. It is similar to the {@link Object#clone()}
+	 * function but the {@link Object#clone()} function requires the returned instance to be
 	 * writable. This function on the other hand allows for example the usage of factories.
 	 * 
 	 * @param x The value used for the x component.

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple2/Tup2oR.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple2/Tup2oR.java
@@ -64,4 +64,43 @@ public interface Tup2oR<X,Y>
 		return getX() != null &&
 				getY() != null;
 	}
+	
+	/**
+	 * Returns a new instance of the type of the origin instance with the components adopted
+	 * from t.
+	 * 
+	 * <p>
+	 * This can be used for type continuety.
+	 * This way even while only using abstractions it is possible to create
+	 * new instances of the original. It is similar to the {@link #clone()}
+	 * function but the {@link #clone()} function requires the returned instance to be
+	 * writable.
+	 * This function on the other hand allows for example the usage of factories.
+	 * 
+	 * @param t The tuple to adopt the components from.
+	 * 
+	 * @return A new instance of the type of the origin instance
+	 */
+	default Tup2oR<X,Y> getNewInstance(Tup2oR<X,Y> t)
+	{
+		return getNewInstance(t.getX(), t.getY());
+	}
+	
+	/**
+	 * Returns a new instance of the type of the origin instance with the components set to
+	 * the corresponding parameters.
+	 * 
+	 * <p>
+	 * This can be used for type continuety.
+	 * This way even while only using abstractions it is possible to create
+	 * new instances of the original. It is similar to the {@link #clone()}
+	 * function but the {@link #clone()} function requires the returned instance to be
+	 * writable. This function on the other hand allows for example the usage of factories.
+	 * 
+	 * @param x The value used for the x component.
+	 * @param y The value used for the y component.
+	 * 
+	 * @return A new instance of the type of the origin instance
+	 */
+	Tup2oR<X,Y> getNewInstance(X x, Y y);
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple2/Tup2oRW.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple2/Tup2oRW.java
@@ -42,4 +42,13 @@ public interface Tup2oRW<X,Y> extends Tup2oR<X,Y>, Tup2oW<X,Y>
 	
 	@Override
 	Tup2oRW<X,Y> set(X x, Y y);
+	
+	@Override
+	default Tup2oRW<X,Y> getNewInstance(Tup2oR<X,Y> t)
+	{
+		return getNewInstance(t.getX(), t.getY());
+	}
+	
+	@Override
+	Tup2oRW<X,Y> getNewInstance(X x, Y y);
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple2/Tup2objR.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple2/Tup2objR.java
@@ -64,4 +64,64 @@ public interface Tup2objR
 		return getX() != null &&
 				getY() != null;
 	}
+	
+	/**
+	 * Returns a new instance of the type of the origin instance with the components adopted
+	 * from t.
+	 * 
+	 * <p>
+	 * This can be used for type continuety.
+	 * This way even while only using abstractions it is possible to create
+	 * new instances of the original. It is similar to the {@link #clone()}
+	 * function but the {@link #clone()} function requires the returned instance to be
+	 * writable.
+	 * This function on the other hand allows for example the usage of factories.
+	 * 
+	 * @param t The tuple to adopt the components from.
+	 * 
+	 * @return A new instance of the type of the origin instance
+	 */
+	default Tup2objR getNewInstance(Tup2objR t)
+	{
+		return getNewInstance(t.getX(), t.getY());
+	}
+	
+	/**
+	 * Returns a new instance of the type of the origin instance with the components set to
+	 * value.
+	 * 
+	 * <p>
+	 * This can be used for type continuety.
+	 * This way even while only using abstractions it is possible to create
+	 * new instances of the original. It is similar to the {@link #clone()}
+	 * function but the {@link #clone()} function requires the returned instance to be
+	 * writable.
+	 * This function on the other hand allows for example the usage of factories.
+	 * 
+	 * @param value The value used for all components.
+	 * 
+	 * @return A new instance of the type of the origin instance
+	 */
+	default Tup2objR getNewInstance(Object value)
+	{
+		return getNewInstance(value, value);
+	}
+	
+	/**
+	 * Returns a new instance of the type of the origin instance with the components set to
+	 * the corresponding parameters.
+	 * 
+	 * <p>
+	 * This can be used for type continuety.
+	 * This way even while only using abstractions it is possible to create
+	 * new instances of the original. It is similar to the {@link #clone()}
+	 * function but the {@link #clone()} function requires the returned instance to be
+	 * writable. This function on the other hand allows for example the usage of factories.
+	 * 
+	 * @param x The value used for the x component.
+	 * @param y The value used for the y component.
+	 * 
+	 * @return A new instance of the type of the origin instance
+	 */
+	Tup2objR getNewInstance(Object x, Object y);
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple2/Tup2objR.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple2/Tup2objR.java
@@ -72,8 +72,8 @@ public interface Tup2objR
 	 * <p>
 	 * This can be used for type continuety.
 	 * This way even while only using abstractions it is possible to create
-	 * new instances of the original. It is similar to the {@link #clone()}
-	 * function but the {@link #clone()} function requires the returned instance to be
+	 * new instances of the original. It is similar to the {@link Object#clone()}
+	 * function but the {@link Object#clone()} function requires the returned instance to be
 	 * writable.
 	 * This function on the other hand allows for example the usage of factories.
 	 * 
@@ -93,8 +93,8 @@ public interface Tup2objR
 	 * <p>
 	 * This can be used for type continuety.
 	 * This way even while only using abstractions it is possible to create
-	 * new instances of the original. It is similar to the {@link #clone()}
-	 * function but the {@link #clone()} function requires the returned instance to be
+	 * new instances of the original. It is similar to the {@link Object#clone()}
+	 * function but the {@link Object#clone()} function requires the returned instance to be
 	 * writable.
 	 * This function on the other hand allows for example the usage of factories.
 	 * 
@@ -114,8 +114,8 @@ public interface Tup2objR
 	 * <p>
 	 * This can be used for type continuety.
 	 * This way even while only using abstractions it is possible to create
-	 * new instances of the original. It is similar to the {@link #clone()}
-	 * function but the {@link #clone()} function requires the returned instance to be
+	 * new instances of the original. It is similar to the {@link Object#clone()}
+	 * function but the {@link Object#clone()} function requires the returned instance to be
 	 * writable. This function on the other hand allows for example the usage of factories.
 	 * 
 	 * @param x The value used for the x component.

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple2/Tup2objRW.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple2/Tup2objRW.java
@@ -45,4 +45,19 @@ public interface Tup2objRW extends Tup2objR, Tup2objW
 	
 	@Override
 	Tup2objRW set(Object x, Object y);
+	
+	@Override
+	default Tup2objRW getNewInstance(Tup2objR t)
+	{
+		return getNewInstance(t.getX(), t.getY());
+	}
+	
+	@Override
+	default Tup2objRW getNewInstance(Object value)
+	{
+		return getNewInstance(value, value);
+	}
+	
+	@Override
+	Tup2objRW getNewInstance(Object x, Object y);
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple2/Tup2sR.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple2/Tup2sR.java
@@ -97,4 +97,64 @@ public interface Tup2sR
 	{
 		return true;
 	}
+	
+	/**
+	 * Returns a new instance of the type of the origin instance with the components adopted
+	 * from t.
+	 * 
+	 * <p>
+	 * This can be used for type continuety.
+	 * This way even while only using abstractions it is possible to create
+	 * new instances of the original. It is similar to the {@link #clone()}
+	 * function but the {@link #clone()} function requires the returned instance to be
+	 * writable.
+	 * This function on the other hand allows for example the usage of factories.
+	 * 
+	 * @param t The tuple to adopt the components from.
+	 * 
+	 * @return A new instance of the type of the origin instance
+	 */
+	default Tup2sR getNewInstance(Tup2sR t)
+	{
+		return getNewInstance(t.getX(), t.getY());
+	}
+	
+	/**
+	 * Returns a new instance of the type of the origin instance with the components set to
+	 * value.
+	 * 
+	 * <p>
+	 * This can be used for type continuety.
+	 * This way even while only using abstractions it is possible to create
+	 * new instances of the original. It is similar to the {@link #clone()}
+	 * function but the {@link #clone()} function requires the returned instance to be
+	 * writable.
+	 * This function on the other hand allows for example the usage of factories.
+	 * 
+	 * @param value The value used for all components.
+	 * 
+	 * @return A new instance of the type of the origin instance
+	 */
+	default Tup2sR getNewInstance(short value)
+	{
+		return getNewInstance(value, value);
+	}
+	
+	/**
+	 * Returns a new instance of the type of the origin instance with the components set to
+	 * the corresponding parameters.
+	 * 
+	 * <p>
+	 * This can be used for type continuety.
+	 * This way even while only using abstractions it is possible to create
+	 * new instances of the original. It is similar to the {@link #clone()}
+	 * function but the {@link #clone()} function requires the returned instance to be
+	 * writable. This function on the other hand allows for example the usage of factories.
+	 * 
+	 * @param x The value used for the x component.
+	 * @param y The value used for the y component.
+	 * 
+	 * @return A new instance of the type of the origin instance
+	 */
+	Tup2sR getNewInstance(short x, short y);
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple2/Tup2sR.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple2/Tup2sR.java
@@ -105,8 +105,8 @@ public interface Tup2sR
 	 * <p>
 	 * This can be used for type continuety.
 	 * This way even while only using abstractions it is possible to create
-	 * new instances of the original. It is similar to the {@link #clone()}
-	 * function but the {@link #clone()} function requires the returned instance to be
+	 * new instances of the original. It is similar to the {@link Object#clone()}
+	 * function but the {@link Object#clone()} function requires the returned instance to be
 	 * writable.
 	 * This function on the other hand allows for example the usage of factories.
 	 * 
@@ -126,8 +126,8 @@ public interface Tup2sR
 	 * <p>
 	 * This can be used for type continuety.
 	 * This way even while only using abstractions it is possible to create
-	 * new instances of the original. It is similar to the {@link #clone()}
-	 * function but the {@link #clone()} function requires the returned instance to be
+	 * new instances of the original. It is similar to the {@link Object#clone()}
+	 * function but the {@link Object#clone()} function requires the returned instance to be
 	 * writable.
 	 * This function on the other hand allows for example the usage of factories.
 	 * 
@@ -147,8 +147,8 @@ public interface Tup2sR
 	 * <p>
 	 * This can be used for type continuety.
 	 * This way even while only using abstractions it is possible to create
-	 * new instances of the original. It is similar to the {@link #clone()}
-	 * function but the {@link #clone()} function requires the returned instance to be
+	 * new instances of the original. It is similar to the {@link Object#clone()}
+	 * function but the {@link Object#clone()} function requires the returned instance to be
 	 * writable. This function on the other hand allows for example the usage of factories.
 	 * 
 	 * @param x The value used for the x component.

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple2/Tup2sRW.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple2/Tup2sRW.java
@@ -45,4 +45,19 @@ public interface Tup2sRW extends Tup2sR, Tup2sW
 	
 	@Override
 	Tup2sRW set(short x, short y);
+	
+	@Override
+	default Tup2sRW getNewInstance(Tup2sR t)
+	{
+		return getNewInstance(t.getX(), t.getY());
+	}
+	
+	@Override
+	default Tup2sRW getNewInstance(short value)
+	{
+		return getNewInstance(value, value);
+	}
+	
+	@Override
+	Tup2sRW getNewInstance(short x, short y);
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple2/Tup2strR.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple2/Tup2strR.java
@@ -64,4 +64,64 @@ public interface Tup2strR
 		return getX() != null &&
 				getY() != null;
 	}
+	
+	/**
+	 * Returns a new instance of the type of the origin instance with the components adopted
+	 * from t.
+	 * 
+	 * <p>
+	 * This can be used for type continuety.
+	 * This way even while only using abstractions it is possible to create
+	 * new instances of the original. It is similar to the {@link #clone()}
+	 * function but the {@link #clone()} function requires the returned instance to be
+	 * writable.
+	 * This function on the other hand allows for example the usage of factories.
+	 * 
+	 * @param t The tuple to adopt the components from.
+	 * 
+	 * @return A new instance of the type of the origin instance
+	 */
+	default Tup2strR getNewInstance(Tup2strR t)
+	{
+		return getNewInstance(t.getX(), t.getY());
+	}
+	
+	/**
+	 * Returns a new instance of the type of the origin instance with the components set to
+	 * value.
+	 * 
+	 * <p>
+	 * This can be used for type continuety.
+	 * This way even while only using abstractions it is possible to create
+	 * new instances of the original. It is similar to the {@link #clone()}
+	 * function but the {@link #clone()} function requires the returned instance to be
+	 * writable.
+	 * This function on the other hand allows for example the usage of factories.
+	 * 
+	 * @param value The value used for all components.
+	 * 
+	 * @return A new instance of the type of the origin instance
+	 */
+	default Tup2strR getNewInstance(String value)
+	{
+		return getNewInstance(value, value);
+	}
+	
+	/**
+	 * Returns a new instance of the type of the origin instance with the components set to
+	 * the corresponding parameters.
+	 * 
+	 * <p>
+	 * This can be used for type continuety.
+	 * This way even while only using abstractions it is possible to create
+	 * new instances of the original. It is similar to the {@link #clone()}
+	 * function but the {@link #clone()} function requires the returned instance to be
+	 * writable. This function on the other hand allows for example the usage of factories.
+	 * 
+	 * @param x The value used for the x component.
+	 * @param y The value used for the y component.
+	 * 
+	 * @return A new instance of the type of the origin instance
+	 */
+	Tup2strR getNewInstance(String x, String y);
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple2/Tup2strR.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple2/Tup2strR.java
@@ -72,8 +72,8 @@ public interface Tup2strR
 	 * <p>
 	 * This can be used for type continuety.
 	 * This way even while only using abstractions it is possible to create
-	 * new instances of the original. It is similar to the {@link #clone()}
-	 * function but the {@link #clone()} function requires the returned instance to be
+	 * new instances of the original. It is similar to the {@link Object#clone()}
+	 * function but the {@link Object#clone()} function requires the returned instance to be
 	 * writable.
 	 * This function on the other hand allows for example the usage of factories.
 	 * 
@@ -93,8 +93,8 @@ public interface Tup2strR
 	 * <p>
 	 * This can be used for type continuety.
 	 * This way even while only using abstractions it is possible to create
-	 * new instances of the original. It is similar to the {@link #clone()}
-	 * function but the {@link #clone()} function requires the returned instance to be
+	 * new instances of the original. It is similar to the {@link Object#clone()}
+	 * function but the {@link Object#clone()} function requires the returned instance to be
 	 * writable.
 	 * This function on the other hand allows for example the usage of factories.
 	 * 
@@ -114,8 +114,8 @@ public interface Tup2strR
 	 * <p>
 	 * This can be used for type continuety.
 	 * This way even while only using abstractions it is possible to create
-	 * new instances of the original. It is similar to the {@link #clone()}
-	 * function but the {@link #clone()} function requires the returned instance to be
+	 * new instances of the original. It is similar to the {@link Object#clone()}
+	 * function but the {@link Object#clone()} function requires the returned instance to be
 	 * writable. This function on the other hand allows for example the usage of factories.
 	 * 
 	 * @param x The value used for the x component.

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple2/Tup2strRW.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple2/Tup2strRW.java
@@ -45,4 +45,19 @@ public interface Tup2strRW extends Tup2strR, Tup2strW
 	
 	@Override
 	Tup2strRW set(String x, String y);
+	
+	@Override
+	default Tup2strRW getNewInstance(Tup2strR t)
+	{
+		return getNewInstance(t.getX(), t.getY());
+	}
+	
+	@Override
+	default Tup2strRW getNewInstance(String value)
+	{
+		return getNewInstance(value, value);
+	}
+	
+	@Override
+	Tup2strRW getNewInstance(String x, String y);
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple3/Tup3bR.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple3/Tup3bR.java
@@ -116,8 +116,8 @@ public interface Tup3bR
 	 * <p>
 	 * This can be used for type continuety.
 	 * This way even while only using abstractions it is possible to create
-	 * new instances of the original. It is similar to the {@link #clone()}
-	 * function but the {@link #clone()} function requires the returned instance to be
+	 * new instances of the original. It is similar to the {@link Object#clone()}
+	 * function but the {@link Object#clone()} function requires the returned instance to be
 	 * writable.
 	 * This function on the other hand allows for example the usage of factories.
 	 * 
@@ -137,8 +137,8 @@ public interface Tup3bR
 	 * <p>
 	 * This can be used for type continuety.
 	 * This way even while only using abstractions it is possible to create
-	 * new instances of the original. It is similar to the {@link #clone()}
-	 * function but the {@link #clone()} function requires the returned instance to be
+	 * new instances of the original. It is similar to the {@link Object#clone()}
+	 * function but the {@link Object#clone()} function requires the returned instance to be
 	 * writable.
 	 * This function on the other hand allows for example the usage of factories.
 	 * 
@@ -158,8 +158,8 @@ public interface Tup3bR
 	 * <p>
 	 * This can be used for type continuety.
 	 * This way even while only using abstractions it is possible to create
-	 * new instances of the original. It is similar to the {@link #clone()}
-	 * function but the {@link #clone()} function requires the returned instance to be
+	 * new instances of the original. It is similar to the {@link Object#clone()}
+	 * function but the {@link Object#clone()} function requires the returned instance to be
 	 * writable. This function on the other hand allows for example the usage of factories.
 	 * 
 	 * @param x The value used for the x component.

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple3/Tup3bR.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple3/Tup3bR.java
@@ -108,4 +108,65 @@ public interface Tup3bR
 	{
 		return true;
 	}
+	
+	/**
+	 * Returns a new instance of the type of the origin instance with the components adopted
+	 * from t.
+	 * 
+	 * <p>
+	 * This can be used for type continuety.
+	 * This way even while only using abstractions it is possible to create
+	 * new instances of the original. It is similar to the {@link #clone()}
+	 * function but the {@link #clone()} function requires the returned instance to be
+	 * writable.
+	 * This function on the other hand allows for example the usage of factories.
+	 * 
+	 * @param t The tuple to adopt the components from.
+	 * 
+	 * @return A new instance of the type of the origin instance
+	 */
+	default Tup3bR getNewInstance(Tup3bR t)
+	{
+		return getNewInstance(t.getX(), t.getY(), t.getZ());
+	}
+	
+	/**
+	 * Returns a new instance of the type of the origin instance with the components set to
+	 * value.
+	 * 
+	 * <p>
+	 * This can be used for type continuety.
+	 * This way even while only using abstractions it is possible to create
+	 * new instances of the original. It is similar to the {@link #clone()}
+	 * function but the {@link #clone()} function requires the returned instance to be
+	 * writable.
+	 * This function on the other hand allows for example the usage of factories.
+	 * 
+	 * @param value The value used for all components.
+	 * 
+	 * @return A new instance of the type of the origin instance
+	 */
+	default Tup3bR getNewInstance(byte value)
+	{
+		return getNewInstance(value, value, value);
+	}
+	
+	/**
+	 * Returns a new instance of the type of the origin instance with the components set to
+	 * the corresponding parameters.
+	 * 
+	 * <p>
+	 * This can be used for type continuety.
+	 * This way even while only using abstractions it is possible to create
+	 * new instances of the original. It is similar to the {@link #clone()}
+	 * function but the {@link #clone()} function requires the returned instance to be
+	 * writable. This function on the other hand allows for example the usage of factories.
+	 * 
+	 * @param x The value used for the x component.
+	 * @param y The value used for the y component.
+	 * @param z The value used for the z component.
+	 * 
+	 * @return A new instance of the type of the origin instance
+	 */
+	Tup3bR getNewInstance(byte x, byte y, byte z);
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple3/Tup3bRW.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple3/Tup3bRW.java
@@ -48,4 +48,19 @@ public interface Tup3bRW extends Tup3bR, Tup3bW
 	
 	@Override
 	Tup3bRW set(byte x, byte y, byte z);
+	
+	@Override
+	default Tup3bRW getNewInstance(Tup3bR t)
+	{
+		return getNewInstance(t.getX(), t.getY(), t.getZ());
+	}
+	
+	@Override
+	default Tup3bRW getNewInstance(byte value)
+	{
+		return getNewInstance(value, value, value);
+	}
+	
+	@Override
+	Tup3bRW getNewInstance(byte x, byte y, byte z);
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple3/Tup3bigdR.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple3/Tup3bigdR.java
@@ -123,8 +123,8 @@ public interface Tup3bigdR
 	 * <p>
 	 * This can be used for type continuety.
 	 * This way even while only using abstractions it is possible to create
-	 * new instances of the original. It is similar to the {@link #clone()}
-	 * function but the {@link #clone()} function requires the returned instance to be
+	 * new instances of the original. It is similar to the {@link Object#clone()}
+	 * function but the {@link Object#clone()} function requires the returned instance to be
 	 * writable.
 	 * This function on the other hand allows for example the usage of factories.
 	 * 
@@ -144,8 +144,8 @@ public interface Tup3bigdR
 	 * <p>
 	 * This can be used for type continuety.
 	 * This way even while only using abstractions it is possible to create
-	 * new instances of the original. It is similar to the {@link #clone()}
-	 * function but the {@link #clone()} function requires the returned instance to be
+	 * new instances of the original. It is similar to the {@link Object#clone()}
+	 * function but the {@link Object#clone()} function requires the returned instance to be
 	 * writable.
 	 * This function on the other hand allows for example the usage of factories.
 	 * 
@@ -165,8 +165,8 @@ public interface Tup3bigdR
 	 * <p>
 	 * This can be used for type continuety.
 	 * This way even while only using abstractions it is possible to create
-	 * new instances of the original. It is similar to the {@link #clone()}
-	 * function but the {@link #clone()} function requires the returned instance to be
+	 * new instances of the original. It is similar to the {@link Object#clone()}
+	 * function but the {@link Object#clone()} function requires the returned instance to be
 	 * writable. This function on the other hand allows for example the usage of factories.
 	 * 
 	 * @param x The value used for the x component.

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple3/Tup3bigdR.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple3/Tup3bigdR.java
@@ -115,4 +115,65 @@ public interface Tup3bigdR
 				getY() != null &&
 				getZ() != null;
 	}
+	
+	/**
+	 * Returns a new instance of the type of the origin instance with the components adopted
+	 * from t.
+	 * 
+	 * <p>
+	 * This can be used for type continuety.
+	 * This way even while only using abstractions it is possible to create
+	 * new instances of the original. It is similar to the {@link #clone()}
+	 * function but the {@link #clone()} function requires the returned instance to be
+	 * writable.
+	 * This function on the other hand allows for example the usage of factories.
+	 * 
+	 * @param t The tuple to adopt the components from.
+	 * 
+	 * @return A new instance of the type of the origin instance
+	 */
+	default Tup3bigdR getNewInstance(Tup3bigdR t)
+	{
+		return getNewInstance(t.getX(), t.getY(), t.getZ());
+	}
+	
+	/**
+	 * Returns a new instance of the type of the origin instance with the components set to
+	 * value.
+	 * 
+	 * <p>
+	 * This can be used for type continuety.
+	 * This way even while only using abstractions it is possible to create
+	 * new instances of the original. It is similar to the {@link #clone()}
+	 * function but the {@link #clone()} function requires the returned instance to be
+	 * writable.
+	 * This function on the other hand allows for example the usage of factories.
+	 * 
+	 * @param value The value used for all components.
+	 * 
+	 * @return A new instance of the type of the origin instance
+	 */
+	default Tup3bigdR getNewInstance(BigDecimal value)
+	{
+		return getNewInstance(value, value, value);
+	}
+	
+	/**
+	 * Returns a new instance of the type of the origin instance with the components set to
+	 * the corresponding parameters.
+	 * 
+	 * <p>
+	 * This can be used for type continuety.
+	 * This way even while only using abstractions it is possible to create
+	 * new instances of the original. It is similar to the {@link #clone()}
+	 * function but the {@link #clone()} function requires the returned instance to be
+	 * writable. This function on the other hand allows for example the usage of factories.
+	 * 
+	 * @param x The value used for the x component.
+	 * @param y The value used for the y component.
+	 * @param z The value used for the z component.
+	 * 
+	 * @return A new instance of the type of the origin instance
+	 */
+	Tup3bigdR getNewInstance(BigDecimal x, BigDecimal y, BigDecimal z);
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple3/Tup3bigdRW.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple3/Tup3bigdRW.java
@@ -50,4 +50,19 @@ public interface Tup3bigdRW extends Tup3bigdR, Tup3bigdW
 	
 	@Override
 	Tup3bigdRW set(BigDecimal x, BigDecimal y, BigDecimal z);
+	
+	@Override
+	default Tup3bigdRW getNewInstance(Tup3bigdR t)
+	{
+		return getNewInstance(t.getX(), t.getY(), t.getZ());
+	}
+	
+	@Override
+	default Tup3bigdRW getNewInstance(BigDecimal value)
+	{
+		return getNewInstance(value, value, value);
+	}
+	
+	@Override
+	Tup3bigdRW getNewInstance(BigDecimal x, BigDecimal y, BigDecimal z);
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple3/Tup3bigiR.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple3/Tup3bigiR.java
@@ -144,8 +144,8 @@ public interface Tup3bigiR
 	 * <p>
 	 * This can be used for type continuety.
 	 * This way even while only using abstractions it is possible to create
-	 * new instances of the original. It is similar to the {@link #clone()}
-	 * function but the {@link #clone()} function requires the returned instance to be
+	 * new instances of the original. It is similar to the {@link Object#clone()}
+	 * function but the {@link Object#clone()} function requires the returned instance to be
 	 * writable.
 	 * This function on the other hand allows for example the usage of factories.
 	 * 

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple3/Tup3bigiR.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple3/Tup3bigiR.java
@@ -115,4 +115,65 @@ public interface Tup3bigiR
 				getY() != null &&
 				getZ() != null;
 	}
+	
+	/**
+	 * Returns a new instance of the type of the origin instance with the components adopted
+	 * from t.
+	 * 
+	 * <p>
+	 * This can be used for type continuety.
+	 * This way even while only using abstractions it is possible to create
+	 * new instances of the original. It is similar to the {@link #clone()}
+	 * function but the {@link #clone()} function requires the returned instance to be
+	 * writable.
+	 * This function on the other hand allows for example the usage of factories.
+	 * 
+	 * @param t The tuple to adopt the components from.
+	 * 
+	 * @return A new instance of the type of the origin instance
+	 */
+	default Tup3bigiR getNewInstance(Tup3bigiR t)
+	{
+		return getNewInstance(t.getX(), t.getY(), t.getZ());
+	}
+	
+	/**
+	 * Returns a new instance of the type of the origin instance with the components set to
+	 * value.
+	 * 
+	 * <p>
+	 * This can be used for type continuety.
+	 * This way even while only using abstractions it is possible to create
+	 * new instances of the original. It is similar to the {@link #clone()}
+	 * function but the {@link #clone()} function requires the returned instance to be
+	 * writable.
+	 * This function on the other hand allows for example the usage of factories.
+	 * 
+	 * @param value The value used for all components.
+	 * 
+	 * @return A new instance of the type of the origin instance
+	 */
+	default Tup3bigiR getNewInstance(BigInteger value)
+	{
+		return getNewInstance(value, value, value);
+	}
+	
+	/**
+	 * Returns a new instance of the type of the origin instance with the components set to
+	 * the corresponding parameters.
+	 * 
+	 * <p>
+	 * This can be used for type continuety.
+	 * This way even while only using abstractions it is possible to create
+	 * new instances of the original. It is similar to the {@link #clone()}
+	 * function but the {@link #clone()} function requires the returned instance to be
+	 * writable. This function on the other hand allows for example the usage of factories.
+	 * 
+	 * @param x The value used for the x component.
+	 * @param y The value used for the y component.
+	 * @param z The value used for the z component.
+	 * 
+	 * @return A new instance of the type of the origin instance
+	 */
+	Tup3bigiR getNewInstance(BigInteger x, BigInteger y, BigInteger z);
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple3/Tup3bigiR.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple3/Tup3bigiR.java
@@ -123,8 +123,8 @@ public interface Tup3bigiR
 	 * <p>
 	 * This can be used for type continuety.
 	 * This way even while only using abstractions it is possible to create
-	 * new instances of the original. It is similar to the {@link #clone()}
-	 * function but the {@link #clone()} function requires the returned instance to be
+	 * new instances of the original. It is similar to the {@link Object#clone()}
+	 * function but the {@link Object#clone()} function requires the returned instance to be
 	 * writable.
 	 * This function on the other hand allows for example the usage of factories.
 	 * 
@@ -165,8 +165,8 @@ public interface Tup3bigiR
 	 * <p>
 	 * This can be used for type continuety.
 	 * This way even while only using abstractions it is possible to create
-	 * new instances of the original. It is similar to the {@link #clone()}
-	 * function but the {@link #clone()} function requires the returned instance to be
+	 * new instances of the original. It is similar to the {@link Object#clone()}
+	 * function but the {@link Object#clone()} function requires the returned instance to be
 	 * writable. This function on the other hand allows for example the usage of factories.
 	 * 
 	 * @param x The value used for the x component.

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple3/Tup3bigiRW.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple3/Tup3bigiRW.java
@@ -50,4 +50,19 @@ public interface Tup3bigiRW extends Tup3bigiR, Tup3bigiW
 	
 	@Override
 	Tup3bigiRW set(BigInteger x, BigInteger y, BigInteger z);
+	
+	@Override
+	default Tup3bigiRW getNewInstance(Tup3bigiR t)
+	{
+		return getNewInstance(t.getX(), t.getY(), t.getZ());
+	}
+	
+	@Override
+	default Tup3bigiRW getNewInstance(BigInteger value)
+	{
+		return getNewInstance(value, value, value);
+	}
+	
+	@Override
+	Tup3bigiRW getNewInstance(BigInteger x, BigInteger y, BigInteger z);
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple3/Tup3boR.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple3/Tup3boR.java
@@ -80,8 +80,8 @@ public interface Tup3boR
 	 * <p>
 	 * This can be used for type continuety.
 	 * This way even while only using abstractions it is possible to create
-	 * new instances of the original. It is similar to the {@link #clone()}
-	 * function but the {@link #clone()} function requires the returned instance to be
+	 * new instances of the original. It is similar to the {@link Object#clone()}
+	 * function but the {@link Object#clone()} function requires the returned instance to be
 	 * writable.
 	 * This function on the other hand allows for example the usage of factories.
 	 * 
@@ -101,8 +101,8 @@ public interface Tup3boR
 	 * <p>
 	 * This can be used for type continuety.
 	 * This way even while only using abstractions it is possible to create
-	 * new instances of the original. It is similar to the {@link #clone()}
-	 * function but the {@link #clone()} function requires the returned instance to be
+	 * new instances of the original. It is similar to the {@link Object#clone()}
+	 * function but the {@link Object#clone()} function requires the returned instance to be
 	 * writable.
 	 * This function on the other hand allows for example the usage of factories.
 	 * 
@@ -122,8 +122,8 @@ public interface Tup3boR
 	 * <p>
 	 * This can be used for type continuety.
 	 * This way even while only using abstractions it is possible to create
-	 * new instances of the original. It is similar to the {@link #clone()}
-	 * function but the {@link #clone()} function requires the returned instance to be
+	 * new instances of the original. It is similar to the {@link Object#clone()}
+	 * function but the {@link Object#clone()} function requires the returned instance to be
 	 * writable. This function on the other hand allows for example the usage of factories.
 	 * 
 	 * @param x The value used for the x component.

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple3/Tup3boR.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple3/Tup3boR.java
@@ -72,4 +72,65 @@ public interface Tup3boR
 	{
 		return true;
 	}
+	
+	/**
+	 * Returns a new instance of the type of the origin instance with the components adopted
+	 * from t.
+	 * 
+	 * <p>
+	 * This can be used for type continuety.
+	 * This way even while only using abstractions it is possible to create
+	 * new instances of the original. It is similar to the {@link #clone()}
+	 * function but the {@link #clone()} function requires the returned instance to be
+	 * writable.
+	 * This function on the other hand allows for example the usage of factories.
+	 * 
+	 * @param t The tuple to adopt the components from.
+	 * 
+	 * @return A new instance of the type of the origin instance
+	 */
+	default Tup3boR getNewInstance(Tup3boR t)
+	{
+		return getNewInstance(t.getX(), t.getY(), t.getZ());
+	}
+	
+	/**
+	 * Returns a new instance of the type of the origin instance with the components set to
+	 * value.
+	 * 
+	 * <p>
+	 * This can be used for type continuety.
+	 * This way even while only using abstractions it is possible to create
+	 * new instances of the original. It is similar to the {@link #clone()}
+	 * function but the {@link #clone()} function requires the returned instance to be
+	 * writable.
+	 * This function on the other hand allows for example the usage of factories.
+	 * 
+	 * @param value The value used for all components.
+	 * 
+	 * @return A new instance of the type of the origin instance
+	 */
+	default Tup3boR getNewInstance(boolean value)
+	{
+		return getNewInstance(value, value, value);
+	}
+	
+	/**
+	 * Returns a new instance of the type of the origin instance with the components set to
+	 * the corresponding parameters.
+	 * 
+	 * <p>
+	 * This can be used for type continuety.
+	 * This way even while only using abstractions it is possible to create
+	 * new instances of the original. It is similar to the {@link #clone()}
+	 * function but the {@link #clone()} function requires the returned instance to be
+	 * writable. This function on the other hand allows for example the usage of factories.
+	 * 
+	 * @param x The value used for the x component.
+	 * @param y The value used for the y component.
+	 * @param z The value used for the z component.
+	 * 
+	 * @return A new instance of the type of the origin instance
+	 */
+	Tup3boR getNewInstance(boolean x, boolean y, boolean z);
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple3/Tup3boRW.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple3/Tup3boRW.java
@@ -48,4 +48,19 @@ public interface Tup3boRW extends Tup3boR, Tup3boW
 	
 	@Override
 	Tup3boRW set(boolean x, boolean y, boolean z);
+	
+	@Override
+	default Tup3boRW getNewInstance(Tup3boR t)
+	{
+		return getNewInstance(t.getX(), t.getY(), t.getZ());
+	}
+	
+	@Override
+	default Tup3boRW getNewInstance(boolean value)
+	{
+		return getNewInstance(value, value, value);
+	}
+	
+	@Override
+	Tup3boRW getNewInstance(boolean x, boolean y, boolean z);
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple3/Tup3cR.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple3/Tup3cR.java
@@ -90,8 +90,8 @@ public interface Tup3cR
 	 * <p>
 	 * This can be used for type continuety.
 	 * This way even while only using abstractions it is possible to create
-	 * new instances of the original. It is similar to the {@link #clone()}
-	 * function but the {@link #clone()} function requires the returned instance to be
+	 * new instances of the original. It is similar to the {@link Object#clone()}
+	 * function but the {@link Object#clone()} function requires the returned instance to be
 	 * writable.
 	 * This function on the other hand allows for example the usage of factories.
 	 * 
@@ -111,8 +111,8 @@ public interface Tup3cR
 	 * <p>
 	 * This can be used for type continuety.
 	 * This way even while only using abstractions it is possible to create
-	 * new instances of the original. It is similar to the {@link #clone()}
-	 * function but the {@link #clone()} function requires the returned instance to be
+	 * new instances of the original. It is similar to the {@link Object#clone()}
+	 * function but the {@link Object#clone()} function requires the returned instance to be
 	 * writable.
 	 * This function on the other hand allows for example the usage of factories.
 	 * 
@@ -132,8 +132,8 @@ public interface Tup3cR
 	 * <p>
 	 * This can be used for type continuety.
 	 * This way even while only using abstractions it is possible to create
-	 * new instances of the original. It is similar to the {@link #clone()}
-	 * function but the {@link #clone()} function requires the returned instance to be
+	 * new instances of the original. It is similar to the {@link Object#clone()}
+	 * function but the {@link Object#clone()} function requires the returned instance to be
 	 * writable. This function on the other hand allows for example the usage of factories.
 	 * 
 	 * @param x The value used for the x component.

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple3/Tup3cR.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple3/Tup3cR.java
@@ -81,5 +81,66 @@ public interface Tup3cR
 	default boolean isValid()
 	{
 		return true;
-	}	
+	}
+	
+	/**
+	 * Returns a new instance of the type of the origin instance with the components adopted
+	 * from t.
+	 * 
+	 * <p>
+	 * This can be used for type continuety.
+	 * This way even while only using abstractions it is possible to create
+	 * new instances of the original. It is similar to the {@link #clone()}
+	 * function but the {@link #clone()} function requires the returned instance to be
+	 * writable.
+	 * This function on the other hand allows for example the usage of factories.
+	 * 
+	 * @param t The tuple to adopt the components from.
+	 * 
+	 * @return A new instance of the type of the origin instance
+	 */
+	default Tup3cR getNewInstance(Tup3cR t)
+	{
+		return getNewInstance(t.getX(), t.getY(), t.getZ());
+	}
+	
+	/**
+	 * Returns a new instance of the type of the origin instance with the components set to
+	 * value.
+	 * 
+	 * <p>
+	 * This can be used for type continuety.
+	 * This way even while only using abstractions it is possible to create
+	 * new instances of the original. It is similar to the {@link #clone()}
+	 * function but the {@link #clone()} function requires the returned instance to be
+	 * writable.
+	 * This function on the other hand allows for example the usage of factories.
+	 * 
+	 * @param value The value used for all components.
+	 * 
+	 * @return A new instance of the type of the origin instance
+	 */
+	default Tup3cR getNewInstance(char value)
+	{
+		return getNewInstance(value, value, value);
+	}
+	
+	/**
+	 * Returns a new instance of the type of the origin instance with the components set to
+	 * the corresponding parameters.
+	 * 
+	 * <p>
+	 * This can be used for type continuety.
+	 * This way even while only using abstractions it is possible to create
+	 * new instances of the original. It is similar to the {@link #clone()}
+	 * function but the {@link #clone()} function requires the returned instance to be
+	 * writable. This function on the other hand allows for example the usage of factories.
+	 * 
+	 * @param x The value used for the x component.
+	 * @param y The value used for the y component.
+	 * @param z The value used for the z component.
+	 * 
+	 * @return A new instance of the type of the origin instance
+	 */
+	Tup3cR getNewInstance(char x, char y, char z);
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple3/Tup3cRW.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple3/Tup3cRW.java
@@ -48,4 +48,19 @@ public interface Tup3cRW extends Tup3cR, Tup3cW
 	
 	@Override
 	Tup3cRW set(char x, char y, char z);
+	
+	@Override
+	default Tup3cRW getNewInstance(Tup3cR t)
+	{
+		return getNewInstance(t.getX(), t.getY(), t.getZ());
+	}
+	
+	@Override
+	default Tup3cRW getNewInstance(char value)
+	{
+		return getNewInstance(value, value, value);
+	}
+	
+	@Override
+	Tup3cRW getNewInstance(char x, char y, char z);
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple3/Tup3dR.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple3/Tup3dR.java
@@ -118,8 +118,8 @@ public interface Tup3dR
 	 * <p>
 	 * This can be used for type continuety.
 	 * This way even while only using abstractions it is possible to create
-	 * new instances of the original. It is similar to the {@link #clone()}
-	 * function but the {@link #clone()} function requires the returned instance to be
+	 * new instances of the original. It is similar to the {@link Object#clone()}
+	 * function but the {@link Object#clone()} function requires the returned instance to be
 	 * writable.
 	 * This function on the other hand allows for example the usage of factories.
 	 * 
@@ -139,8 +139,8 @@ public interface Tup3dR
 	 * <p>
 	 * This can be used for type continuety.
 	 * This way even while only using abstractions it is possible to create
-	 * new instances of the original. It is similar to the {@link #clone()}
-	 * function but the {@link #clone()} function requires the returned instance to be
+	 * new instances of the original. It is similar to the {@link Object#clone()}
+	 * function but the {@link Object#clone()} function requires the returned instance to be
 	 * writable.
 	 * This function on the other hand allows for example the usage of factories.
 	 * 
@@ -160,8 +160,8 @@ public interface Tup3dR
 	 * <p>
 	 * This can be used for type continuety.
 	 * This way even while only using abstractions it is possible to create
-	 * new instances of the original. It is similar to the {@link #clone()}
-	 * function but the {@link #clone()} function requires the returned instance to be
+	 * new instances of the original. It is similar to the {@link Object#clone()}
+	 * function but the {@link Object#clone()} function requires the returned instance to be
 	 * writable. This function on the other hand allows for example the usage of factories.
 	 * 
 	 * @param x The value used for the x component.

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple3/Tup3dR.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple3/Tup3dR.java
@@ -110,4 +110,65 @@ public interface Tup3dR
 	{
 		return true;
 	}
+	
+	/**
+	 * Returns a new instance of the type of the origin instance with the components adopted
+	 * from t.
+	 * 
+	 * <p>
+	 * This can be used for type continuety.
+	 * This way even while only using abstractions it is possible to create
+	 * new instances of the original. It is similar to the {@link #clone()}
+	 * function but the {@link #clone()} function requires the returned instance to be
+	 * writable.
+	 * This function on the other hand allows for example the usage of factories.
+	 * 
+	 * @param t The tuple to adopt the components from.
+	 * 
+	 * @return A new instance of the type of the origin instance
+	 */
+	default Tup3dR getNewInstance(Tup3dR t)
+	{
+		return getNewInstance(t.getX(), t.getY(), t.getZ());
+	}
+	
+	/**
+	 * Returns a new instance of the type of the origin instance with the components set to
+	 * value.
+	 * 
+	 * <p>
+	 * This can be used for type continuety.
+	 * This way even while only using abstractions it is possible to create
+	 * new instances of the original. It is similar to the {@link #clone()}
+	 * function but the {@link #clone()} function requires the returned instance to be
+	 * writable.
+	 * This function on the other hand allows for example the usage of factories.
+	 * 
+	 * @param value The value used for all components.
+	 * 
+	 * @return A new instance of the type of the origin instance
+	 */
+	default Tup3dR getNewInstance(double value)
+	{
+		return getNewInstance(value, value, value);
+	}
+	
+	/**
+	 * Returns a new instance of the type of the origin instance with the components set to
+	 * the corresponding parameters.
+	 * 
+	 * <p>
+	 * This can be used for type continuety.
+	 * This way even while only using abstractions it is possible to create
+	 * new instances of the original. It is similar to the {@link #clone()}
+	 * function but the {@link #clone()} function requires the returned instance to be
+	 * writable. This function on the other hand allows for example the usage of factories.
+	 * 
+	 * @param x The value used for the x component.
+	 * @param y The value used for the y component.
+	 * @param z The value used for the z component.
+	 * 
+	 * @return A new instance of the type of the origin instance
+	 */
+	Tup3dR getNewInstance(double x, double y, double z);
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple3/Tup3dRW.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple3/Tup3dRW.java
@@ -48,4 +48,19 @@ public interface Tup3dRW extends Tup3dR, Tup3dW
 	
 	@Override
 	Tup3dRW set(double x, double y, double z);
+	
+	@Override
+	default Tup3dRW getNewInstance(Tup3dR t)
+	{
+		return getNewInstance(t.getX(), t.getY(), t.getZ());
+	}
+	
+	@Override
+	default Tup3dRW getNewInstance(double value)
+	{
+		return getNewInstance(value, value, value);
+	}
+	
+	@Override
+	Tup3dRW getNewInstance(double x, double y, double z);
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple3/Tup3fR.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple3/Tup3fR.java
@@ -118,8 +118,8 @@ public interface Tup3fR
 	 * <p>
 	 * This can be used for type continuety.
 	 * This way even while only using abstractions it is possible to create
-	 * new instances of the original. It is similar to the {@link #clone()}
-	 * function but the {@link #clone()} function requires the returned instance to be
+	 * new instances of the original. It is similar to the {@link Object#clone()}
+	 * function but the {@link Object#clone()} function requires the returned instance to be
 	 * writable.
 	 * This function on the other hand allows for example the usage of factories.
 	 * 
@@ -139,8 +139,8 @@ public interface Tup3fR
 	 * <p>
 	 * This can be used for type continuety.
 	 * This way even while only using abstractions it is possible to create
-	 * new instances of the original. It is similar to the {@link #clone()}
-	 * function but the {@link #clone()} function requires the returned instance to be
+	 * new instances of the original. It is similar to the {@link Object#clone()}
+	 * function but the {@link Object#clone()} function requires the returned instance to be
 	 * writable.
 	 * This function on the other hand allows for example the usage of factories.
 	 * 
@@ -160,8 +160,8 @@ public interface Tup3fR
 	 * <p>
 	 * This can be used for type continuety.
 	 * This way even while only using abstractions it is possible to create
-	 * new instances of the original. It is similar to the {@link #clone()}
-	 * function but the {@link #clone()} function requires the returned instance to be
+	 * new instances of the original. It is similar to the {@link Object#clone()}
+	 * function but the {@link Object#clone()} function requires the returned instance to be
 	 * writable. This function on the other hand allows for example the usage of factories.
 	 * 
 	 * @param x The value used for the x component.

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple3/Tup3fR.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple3/Tup3fR.java
@@ -110,4 +110,65 @@ public interface Tup3fR
 	{
 		return true;
 	}
+	
+	/**
+	 * Returns a new instance of the type of the origin instance with the components adopted
+	 * from t.
+	 * 
+	 * <p>
+	 * This can be used for type continuety.
+	 * This way even while only using abstractions it is possible to create
+	 * new instances of the original. It is similar to the {@link #clone()}
+	 * function but the {@link #clone()} function requires the returned instance to be
+	 * writable.
+	 * This function on the other hand allows for example the usage of factories.
+	 * 
+	 * @param t The tuple to adopt the components from.
+	 * 
+	 * @return A new instance of the type of the origin instance
+	 */
+	default Tup3fR getNewInstance(Tup3fR t)
+	{
+		return getNewInstance(t.getX(), t.getY(), t.getZ());
+	}
+	
+	/**
+	 * Returns a new instance of the type of the origin instance with the components set to
+	 * value.
+	 * 
+	 * <p>
+	 * This can be used for type continuety.
+	 * This way even while only using abstractions it is possible to create
+	 * new instances of the original. It is similar to the {@link #clone()}
+	 * function but the {@link #clone()} function requires the returned instance to be
+	 * writable.
+	 * This function on the other hand allows for example the usage of factories.
+	 * 
+	 * @param value The value used for all components.
+	 * 
+	 * @return A new instance of the type of the origin instance
+	 */
+	default Tup3fR getNewInstance(float value)
+	{
+		return getNewInstance(value, value, value);
+	}
+	
+	/**
+	 * Returns a new instance of the type of the origin instance with the components set to
+	 * the corresponding parameters.
+	 * 
+	 * <p>
+	 * This can be used for type continuety.
+	 * This way even while only using abstractions it is possible to create
+	 * new instances of the original. It is similar to the {@link #clone()}
+	 * function but the {@link #clone()} function requires the returned instance to be
+	 * writable. This function on the other hand allows for example the usage of factories.
+	 * 
+	 * @param x The value used for the x component.
+	 * @param y The value used for the y component.
+	 * @param z The value used for the z component.
+	 * 
+	 * @return A new instance of the type of the origin instance
+	 */
+	Tup3fR getNewInstance(float x, float y, float z);
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple3/Tup3fRW.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple3/Tup3fRW.java
@@ -48,4 +48,19 @@ public interface Tup3fRW extends Tup3fR, Tup3fW
 	
 	@Override
 	Tup3fRW set(float x, float y, float z);
+	
+	@Override
+	default Tup3fRW getNewInstance(Tup3fR t)
+	{
+		return getNewInstance(t.getX(), t.getY(), t.getZ());
+	}
+	
+	@Override
+	default Tup3fRW getNewInstance(float value)
+	{
+		return getNewInstance(value, value, value);
+	}
+	
+	@Override
+	Tup3fRW getNewInstance(float x, float y, float z);
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple3/Tup3iR.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple3/Tup3iR.java
@@ -116,8 +116,8 @@ public interface Tup3iR
 	 * <p>
 	 * This can be used for type continuety.
 	 * This way even while only using abstractions it is possible to create
-	 * new instances of the original. It is similar to the {@link #clone()}
-	 * function but the {@link #clone()} function requires the returned instance to be
+	 * new instances of the original. It is similar to the {@link Object#clone()}
+	 * function but the {@link Object#clone()} function requires the returned instance to be
 	 * writable.
 	 * This function on the other hand allows for example the usage of factories.
 	 * 
@@ -137,8 +137,8 @@ public interface Tup3iR
 	 * <p>
 	 * This can be used for type continuety.
 	 * This way even while only using abstractions it is possible to create
-	 * new instances of the original. It is similar to the {@link #clone()}
-	 * function but the {@link #clone()} function requires the returned instance to be
+	 * new instances of the original. It is similar to the {@link Object#clone()}
+	 * function but the {@link Object#clone()} function requires the returned instance to be
 	 * writable.
 	 * This function on the other hand allows for example the usage of factories.
 	 * 
@@ -158,8 +158,8 @@ public interface Tup3iR
 	 * <p>
 	 * This can be used for type continuety.
 	 * This way even while only using abstractions it is possible to create
-	 * new instances of the original. It is similar to the {@link #clone()}
-	 * function but the {@link #clone()} function requires the returned instance to be
+	 * new instances of the original. It is similar to the {@link Object#clone()}
+	 * function but the {@link Object#clone()} function requires the returned instance to be
 	 * writable. This function on the other hand allows for example the usage of factories.
 	 * 
 	 * @param x The value used for the x component.

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple3/Tup3iR.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple3/Tup3iR.java
@@ -108,4 +108,65 @@ public interface Tup3iR
 	{
 		return true;
 	}
+	
+	/**
+	 * Returns a new instance of the type of the origin instance with the components adopted
+	 * from t.
+	 * 
+	 * <p>
+	 * This can be used for type continuety.
+	 * This way even while only using abstractions it is possible to create
+	 * new instances of the original. It is similar to the {@link #clone()}
+	 * function but the {@link #clone()} function requires the returned instance to be
+	 * writable.
+	 * This function on the other hand allows for example the usage of factories.
+	 * 
+	 * @param t The tuple to adopt the components from.
+	 * 
+	 * @return A new instance of the type of the origin instance
+	 */
+	default Tup3iR getNewInstance(Tup3iR t)
+	{
+		return getNewInstance(t.getX(), t.getY(), t.getZ());
+	}
+	
+	/**
+	 * Returns a new instance of the type of the origin instance with the components set to
+	 * value.
+	 * 
+	 * <p>
+	 * This can be used for type continuety.
+	 * This way even while only using abstractions it is possible to create
+	 * new instances of the original. It is similar to the {@link #clone()}
+	 * function but the {@link #clone()} function requires the returned instance to be
+	 * writable.
+	 * This function on the other hand allows for example the usage of factories.
+	 * 
+	 * @param value The value used for all components.
+	 * 
+	 * @return A new instance of the type of the origin instance
+	 */
+	default Tup3iR getNewInstance(int value)
+	{
+		return getNewInstance(value, value, value);
+	}
+	
+	/**
+	 * Returns a new instance of the type of the origin instance with the components set to
+	 * the corresponding parameters.
+	 * 
+	 * <p>
+	 * This can be used for type continuety.
+	 * This way even while only using abstractions it is possible to create
+	 * new instances of the original. It is similar to the {@link #clone()}
+	 * function but the {@link #clone()} function requires the returned instance to be
+	 * writable. This function on the other hand allows for example the usage of factories.
+	 * 
+	 * @param x The value used for the x component.
+	 * @param y The value used for the y component.
+	 * @param z The value used for the z component.
+	 * 
+	 * @return A new instance of the type of the origin instance
+	 */
+	Tup3iR getNewInstance(int x, int y, int z);
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple3/Tup3iRW.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple3/Tup3iRW.java
@@ -48,4 +48,19 @@ public interface Tup3iRW extends Tup3iR, Tup3iW
 	
 	@Override
 	Tup3iRW set(int x, int y, int z);
+	
+	@Override
+	default Tup3iRW getNewInstance(Tup3iR t)
+	{
+		return getNewInstance(t.getX(), t.getY(), t.getZ());
+	}
+	
+	@Override
+	default Tup3iRW getNewInstance(int value)
+	{
+		return getNewInstance(value, value, value);
+	}
+	
+	@Override
+	Tup3iRW getNewInstance(int x, int y, int z);
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple3/Tup3lR.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple3/Tup3lR.java
@@ -116,8 +116,8 @@ public interface Tup3lR
 	 * <p>
 	 * This can be used for type continuety.
 	 * This way even while only using abstractions it is possible to create
-	 * new instances of the original. It is similar to the {@link #clone()}
-	 * function but the {@link #clone()} function requires the returned instance to be
+	 * new instances of the original. It is similar to the {@link Object#clone()}
+	 * function but the {@link Object#clone()} function requires the returned instance to be
 	 * writable.
 	 * This function on the other hand allows for example the usage of factories.
 	 * 
@@ -137,8 +137,8 @@ public interface Tup3lR
 	 * <p>
 	 * This can be used for type continuety.
 	 * This way even while only using abstractions it is possible to create
-	 * new instances of the original. It is similar to the {@link #clone()}
-	 * function but the {@link #clone()} function requires the returned instance to be
+	 * new instances of the original. It is similar to the {@link Object#clone()}
+	 * function but the {@link Object#clone()} function requires the returned instance to be
 	 * writable.
 	 * This function on the other hand allows for example the usage of factories.
 	 * 
@@ -158,8 +158,8 @@ public interface Tup3lR
 	 * <p>
 	 * This can be used for type continuety.
 	 * This way even while only using abstractions it is possible to create
-	 * new instances of the original. It is similar to the {@link #clone()}
-	 * function but the {@link #clone()} function requires the returned instance to be
+	 * new instances of the original. It is similar to the {@link Object#clone()}
+	 * function but the {@link Object#clone()} function requires the returned instance to be
 	 * writable. This function on the other hand allows for example the usage of factories.
 	 * 
 	 * @param x The value used for the x component.

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple3/Tup3lR.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple3/Tup3lR.java
@@ -108,4 +108,65 @@ public interface Tup3lR
 	{
 		return true;
 	}
+	
+	/**
+	 * Returns a new instance of the type of the origin instance with the components adopted
+	 * from t.
+	 * 
+	 * <p>
+	 * This can be used for type continuety.
+	 * This way even while only using abstractions it is possible to create
+	 * new instances of the original. It is similar to the {@link #clone()}
+	 * function but the {@link #clone()} function requires the returned instance to be
+	 * writable.
+	 * This function on the other hand allows for example the usage of factories.
+	 * 
+	 * @param t The tuple to adopt the components from.
+	 * 
+	 * @return A new instance of the type of the origin instance
+	 */
+	default Tup3lR getNewInstance(Tup3lR t)
+	{
+		return getNewInstance(t.getX(), t.getY(), t.getZ());
+	}
+	
+	/**
+	 * Returns a new instance of the type of the origin instance with the components set to
+	 * value.
+	 * 
+	 * <p>
+	 * This can be used for type continuety.
+	 * This way even while only using abstractions it is possible to create
+	 * new instances of the original. It is similar to the {@link #clone()}
+	 * function but the {@link #clone()} function requires the returned instance to be
+	 * writable.
+	 * This function on the other hand allows for example the usage of factories.
+	 * 
+	 * @param value The value used for all components.
+	 * 
+	 * @return A new instance of the type of the origin instance
+	 */
+	default Tup3lR getNewInstance(long value)
+	{
+		return getNewInstance(value, value, value);
+	}
+	
+	/**
+	 * Returns a new instance of the type of the origin instance with the components set to
+	 * the corresponding parameters.
+	 * 
+	 * <p>
+	 * This can be used for type continuety.
+	 * This way even while only using abstractions it is possible to create
+	 * new instances of the original. It is similar to the {@link #clone()}
+	 * function but the {@link #clone()} function requires the returned instance to be
+	 * writable. This function on the other hand allows for example the usage of factories.
+	 * 
+	 * @param x The value used for the x component.
+	 * @param y The value used for the y component.
+	 * @param z The value used for the z component.
+	 * 
+	 * @return A new instance of the type of the origin instance
+	 */
+	Tup3lR getNewInstance(long x, long y, long z);
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple3/Tup3lRW.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple3/Tup3lRW.java
@@ -48,4 +48,19 @@ public interface Tup3lRW extends Tup3lR, Tup3lW
 	
 	@Override
 	Tup3lRW set(long x, long y, long z);
+	
+	@Override
+	default Tup3lRW getNewInstance(Tup3lR t)
+	{
+		return getNewInstance(t.getX(), t.getY(), t.getZ());
+	}
+	
+	@Override
+	default Tup3lRW getNewInstance(long value)
+	{
+		return getNewInstance(value, value, value);
+	}
+	
+	@Override
+	Tup3lRW getNewInstance(long x, long y, long z);
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple3/Tup3oR.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple3/Tup3oR.java
@@ -74,4 +74,44 @@ public interface Tup3oR<X,Y,Z>
 				getY() != null &&
 				getZ() != null;
 	}
+	
+	/**
+	 * Returns a new instance of the type of the origin instance with the components adopted
+	 * from t.
+	 * 
+	 * <p>
+	 * This can be used for type continuety.
+	 * This way even while only using abstractions it is possible to create
+	 * new instances of the original. It is similar to the {@link #clone()}
+	 * function but the {@link #clone()} function requires the returned instance to be
+	 * writable.
+	 * This function on the other hand allows for example the usage of factories.
+	 * 
+	 * @param t The tuple to adopt the components from.
+	 * 
+	 * @return A new instance of the type of the origin instance
+	 */
+	default Tup3oR<X,Y,Z> getNewInstance(Tup3oR<X,Y,Z> t)
+	{
+		return getNewInstance(t.getX(), t.getY(), t.getZ());
+	}
+	
+	/**
+	 * Returns a new instance of the type of the origin instance with the components set to
+	 * the corresponding parameters.
+	 * 
+	 * <p>
+	 * This can be used for type continuety.
+	 * This way even while only using abstractions it is possible to create
+	 * new instances of the original. It is similar to the {@link #clone()}
+	 * function but the {@link #clone()} function requires the returned instance to be
+	 * writable. This function on the other hand allows for example the usage of factories.
+	 * 
+	 * @param x The value used for the x component.
+	 * @param y The value used for the y component.
+	 * @param z The value used for the z component.
+	 * 
+	 * @return A new instance of the type of the origin instance
+	 */
+	Tup3oR<X,Y,Z> getNewInstance(X x, Y y, Z z);
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple3/Tup3oR.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple3/Tup3oR.java
@@ -82,8 +82,8 @@ public interface Tup3oR<X,Y,Z>
 	 * <p>
 	 * This can be used for type continuety.
 	 * This way even while only using abstractions it is possible to create
-	 * new instances of the original. It is similar to the {@link #clone()}
-	 * function but the {@link #clone()} function requires the returned instance to be
+	 * new instances of the original. It is similar to the {@link Object#clone()}
+	 * function but the {@link Object#clone()} function requires the returned instance to be
 	 * writable.
 	 * This function on the other hand allows for example the usage of factories.
 	 * 
@@ -103,8 +103,8 @@ public interface Tup3oR<X,Y,Z>
 	 * <p>
 	 * This can be used for type continuety.
 	 * This way even while only using abstractions it is possible to create
-	 * new instances of the original. It is similar to the {@link #clone()}
-	 * function but the {@link #clone()} function requires the returned instance to be
+	 * new instances of the original. It is similar to the {@link Object#clone()}
+	 * function but the {@link Object#clone()} function requires the returned instance to be
 	 * writable. This function on the other hand allows for example the usage of factories.
 	 * 
 	 * @param x The value used for the x component.

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple3/Tup3oRW.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple3/Tup3oRW.java
@@ -45,4 +45,13 @@ public interface Tup3oRW<X,Y,Z> extends Tup3oR<X,Y,Z>, Tup3oW<X,Y,Z>
 	
 	@Override
 	Tup3oRW<X,Y,Z> set(X x, Y y, Z z);
+	
+	@Override
+	default Tup3oRW<X,Y,Z> getNewInstance(Tup3oR<X,Y,Z> t)
+	{
+		return getNewInstance(t.getX(), t.getY(), t.getZ());
+	}
+	
+	@Override
+	Tup3oRW<X,Y,Z> getNewInstance(X x, Y y, Z z);
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple3/Tup3objR.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple3/Tup3objR.java
@@ -74,4 +74,65 @@ public interface Tup3objR
 				getY() != null &&
 				getZ() != null;
 	}
+	
+	/**
+	 * Returns a new instance of the type of the origin instance with the components adopted
+	 * from t.
+	 * 
+	 * <p>
+	 * This can be used for type continuety.
+	 * This way even while only using abstractions it is possible to create
+	 * new instances of the original. It is similar to the {@link #clone()}
+	 * function but the {@link #clone()} function requires the returned instance to be
+	 * writable.
+	 * This function on the other hand allows for example the usage of factories.
+	 * 
+	 * @param t The tuple to adopt the components from.
+	 * 
+	 * @return A new instance of the type of the origin instance
+	 */
+	default Tup3objR getNewInstance(Tup3objR t)
+	{
+		return getNewInstance(t.getX(), t.getY(), t.getZ());
+	}
+	
+	/**
+	 * Returns a new instance of the type of the origin instance with the components set to
+	 * value.
+	 * 
+	 * <p>
+	 * This can be used for type continuety.
+	 * This way even while only using abstractions it is possible to create
+	 * new instances of the original. It is similar to the {@link #clone()}
+	 * function but the {@link #clone()} function requires the returned instance to be
+	 * writable.
+	 * This function on the other hand allows for example the usage of factories.
+	 * 
+	 * @param value The value used for all components.
+	 * 
+	 * @return A new instance of the type of the origin instance
+	 */
+	default Tup3objR getNewInstance(Object value)
+	{
+		return getNewInstance(value, value, value);
+	}
+	
+	/**
+	 * Returns a new instance of the type of the origin instance with the components set to
+	 * the corresponding parameters.
+	 * 
+	 * <p>
+	 * This can be used for type continuety.
+	 * This way even while only using abstractions it is possible to create
+	 * new instances of the original. It is similar to the {@link #clone()}
+	 * function but the {@link #clone()} function requires the returned instance to be
+	 * writable. This function on the other hand allows for example the usage of factories.
+	 * 
+	 * @param x The value used for the x component.
+	 * @param y The value used for the y component.
+	 * @param z The value used for the z component.
+	 * 
+	 * @return A new instance of the type of the origin instance
+	 */
+	Tup3objR getNewInstance(Object x, Object y, Object z);
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple3/Tup3objR.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple3/Tup3objR.java
@@ -82,8 +82,8 @@ public interface Tup3objR
 	 * <p>
 	 * This can be used for type continuety.
 	 * This way even while only using abstractions it is possible to create
-	 * new instances of the original. It is similar to the {@link #clone()}
-	 * function but the {@link #clone()} function requires the returned instance to be
+	 * new instances of the original. It is similar to the {@link Object#clone()}
+	 * function but the {@link Object#clone()} function requires the returned instance to be
 	 * writable.
 	 * This function on the other hand allows for example the usage of factories.
 	 * 
@@ -103,8 +103,8 @@ public interface Tup3objR
 	 * <p>
 	 * This can be used for type continuety.
 	 * This way even while only using abstractions it is possible to create
-	 * new instances of the original. It is similar to the {@link #clone()}
-	 * function but the {@link #clone()} function requires the returned instance to be
+	 * new instances of the original. It is similar to the {@link Object#clone()}
+	 * function but the {@link Object#clone()} function requires the returned instance to be
 	 * writable.
 	 * This function on the other hand allows for example the usage of factories.
 	 * 
@@ -124,8 +124,8 @@ public interface Tup3objR
 	 * <p>
 	 * This can be used for type continuety.
 	 * This way even while only using abstractions it is possible to create
-	 * new instances of the original. It is similar to the {@link #clone()}
-	 * function but the {@link #clone()} function requires the returned instance to be
+	 * new instances of the original. It is similar to the {@link Object#clone()}
+	 * function but the {@link Object#clone()} function requires the returned instance to be
 	 * writable. This function on the other hand allows for example the usage of factories.
 	 * 
 	 * @param x The value used for the x component.

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple3/Tup3objRW.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple3/Tup3objRW.java
@@ -48,4 +48,19 @@ public interface Tup3objRW extends Tup3objR, Tup3objW
 	
 	@Override
 	Tup3objRW set(Object x, Object y, Object z);
+	
+	@Override
+	default Tup3objRW getNewInstance(Tup3objR t)
+	{
+		return getNewInstance(t.getX(), t.getY(), t.getZ());
+	}
+	
+	@Override
+	default Tup3objRW getNewInstance(Object value)
+	{
+		return getNewInstance(value, value, value);
+	}
+	
+	@Override
+	Tup3objRW getNewInstance(Object x, Object y, Object z);
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple3/Tup3sR.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple3/Tup3sR.java
@@ -116,8 +116,8 @@ public interface Tup3sR
 	 * <p>
 	 * This can be used for type continuety.
 	 * This way even while only using abstractions it is possible to create
-	 * new instances of the original. It is similar to the {@link #clone()}
-	 * function but the {@link #clone()} function requires the returned instance to be
+	 * new instances of the original. It is similar to the {@link Object#clone()}
+	 * function but the {@link Object#clone()} function requires the returned instance to be
 	 * writable.
 	 * This function on the other hand allows for example the usage of factories.
 	 * 
@@ -137,8 +137,8 @@ public interface Tup3sR
 	 * <p>
 	 * This can be used for type continuety.
 	 * This way even while only using abstractions it is possible to create
-	 * new instances of the original. It is similar to the {@link #clone()}
-	 * function but the {@link #clone()} function requires the returned instance to be
+	 * new instances of the original. It is similar to the {@link Object#clone()}
+	 * function but the {@link Object#clone()} function requires the returned instance to be
 	 * writable.
 	 * This function on the other hand allows for example the usage of factories.
 	 * 
@@ -158,8 +158,8 @@ public interface Tup3sR
 	 * <p>
 	 * This can be used for type continuety.
 	 * This way even while only using abstractions it is possible to create
-	 * new instances of the original. It is similar to the {@link #clone()}
-	 * function but the {@link #clone()} function requires the returned instance to be
+	 * new instances of the original. It is similar to the {@link Object#clone()}
+	 * function but the {@link Object#clone()} function requires the returned instance to be
 	 * writable. This function on the other hand allows for example the usage of factories.
 	 * 
 	 * @param x The value used for the x component.

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple3/Tup3sR.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple3/Tup3sR.java
@@ -108,4 +108,65 @@ public interface Tup3sR
 	{
 		return true;
 	}
+	
+	/**
+	 * Returns a new instance of the type of the origin instance with the components adopted
+	 * from t.
+	 * 
+	 * <p>
+	 * This can be used for type continuety.
+	 * This way even while only using abstractions it is possible to create
+	 * new instances of the original. It is similar to the {@link #clone()}
+	 * function but the {@link #clone()} function requires the returned instance to be
+	 * writable.
+	 * This function on the other hand allows for example the usage of factories.
+	 * 
+	 * @param t The tuple to adopt the components from.
+	 * 
+	 * @return A new instance of the type of the origin instance
+	 */
+	default Tup3sR getNewInstance(Tup3sR t)
+	{
+		return getNewInstance(t.getX(), t.getY(), t.getZ());
+	}
+	
+	/**
+	 * Returns a new instance of the type of the origin instance with the components set to
+	 * value.
+	 * 
+	 * <p>
+	 * This can be used for type continuety.
+	 * This way even while only using abstractions it is possible to create
+	 * new instances of the original. It is similar to the {@link #clone()}
+	 * function but the {@link #clone()} function requires the returned instance to be
+	 * writable.
+	 * This function on the other hand allows for example the usage of factories.
+	 * 
+	 * @param value The value used for all components.
+	 * 
+	 * @return A new instance of the type of the origin instance
+	 */
+	default Tup3sR getNewInstance(short value)
+	{
+		return getNewInstance(value, value, value);
+	}
+	
+	/**
+	 * Returns a new instance of the type of the origin instance with the components set to
+	 * the corresponding parameters.
+	 * 
+	 * <p>
+	 * This can be used for type continuety.
+	 * This way even while only using abstractions it is possible to create
+	 * new instances of the original. It is similar to the {@link #clone()}
+	 * function but the {@link #clone()} function requires the returned instance to be
+	 * writable. This function on the other hand allows for example the usage of factories.
+	 * 
+	 * @param x The value used for the x component.
+	 * @param y The value used for the y component.
+	 * @param z The value used for the z component.
+	 * 
+	 * @return A new instance of the type of the origin instance
+	 */
+	Tup3sR getNewInstance(short x, short y, short z);
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple3/Tup3sRW.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple3/Tup3sRW.java
@@ -48,4 +48,19 @@ public interface Tup3sRW extends Tup3sR, Tup3sW
 	
 	@Override
 	Tup3sRW set(short x, short y, short z);
+	
+	@Override
+	default Tup3sRW getNewInstance(Tup3sR t)
+	{
+		return getNewInstance(t.getX(), t.getY(), t.getZ());
+	}
+	
+	@Override
+	default Tup3sRW getNewInstance(short value)
+	{
+		return getNewInstance(value, value, value);
+	}
+	
+	@Override
+	Tup3sRW getNewInstance(short x, short y, short z);
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple3/Tup3strR.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple3/Tup3strR.java
@@ -74,4 +74,65 @@ public interface Tup3strR
 				getY() != null &&
 				getZ() != null;
 	}
+	
+	/**
+	 * Returns a new instance of the type of the origin instance with the components adopted
+	 * from t.
+	 * 
+	 * <p>
+	 * This can be used for type continuety.
+	 * This way even while only using abstractions it is possible to create
+	 * new instances of the original. It is similar to the {@link #clone()}
+	 * function but the {@link #clone()} function requires the returned instance to be
+	 * writable.
+	 * This function on the other hand allows for example the usage of factories.
+	 * 
+	 * @param t The tuple to adopt the components from.
+	 * 
+	 * @return A new instance of the type of the origin instance
+	 */
+	default Tup3strR getNewInstance(Tup3strR t)
+	{
+		return getNewInstance(t.getX(), t.getY(), t.getZ());
+	}
+	
+	/**
+	 * Returns a new instance of the type of the origin instance with the components set to
+	 * value.
+	 * 
+	 * <p>
+	 * This can be used for type continuety.
+	 * This way even while only using abstractions it is possible to create
+	 * new instances of the original. It is similar to the {@link #clone()}
+	 * function but the {@link #clone()} function requires the returned instance to be
+	 * writable.
+	 * This function on the other hand allows for example the usage of factories.
+	 * 
+	 * @param value The value used for all components.
+	 * 
+	 * @return A new instance of the type of the origin instance
+	 */
+	default Tup3strR getNewInstance(String value)
+	{
+		return getNewInstance(value, value, value);
+	}
+	
+	/**
+	 * Returns a new instance of the type of the origin instance with the components set to
+	 * the corresponding parameters.
+	 * 
+	 * <p>
+	 * This can be used for type continuety.
+	 * This way even while only using abstractions it is possible to create
+	 * new instances of the original. It is similar to the {@link #clone()}
+	 * function but the {@link #clone()} function requires the returned instance to be
+	 * writable. This function on the other hand allows for example the usage of factories.
+	 * 
+	 * @param x The value used for the x component.
+	 * @param y The value used for the y component.
+	 * @param z The value used for the z component.
+	 * 
+	 * @return A new instance of the type of the origin instance
+	 */
+	Tup3strR getNewInstance(String x, String y, String z);
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple3/Tup3strR.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple3/Tup3strR.java
@@ -82,8 +82,8 @@ public interface Tup3strR
 	 * <p>
 	 * This can be used for type continuety.
 	 * This way even while only using abstractions it is possible to create
-	 * new instances of the original. It is similar to the {@link #clone()}
-	 * function but the {@link #clone()} function requires the returned instance to be
+	 * new instances of the original. It is similar to the {@link Object#clone()}
+	 * function but the {@link Object#clone()} function requires the returned instance to be
 	 * writable.
 	 * This function on the other hand allows for example the usage of factories.
 	 * 
@@ -103,8 +103,8 @@ public interface Tup3strR
 	 * <p>
 	 * This can be used for type continuety.
 	 * This way even while only using abstractions it is possible to create
-	 * new instances of the original. It is similar to the {@link #clone()}
-	 * function but the {@link #clone()} function requires the returned instance to be
+	 * new instances of the original. It is similar to the {@link Object#clone()}
+	 * function but the {@link Object#clone()} function requires the returned instance to be
 	 * writable.
 	 * This function on the other hand allows for example the usage of factories.
 	 * 
@@ -124,8 +124,8 @@ public interface Tup3strR
 	 * <p>
 	 * This can be used for type continuety.
 	 * This way even while only using abstractions it is possible to create
-	 * new instances of the original. It is similar to the {@link #clone()}
-	 * function but the {@link #clone()} function requires the returned instance to be
+	 * new instances of the original. It is similar to the {@link Object#clone()}
+	 * function but the {@link Object#clone()} function requires the returned instance to be
 	 * writable. This function on the other hand allows for example the usage of factories.
 	 * 
 	 * @param x The value used for the x component.

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple3/Tup3strRW.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple3/Tup3strRW.java
@@ -48,4 +48,19 @@ public interface Tup3strRW extends Tup3strR, Tup3strW
 	
 	@Override
 	Tup3strRW set(String x, String y, String z);
+	
+	@Override
+	default Tup3strRW getNewInstance(Tup3strR t)
+	{
+		return getNewInstance(t.getX(), t.getY(), t.getZ());
+	}
+	
+	@Override
+	default Tup3strRW getNewInstance(String value)
+	{
+		return getNewInstance(value, value, value);
+	}
+	
+	@Override
+	Tup3strRW getNewInstance(String x, String y, String z);
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple4/Tup4bR.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple4/Tup4bR.java
@@ -119,4 +119,66 @@ public interface Tup4bR
 	{
 		return true;
 	}
+	
+	/**
+	 * Returns a new instance of the type of the origin instance with the components adopted
+	 * from t.
+	 * 
+	 * <p>
+	 * This can be used for type continuety.
+	 * This way even while only using abstractions it is possible to create
+	 * new instances of the original. It is similar to the {@link #clone()}
+	 * function but the {@link #clone()} function requires the returned instance to be
+	 * writable.
+	 * This function on the other hand allows for example the usage of factories.
+	 * 
+	 * @param t The tuple to adopt the components from.
+	 * 
+	 * @return A new instance of the type of the origin instance
+	 */
+	default Tup4bR getNewInstance(Tup4bR t)
+	{
+		return getNewInstance(t.getX(), t.getY(), t.getZ(), t.getW());
+	}
+	
+	/**
+	 * Returns a new instance of the type of the origin instance with the components set to
+	 * value.
+	 * 
+	 * <p>
+	 * This can be used for type continuety.
+	 * This way even while only using abstractions it is possible to create
+	 * new instances of the original. It is similar to the {@link #clone()}
+	 * function but the {@link #clone()} function requires the returned instance to be
+	 * writable.
+	 * This function on the other hand allows for example the usage of factories.
+	 * 
+	 * @param value The value used for all components.
+	 * 
+	 * @return A new instance of the type of the origin instance
+	 */
+	default Tup4bR getNewInstance(byte value)
+	{
+		return getNewInstance(value, value, value, value);
+	}
+	
+	/**
+	 * Returns a new instance of the type of the origin instance with the components set to
+	 * the corresponding parameters.
+	 * 
+	 * <p>
+	 * This can be used for type continuety.
+	 * This way even while only using abstractions it is possible to create
+	 * new instances of the original. It is similar to the {@link #clone()}
+	 * function but the {@link #clone()} function requires the returned instance to be
+	 * writable. This function on the other hand allows for example the usage of factories.
+	 * 
+	 * @param x The value used for the x component.
+	 * @param y The value used for the y component.
+	 * @param z The value used for the z component.
+	 * @param w The value used for the w component.
+	 * 
+	 * @return A new instance of the type of the origin instance
+	 */
+	Tup4bR getNewInstance(byte x, byte y, byte z, byte w);
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple4/Tup4bR.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple4/Tup4bR.java
@@ -127,8 +127,8 @@ public interface Tup4bR
 	 * <p>
 	 * This can be used for type continuety.
 	 * This way even while only using abstractions it is possible to create
-	 * new instances of the original. It is similar to the {@link #clone()}
-	 * function but the {@link #clone()} function requires the returned instance to be
+	 * new instances of the original. It is similar to the {@link Object#clone()}
+	 * function but the {@link Object#clone()} function requires the returned instance to be
 	 * writable.
 	 * This function on the other hand allows for example the usage of factories.
 	 * 
@@ -148,8 +148,8 @@ public interface Tup4bR
 	 * <p>
 	 * This can be used for type continuety.
 	 * This way even while only using abstractions it is possible to create
-	 * new instances of the original. It is similar to the {@link #clone()}
-	 * function but the {@link #clone()} function requires the returned instance to be
+	 * new instances of the original. It is similar to the {@link Object#clone()}
+	 * function but the {@link Object#clone()} function requires the returned instance to be
 	 * writable.
 	 * This function on the other hand allows for example the usage of factories.
 	 * 
@@ -169,8 +169,8 @@ public interface Tup4bR
 	 * <p>
 	 * This can be used for type continuety.
 	 * This way even while only using abstractions it is possible to create
-	 * new instances of the original. It is similar to the {@link #clone()}
-	 * function but the {@link #clone()} function requires the returned instance to be
+	 * new instances of the original. It is similar to the {@link Object#clone()}
+	 * function but the {@link Object#clone()} function requires the returned instance to be
 	 * writable. This function on the other hand allows for example the usage of factories.
 	 * 
 	 * @param x The value used for the x component.

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple4/Tup4bRW.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple4/Tup4bRW.java
@@ -51,4 +51,19 @@ public interface Tup4bRW extends Tup4bR, Tup4bW
 	
 	@Override
 	Tup4bRW set(byte x, byte y, byte z, byte w);
+	
+	@Override
+	default Tup4bRW getNewInstance(Tup4bR t)
+	{
+		return getNewInstance(t.getX(), t.getY(), t.getZ(), t.getW());
+	}
+	
+	@Override
+	default Tup4bRW getNewInstance(byte value)
+	{
+		return getNewInstance(value, value, value, value);
+	}
+	
+	@Override
+	Tup4bRW getNewInstance(byte x, byte y, byte z, byte w);
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple4/Tup4bigdR.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple4/Tup4bigdR.java
@@ -135,8 +135,8 @@ public interface Tup4bigdR
 	 * <p>
 	 * This can be used for type continuety.
 	 * This way even while only using abstractions it is possible to create
-	 * new instances of the original. It is similar to the {@link #clone()}
-	 * function but the {@link #clone()} function requires the returned instance to be
+	 * new instances of the original. It is similar to the {@link Object#clone()}
+	 * function but the {@link Object#clone()} function requires the returned instance to be
 	 * writable.
 	 * This function on the other hand allows for example the usage of factories.
 	 * 
@@ -156,8 +156,8 @@ public interface Tup4bigdR
 	 * <p>
 	 * This can be used for type continuety.
 	 * This way even while only using abstractions it is possible to create
-	 * new instances of the original. It is similar to the {@link #clone()}
-	 * function but the {@link #clone()} function requires the returned instance to be
+	 * new instances of the original. It is similar to the {@link Object#clone()}
+	 * function but the {@link Object#clone()} function requires the returned instance to be
 	 * writable.
 	 * This function on the other hand allows for example the usage of factories.
 	 * 
@@ -177,8 +177,8 @@ public interface Tup4bigdR
 	 * <p>
 	 * This can be used for type continuety.
 	 * This way even while only using abstractions it is possible to create
-	 * new instances of the original. It is similar to the {@link #clone()}
-	 * function but the {@link #clone()} function requires the returned instance to be
+	 * new instances of the original. It is similar to the {@link Object#clone()}
+	 * function but the {@link Object#clone()} function requires the returned instance to be
 	 * writable. This function on the other hand allows for example the usage of factories.
 	 * 
 	 * @param x The value used for the x component.

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple4/Tup4bigdR.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple4/Tup4bigdR.java
@@ -127,4 +127,66 @@ public interface Tup4bigdR
 				getZ() != null &&
 				getW() != null;
 	}
+	
+	/**
+	 * Returns a new instance of the type of the origin instance with the components adopted
+	 * from t.
+	 * 
+	 * <p>
+	 * This can be used for type continuety.
+	 * This way even while only using abstractions it is possible to create
+	 * new instances of the original. It is similar to the {@link #clone()}
+	 * function but the {@link #clone()} function requires the returned instance to be
+	 * writable.
+	 * This function on the other hand allows for example the usage of factories.
+	 * 
+	 * @param t The tuple to adopt the components from.
+	 * 
+	 * @return A new instance of the type of the origin instance
+	 */
+	default Tup4bigdR getNewInstance(Tup4bigdR t)
+	{
+		return getNewInstance(t.getX(), t.getY(), t.getZ(), t.getW());
+	}
+	
+	/**
+	 * Returns a new instance of the type of the origin instance with the components set to
+	 * value.
+	 * 
+	 * <p>
+	 * This can be used for type continuety.
+	 * This way even while only using abstractions it is possible to create
+	 * new instances of the original. It is similar to the {@link #clone()}
+	 * function but the {@link #clone()} function requires the returned instance to be
+	 * writable.
+	 * This function on the other hand allows for example the usage of factories.
+	 * 
+	 * @param value The value used for all components.
+	 * 
+	 * @return A new instance of the type of the origin instance
+	 */
+	default Tup4bigdR getNewInstance(BigDecimal value)
+	{
+		return getNewInstance(value, value, value, value);
+	}
+	
+	/**
+	 * Returns a new instance of the type of the origin instance with the components set to
+	 * the corresponding parameters.
+	 * 
+	 * <p>
+	 * This can be used for type continuety.
+	 * This way even while only using abstractions it is possible to create
+	 * new instances of the original. It is similar to the {@link #clone()}
+	 * function but the {@link #clone()} function requires the returned instance to be
+	 * writable. This function on the other hand allows for example the usage of factories.
+	 * 
+	 * @param x The value used for the x component.
+	 * @param y The value used for the y component.
+	 * @param z The value used for the z component.
+	 * @param w The value used for the w component.
+	 * 
+	 * @return A new instance of the type of the origin instance
+	 */
+	Tup4bigdR getNewInstance(BigDecimal x, BigDecimal y, BigDecimal z, BigDecimal w);
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple4/Tup4bigdRW.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple4/Tup4bigdRW.java
@@ -31,4 +31,19 @@ public interface Tup4bigdRW extends Tup4bigdR, Tup4bigdW
 	
 	@Override
 	Tup4bigdRW set(BigDecimal x, BigDecimal y, BigDecimal z, BigDecimal w);
+	
+	@Override
+	default Tup4bigdRW getNewInstance(Tup4bigdR t)
+	{
+		return getNewInstance(t.getX(), t.getY(), t.getZ(), t.getW());
+	}
+	
+	@Override
+	default Tup4bigdRW getNewInstance(BigDecimal value)
+	{
+		return getNewInstance(value, value, value, value);
+	}
+	
+	@Override
+	Tup4bigdRW getNewInstance(BigDecimal x, BigDecimal y, BigDecimal z, BigDecimal w);
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple4/Tup4bigiR.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple4/Tup4bigiR.java
@@ -127,4 +127,66 @@ public interface Tup4bigiR
 				getZ() != null &&
 				getW() != null;
 	}
+	
+	/**
+	 * Returns a new instance of the type of the origin instance with the components adopted
+	 * from t.
+	 * 
+	 * <p>
+	 * This can be used for type continuety.
+	 * This way even while only using abstractions it is possible to create
+	 * new instances of the original. It is similar to the {@link #clone()}
+	 * function but the {@link #clone()} function requires the returned instance to be
+	 * writable.
+	 * This function on the other hand allows for example the usage of factories.
+	 * 
+	 * @param t The tuple to adopt the components from.
+	 * 
+	 * @return A new instance of the type of the origin instance
+	 */
+	default Tup4bigiR getNewInstance(Tup4bigiR t)
+	{
+		return getNewInstance(t.getX(), t.getY(), t.getZ(), t.getW());
+	}
+	
+	/**
+	 * Returns a new instance of the type of the origin instance with the components set to
+	 * value.
+	 * 
+	 * <p>
+	 * This can be used for type continuety.
+	 * This way even while only using abstractions it is possible to create
+	 * new instances of the original. It is similar to the {@link #clone()}
+	 * function but the {@link #clone()} function requires the returned instance to be
+	 * writable.
+	 * This function on the other hand allows for example the usage of factories.
+	 * 
+	 * @param value The value used for all components.
+	 * 
+	 * @return A new instance of the type of the origin instance
+	 */
+	default Tup4bigiR getNewInstance(BigInteger value)
+	{
+		return getNewInstance(value, value, value, value);
+	}
+	
+	/**
+	 * Returns a new instance of the type of the origin instance with the components set to
+	 * the corresponding parameters.
+	 * 
+	 * <p>
+	 * This can be used for type continuety.
+	 * This way even while only using abstractions it is possible to create
+	 * new instances of the original. It is similar to the {@link #clone()}
+	 * function but the {@link #clone()} function requires the returned instance to be
+	 * writable. This function on the other hand allows for example the usage of factories.
+	 * 
+	 * @param x The value used for the x component.
+	 * @param y The value used for the y component.
+	 * @param z The value used for the z component.
+	 * @param w The value used for the w component.
+	 * 
+	 * @return A new instance of the type of the origin instance
+	 */
+	Tup4bigiR getNewInstance(BigInteger x, BigInteger y, BigInteger z, BigInteger w);
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple4/Tup4bigiR.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple4/Tup4bigiR.java
@@ -135,8 +135,8 @@ public interface Tup4bigiR
 	 * <p>
 	 * This can be used for type continuety.
 	 * This way even while only using abstractions it is possible to create
-	 * new instances of the original. It is similar to the {@link #clone()}
-	 * function but the {@link #clone()} function requires the returned instance to be
+	 * new instances of the original. It is similar to the {@link Object#clone()}
+	 * function but the {@link Object#clone()} function requires the returned instance to be
 	 * writable.
 	 * This function on the other hand allows for example the usage of factories.
 	 * 
@@ -156,8 +156,8 @@ public interface Tup4bigiR
 	 * <p>
 	 * This can be used for type continuety.
 	 * This way even while only using abstractions it is possible to create
-	 * new instances of the original. It is similar to the {@link #clone()}
-	 * function but the {@link #clone()} function requires the returned instance to be
+	 * new instances of the original. It is similar to the {@link Object#clone()}
+	 * function but the {@link Object#clone()} function requires the returned instance to be
 	 * writable.
 	 * This function on the other hand allows for example the usage of factories.
 	 * 
@@ -177,8 +177,8 @@ public interface Tup4bigiR
 	 * <p>
 	 * This can be used for type continuety.
 	 * This way even while only using abstractions it is possible to create
-	 * new instances of the original. It is similar to the {@link #clone()}
-	 * function but the {@link #clone()} function requires the returned instance to be
+	 * new instances of the original. It is similar to the {@link Object#clone()}
+	 * function but the {@link Object#clone()} function requires the returned instance to be
 	 * writable. This function on the other hand allows for example the usage of factories.
 	 * 
 	 * @param x The value used for the x component.

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple4/Tup4bigiRW.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple4/Tup4bigiRW.java
@@ -53,4 +53,19 @@ public interface Tup4bigiRW extends Tup4bigiR, Tup4bigiW
 	
 	@Override
 	Tup4bigiRW set(BigInteger x, BigInteger y, BigInteger z, BigInteger w);
+	
+	@Override
+	default Tup4bigiRW getNewInstance(Tup4bigiR t)
+	{
+		return getNewInstance(t.getX(), t.getY(), t.getZ(), t.getW());
+	}
+	
+	@Override
+	default Tup4bigiRW getNewInstance(BigInteger value)
+	{
+		return getNewInstance(value, value, value, value);
+	}
+	
+	@Override
+	Tup4bigiRW getNewInstance(BigInteger x, BigInteger y, BigInteger z, BigInteger w);
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple4/Tup4boR.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple4/Tup4boR.java
@@ -89,8 +89,8 @@ public interface Tup4boR
 	 * <p>
 	 * This can be used for type continuety.
 	 * This way even while only using abstractions it is possible to create
-	 * new instances of the original. It is similar to the {@link #clone()}
-	 * function but the {@link #clone()} function requires the returned instance to be
+	 * new instances of the original. It is similar to the {@link Object#clone()}
+	 * function but the {@link Object#clone()} function requires the returned instance to be
 	 * writable.
 	 * This function on the other hand allows for example the usage of factories.
 	 * 
@@ -110,8 +110,8 @@ public interface Tup4boR
 	 * <p>
 	 * This can be used for type continuety.
 	 * This way even while only using abstractions it is possible to create
-	 * new instances of the original. It is similar to the {@link #clone()}
-	 * function but the {@link #clone()} function requires the returned instance to be
+	 * new instances of the original. It is similar to the {@link Object#clone()}
+	 * function but the {@link Object#clone()} function requires the returned instance to be
 	 * writable.
 	 * This function on the other hand allows for example the usage of factories.
 	 * 
@@ -131,8 +131,8 @@ public interface Tup4boR
 	 * <p>
 	 * This can be used for type continuety.
 	 * This way even while only using abstractions it is possible to create
-	 * new instances of the original. It is similar to the {@link #clone()}
-	 * function but the {@link #clone()} function requires the returned instance to be
+	 * new instances of the original. It is similar to the {@link Object#clone()}
+	 * function but the {@link Object#clone()} function requires the returned instance to be
 	 * writable. This function on the other hand allows for example the usage of factories.
 	 * 
 	 * @param x The value used for the x component.

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple4/Tup4boR.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple4/Tup4boR.java
@@ -81,4 +81,66 @@ public interface Tup4boR
 	{
 		return true;
 	}
+	
+	/**
+	 * Returns a new instance of the type of the origin instance with the components adopted
+	 * from t.
+	 * 
+	 * <p>
+	 * This can be used for type continuety.
+	 * This way even while only using abstractions it is possible to create
+	 * new instances of the original. It is similar to the {@link #clone()}
+	 * function but the {@link #clone()} function requires the returned instance to be
+	 * writable.
+	 * This function on the other hand allows for example the usage of factories.
+	 * 
+	 * @param t The tuple to adopt the components from.
+	 * 
+	 * @return A new instance of the type of the origin instance
+	 */
+	default Tup4boR getNewInstance(Tup4boR t)
+	{
+		return getNewInstance(t.getX(), t.getY(), t.getZ(), t.getW());
+	}
+	
+	/**
+	 * Returns a new instance of the type of the origin instance with the components set to
+	 * value.
+	 * 
+	 * <p>
+	 * This can be used for type continuety.
+	 * This way even while only using abstractions it is possible to create
+	 * new instances of the original. It is similar to the {@link #clone()}
+	 * function but the {@link #clone()} function requires the returned instance to be
+	 * writable.
+	 * This function on the other hand allows for example the usage of factories.
+	 * 
+	 * @param value The value used for all components.
+	 * 
+	 * @return A new instance of the type of the origin instance
+	 */
+	default Tup4boR getNewInstance(boolean value)
+	{
+		return getNewInstance(value, value, value, value);
+	}
+	
+	/**
+	 * Returns a new instance of the type of the origin instance with the components set to
+	 * the corresponding parameters.
+	 * 
+	 * <p>
+	 * This can be used for type continuety.
+	 * This way even while only using abstractions it is possible to create
+	 * new instances of the original. It is similar to the {@link #clone()}
+	 * function but the {@link #clone()} function requires the returned instance to be
+	 * writable. This function on the other hand allows for example the usage of factories.
+	 * 
+	 * @param x The value used for the x component.
+	 * @param y The value used for the y component.
+	 * @param z The value used for the z component.
+	 * @param w The value used for the w component.
+	 * 
+	 * @return A new instance of the type of the origin instance
+	 */
+	Tup4boR getNewInstance(boolean x, boolean y, boolean z, boolean w);
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple4/Tup4boRW.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple4/Tup4boRW.java
@@ -51,4 +51,19 @@ public interface Tup4boRW extends Tup4boR, Tup4boW
 	
 	@Override
 	Tup4boRW set(boolean x, boolean y, boolean z, boolean w);
+	
+	@Override
+	default Tup4boRW getNewInstance(Tup4boR t)
+	{
+		return getNewInstance(t.getX(), t.getY(), t.getZ(), t.getW());
+	}
+	
+	@Override
+	default Tup4boRW getNewInstance(boolean value)
+	{
+		return getNewInstance(value, value, value, value);
+	}
+	
+	@Override
+	Tup4boRW getNewInstance(boolean x, boolean y, boolean z, boolean w);
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple4/Tup4cR.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple4/Tup4cR.java
@@ -90,5 +90,67 @@ public interface Tup4cR
 	default boolean isValid()
 	{
 		return true;
-	}	
+	}
+	
+	/**
+	 * Returns a new instance of the type of the origin instance with the components adopted
+	 * from t.
+	 * 
+	 * <p>
+	 * This can be used for type continuety.
+	 * This way even while only using abstractions it is possible to create
+	 * new instances of the original. It is similar to the {@link #clone()}
+	 * function but the {@link #clone()} function requires the returned instance to be
+	 * writable.
+	 * This function on the other hand allows for example the usage of factories.
+	 * 
+	 * @param t The tuple to adopt the components from.
+	 * 
+	 * @return A new instance of the type of the origin instance
+	 */
+	default Tup4cR getNewInstance(Tup4cR t)
+	{
+		return getNewInstance(t.getX(), t.getY(), t.getZ(), t.getW());
+	}
+	
+	/**
+	 * Returns a new instance of the type of the origin instance with the components set to
+	 * value.
+	 * 
+	 * <p>
+	 * This can be used for type continuety.
+	 * This way even while only using abstractions it is possible to create
+	 * new instances of the original. It is similar to the {@link #clone()}
+	 * function but the {@link #clone()} function requires the returned instance to be
+	 * writable.
+	 * This function on the other hand allows for example the usage of factories.
+	 * 
+	 * @param value The value used for all components.
+	 * 
+	 * @return A new instance of the type of the origin instance
+	 */
+	default Tup4cR getNewInstance(char value)
+	{
+		return getNewInstance(value, value, value, value);
+	}
+	
+	/**
+	 * Returns a new instance of the type of the origin instance with the components set to
+	 * the corresponding parameters.
+	 * 
+	 * <p>
+	 * This can be used for type continuety.
+	 * This way even while only using abstractions it is possible to create
+	 * new instances of the original. It is similar to the {@link #clone()}
+	 * function but the {@link #clone()} function requires the returned instance to be
+	 * writable. This function on the other hand allows for example the usage of factories.
+	 * 
+	 * @param x The value used for the x component.
+	 * @param y The value used for the y component.
+	 * @param z The value used for the z component.
+	 * @param w The value used for the w component.
+	 * 
+	 * @return A new instance of the type of the origin instance
+	 */
+	Tup4cR getNewInstance(char x, char y, char z, char w);
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple4/Tup4cR.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple4/Tup4cR.java
@@ -99,8 +99,8 @@ public interface Tup4cR
 	 * <p>
 	 * This can be used for type continuety.
 	 * This way even while only using abstractions it is possible to create
-	 * new instances of the original. It is similar to the {@link #clone()}
-	 * function but the {@link #clone()} function requires the returned instance to be
+	 * new instances of the original. It is similar to the {@link Object#clone()}
+	 * function but the {@link Object#clone()} function requires the returned instance to be
 	 * writable.
 	 * This function on the other hand allows for example the usage of factories.
 	 * 
@@ -120,8 +120,8 @@ public interface Tup4cR
 	 * <p>
 	 * This can be used for type continuety.
 	 * This way even while only using abstractions it is possible to create
-	 * new instances of the original. It is similar to the {@link #clone()}
-	 * function but the {@link #clone()} function requires the returned instance to be
+	 * new instances of the original. It is similar to the {@link Object#clone()}
+	 * function but the {@link Object#clone()} function requires the returned instance to be
 	 * writable.
 	 * This function on the other hand allows for example the usage of factories.
 	 * 
@@ -141,8 +141,8 @@ public interface Tup4cR
 	 * <p>
 	 * This can be used for type continuety.
 	 * This way even while only using abstractions it is possible to create
-	 * new instances of the original. It is similar to the {@link #clone()}
-	 * function but the {@link #clone()} function requires the returned instance to be
+	 * new instances of the original. It is similar to the {@link Object#clone()}
+	 * function but the {@link Object#clone()} function requires the returned instance to be
 	 * writable. This function on the other hand allows for example the usage of factories.
 	 * 
 	 * @param x The value used for the x component.

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple4/Tup4cRW.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple4/Tup4cRW.java
@@ -51,4 +51,19 @@ public interface Tup4cRW extends Tup4cR, Tup4cW
 	
 	@Override
 	Tup4cRW set(char x, char y, char z, char w);
+	
+	@Override
+	default Tup4cRW getNewInstance(Tup4cR t)
+	{
+		return getNewInstance(t.getX(), t.getY(), t.getZ(), t.getW());
+	}
+	
+	@Override
+	default Tup4cRW getNewInstance(char value)
+	{
+		return getNewInstance(value, value, value, value);
+	}
+	
+	@Override
+	Tup4cRW getNewInstance(char x, char y, char z, char w);
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple4/Tup4dR.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple4/Tup4dR.java
@@ -130,8 +130,8 @@ public interface Tup4dR
 	 * <p>
 	 * This can be used for type continuety.
 	 * This way even while only using abstractions it is possible to create
-	 * new instances of the original. It is similar to the {@link #clone()}
-	 * function but the {@link #clone()} function requires the returned instance to be
+	 * new instances of the original. It is similar to the {@link Object#clone()}
+	 * function but the {@link Object#clone()} function requires the returned instance to be
 	 * writable.
 	 * This function on the other hand allows for example the usage of factories.
 	 * 
@@ -151,8 +151,8 @@ public interface Tup4dR
 	 * <p>
 	 * This can be used for type continuety.
 	 * This way even while only using abstractions it is possible to create
-	 * new instances of the original. It is similar to the {@link #clone()}
-	 * function but the {@link #clone()} function requires the returned instance to be
+	 * new instances of the original. It is similar to the {@link Object#clone()}
+	 * function but the {@link Object#clone()} function requires the returned instance to be
 	 * writable.
 	 * This function on the other hand allows for example the usage of factories.
 	 * 
@@ -172,8 +172,8 @@ public interface Tup4dR
 	 * <p>
 	 * This can be used for type continuety.
 	 * This way even while only using abstractions it is possible to create
-	 * new instances of the original. It is similar to the {@link #clone()}
-	 * function but the {@link #clone()} function requires the returned instance to be
+	 * new instances of the original. It is similar to the {@link Object#clone()}
+	 * function but the {@link Object#clone()} function requires the returned instance to be
 	 * writable. This function on the other hand allows for example the usage of factories.
 	 * 
 	 * @param x The value used for the x component.

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple4/Tup4dR.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple4/Tup4dR.java
@@ -122,4 +122,66 @@ public interface Tup4dR
 	{
 		return true;
 	}
+	
+	/**
+	 * Returns a new instance of the type of the origin instance with the components adopted
+	 * from t.
+	 * 
+	 * <p>
+	 * This can be used for type continuety.
+	 * This way even while only using abstractions it is possible to create
+	 * new instances of the original. It is similar to the {@link #clone()}
+	 * function but the {@link #clone()} function requires the returned instance to be
+	 * writable.
+	 * This function on the other hand allows for example the usage of factories.
+	 * 
+	 * @param t The tuple to adopt the components from.
+	 * 
+	 * @return A new instance of the type of the origin instance
+	 */
+	default Tup4dR getNewInstance(Tup4dR t)
+	{
+		return getNewInstance(t.getX(), t.getY(), t.getZ(), t.getW());
+	}
+	
+	/**
+	 * Returns a new instance of the type of the origin instance with the components set to
+	 * value.
+	 * 
+	 * <p>
+	 * This can be used for type continuety.
+	 * This way even while only using abstractions it is possible to create
+	 * new instances of the original. It is similar to the {@link #clone()}
+	 * function but the {@link #clone()} function requires the returned instance to be
+	 * writable.
+	 * This function on the other hand allows for example the usage of factories.
+	 * 
+	 * @param value The value used for all components.
+	 * 
+	 * @return A new instance of the type of the origin instance
+	 */
+	default Tup4dR getNewInstance(double value)
+	{
+		return getNewInstance(value, value, value, value);
+	}
+	
+	/**
+	 * Returns a new instance of the type of the origin instance with the components set to
+	 * the corresponding parameters.
+	 * 
+	 * <p>
+	 * This can be used for type continuety.
+	 * This way even while only using abstractions it is possible to create
+	 * new instances of the original. It is similar to the {@link #clone()}
+	 * function but the {@link #clone()} function requires the returned instance to be
+	 * writable. This function on the other hand allows for example the usage of factories.
+	 * 
+	 * @param x The value used for the x component.
+	 * @param y The value used for the y component.
+	 * @param z The value used for the z component.
+	 * @param w The value used for the w component.
+	 * 
+	 * @return A new instance of the type of the origin instance
+	 */
+	Tup4dR getNewInstance(double x, double y, double z, double w);
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple4/Tup4dRW.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple4/Tup4dRW.java
@@ -51,4 +51,19 @@ public interface Tup4dRW extends Tup4dR, Tup4dW
 	
 	@Override
 	Tup4dRW set(double x, double y, double z, double w);
+	
+	@Override
+	default Tup4dRW getNewInstance(Tup4dR t)
+	{
+		return getNewInstance(t.getX(), t.getY(), t.getZ(), t.getW());
+	}
+	
+	@Override
+	default Tup4dRW getNewInstance(double value)
+	{
+		return getNewInstance(value, value, value, value);
+	}
+	
+	@Override
+	Tup4dRW getNewInstance(double x, double y, double z, double w);
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple4/Tup4fR.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple4/Tup4fR.java
@@ -122,4 +122,66 @@ public interface Tup4fR
 	{
 		return true;
 	}
+	
+	/**
+	 * Returns a new instance of the type of the origin instance with the components adopted
+	 * from t.
+	 * 
+	 * <p>
+	 * This can be used for type continuety.
+	 * This way even while only using abstractions it is possible to create
+	 * new instances of the original. It is similar to the {@link #clone()}
+	 * function but the {@link #clone()} function requires the returned instance to be
+	 * writable.
+	 * This function on the other hand allows for example the usage of factories.
+	 * 
+	 * @param t The tuple to adopt the components from.
+	 * 
+	 * @return A new instance of the type of the origin instance
+	 */
+	default Tup4fR getNewInstance(Tup4fR t)
+	{
+		return getNewInstance(t.getX(), t.getY(), t.getZ(), t.getW());
+	}
+	
+	/**
+	 * Returns a new instance of the type of the origin instance with the components set to
+	 * value.
+	 * 
+	 * <p>
+	 * This can be used for type continuety.
+	 * This way even while only using abstractions it is possible to create
+	 * new instances of the original. It is similar to the {@link #clone()}
+	 * function but the {@link #clone()} function requires the returned instance to be
+	 * writable.
+	 * This function on the other hand allows for example the usage of factories.
+	 * 
+	 * @param value The value used for all components.
+	 * 
+	 * @return A new instance of the type of the origin instance
+	 */
+	default Tup4fR getNewInstance(float value)
+	{
+		return getNewInstance(value, value, value, value);
+	}
+	
+	/**
+	 * Returns a new instance of the type of the origin instance with the components set to
+	 * the corresponding parameters.
+	 * 
+	 * <p>
+	 * This can be used for type continuety.
+	 * This way even while only using abstractions it is possible to create
+	 * new instances of the original. It is similar to the {@link #clone()}
+	 * function but the {@link #clone()} function requires the returned instance to be
+	 * writable. This function on the other hand allows for example the usage of factories.
+	 * 
+	 * @param x The value used for the x component.
+	 * @param y The value used for the y component.
+	 * @param z The value used for the z component.
+	 * @param w The value used for the w component.
+	 * 
+	 * @return A new instance of the type of the origin instance
+	 */
+	Tup4fR getNewInstance(float x, float y, float z, float w);
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple4/Tup4fR.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple4/Tup4fR.java
@@ -130,8 +130,8 @@ public interface Tup4fR
 	 * <p>
 	 * This can be used for type continuety.
 	 * This way even while only using abstractions it is possible to create
-	 * new instances of the original. It is similar to the {@link #clone()}
-	 * function but the {@link #clone()} function requires the returned instance to be
+	 * new instances of the original. It is similar to the {@link Object#clone()}
+	 * function but the {@link Object#clone()} function requires the returned instance to be
 	 * writable.
 	 * This function on the other hand allows for example the usage of factories.
 	 * 
@@ -151,8 +151,8 @@ public interface Tup4fR
 	 * <p>
 	 * This can be used for type continuety.
 	 * This way even while only using abstractions it is possible to create
-	 * new instances of the original. It is similar to the {@link #clone()}
-	 * function but the {@link #clone()} function requires the returned instance to be
+	 * new instances of the original. It is similar to the {@link Object#clone()}
+	 * function but the {@link Object#clone()} function requires the returned instance to be
 	 * writable.
 	 * This function on the other hand allows for example the usage of factories.
 	 * 
@@ -172,8 +172,8 @@ public interface Tup4fR
 	 * <p>
 	 * This can be used for type continuety.
 	 * This way even while only using abstractions it is possible to create
-	 * new instances of the original. It is similar to the {@link #clone()}
-	 * function but the {@link #clone()} function requires the returned instance to be
+	 * new instances of the original. It is similar to the {@link Object#clone()}
+	 * function but the {@link Object#clone()} function requires the returned instance to be
 	 * writable. This function on the other hand allows for example the usage of factories.
 	 * 
 	 * @param x The value used for the x component.

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple4/Tup4fRW.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple4/Tup4fRW.java
@@ -51,4 +51,19 @@ public interface Tup4fRW extends Tup4fR, Tup4fW
 	
 	@Override
 	Tup4fRW set(float x, float y, float z, float w);
+	
+	@Override
+	default Tup4fRW getNewInstance(Tup4fR t)
+	{
+		return getNewInstance(t.getX(), t.getY(), t.getZ(), t.getW());
+	}
+	
+	@Override
+	default Tup4fRW getNewInstance(float value)
+	{
+		return getNewInstance(value, value, value, value);
+	}
+	
+	@Override
+	Tup4fRW getNewInstance(float x, float y, float z, float w);
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple4/Tup4iR.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple4/Tup4iR.java
@@ -119,4 +119,66 @@ public interface Tup4iR
 	{
 		return true;
 	}
+	
+	/**
+	 * Returns a new instance of the type of the origin instance with the components adopted
+	 * from t.
+	 * 
+	 * <p>
+	 * This can be used for type continuety.
+	 * This way even while only using abstractions it is possible to create
+	 * new instances of the original. It is similar to the {@link #clone()}
+	 * function but the {@link #clone()} function requires the returned instance to be
+	 * writable.
+	 * This function on the other hand allows for example the usage of factories.
+	 * 
+	 * @param t The tuple to adopt the components from.
+	 * 
+	 * @return A new instance of the type of the origin instance
+	 */
+	default Tup4iR getNewInstance(Tup4iR t)
+	{
+		return getNewInstance(t.getX(), t.getY(), t.getZ(), t.getW());
+	}
+	
+	/**
+	 * Returns a new instance of the type of the origin instance with the components set to
+	 * value.
+	 * 
+	 * <p>
+	 * This can be used for type continuety.
+	 * This way even while only using abstractions it is possible to create
+	 * new instances of the original. It is similar to the {@link #clone()}
+	 * function but the {@link #clone()} function requires the returned instance to be
+	 * writable.
+	 * This function on the other hand allows for example the usage of factories.
+	 * 
+	 * @param value The value used for all components.
+	 * 
+	 * @return A new instance of the type of the origin instance
+	 */
+	default Tup4iR getNewInstance(int value)
+	{
+		return getNewInstance(value, value, value, value);
+	}
+	
+	/**
+	 * Returns a new instance of the type of the origin instance with the components set to
+	 * the corresponding parameters.
+	 * 
+	 * <p>
+	 * This can be used for type continuety.
+	 * This way even while only using abstractions it is possible to create
+	 * new instances of the original. It is similar to the {@link #clone()}
+	 * function but the {@link #clone()} function requires the returned instance to be
+	 * writable. This function on the other hand allows for example the usage of factories.
+	 * 
+	 * @param x The value used for the x component.
+	 * @param y The value used for the y component.
+	 * @param z The value used for the z component.
+	 * @param w The value used for the w component.
+	 * 
+	 * @return A new instance of the type of the origin instance
+	 */
+	Tup4iR getNewInstance(int x, int y, int z, int w);
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple4/Tup4iR.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple4/Tup4iR.java
@@ -127,8 +127,8 @@ public interface Tup4iR
 	 * <p>
 	 * This can be used for type continuety.
 	 * This way even while only using abstractions it is possible to create
-	 * new instances of the original. It is similar to the {@link #clone()}
-	 * function but the {@link #clone()} function requires the returned instance to be
+	 * new instances of the original. It is similar to the {@link Object#clone()}
+	 * function but the {@link Object#clone()} function requires the returned instance to be
 	 * writable.
 	 * This function on the other hand allows for example the usage of factories.
 	 * 
@@ -148,8 +148,8 @@ public interface Tup4iR
 	 * <p>
 	 * This can be used for type continuety.
 	 * This way even while only using abstractions it is possible to create
-	 * new instances of the original. It is similar to the {@link #clone()}
-	 * function but the {@link #clone()} function requires the returned instance to be
+	 * new instances of the original. It is similar to the {@link Object#clone()}
+	 * function but the {@link Object#clone()} function requires the returned instance to be
 	 * writable.
 	 * This function on the other hand allows for example the usage of factories.
 	 * 
@@ -169,8 +169,8 @@ public interface Tup4iR
 	 * <p>
 	 * This can be used for type continuety.
 	 * This way even while only using abstractions it is possible to create
-	 * new instances of the original. It is similar to the {@link #clone()}
-	 * function but the {@link #clone()} function requires the returned instance to be
+	 * new instances of the original. It is similar to the {@link Object#clone()}
+	 * function but the {@link Object#clone()} function requires the returned instance to be
 	 * writable. This function on the other hand allows for example the usage of factories.
 	 * 
 	 * @param x The value used for the x component.

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple4/Tup4iRW.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple4/Tup4iRW.java
@@ -51,4 +51,19 @@ public interface Tup4iRW extends Tup4iR, Tup4iW
 	
 	@Override
 	Tup4iRW set(int x, int y, int z, int w);
+	
+	@Override
+	default Tup4iRW getNewInstance(Tup4iR t)
+	{
+		return getNewInstance(t.getX(), t.getY(), t.getZ(), t.getW());
+	}
+	
+	@Override
+	default Tup4iRW getNewInstance(int value)
+	{
+		return getNewInstance(value, value, value, value);
+	}
+	
+	@Override
+	Tup4iRW getNewInstance(int x, int y, int z, int w);
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple4/Tup4lR.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple4/Tup4lR.java
@@ -127,8 +127,8 @@ public interface Tup4lR
 	 * <p>
 	 * This can be used for type continuety.
 	 * This way even while only using abstractions it is possible to create
-	 * new instances of the original. It is similar to the {@link #clone()}
-	 * function but the {@link #clone()} function requires the returned instance to be
+	 * new instances of the original. It is similar to the {@link Object#clone()}
+	 * function but the {@link Object#clone()} function requires the returned instance to be
 	 * writable.
 	 * This function on the other hand allows for example the usage of factories.
 	 * 
@@ -148,8 +148,8 @@ public interface Tup4lR
 	 * <p>
 	 * This can be used for type continuety.
 	 * This way even while only using abstractions it is possible to create
-	 * new instances of the original. It is similar to the {@link #clone()}
-	 * function but the {@link #clone()} function requires the returned instance to be
+	 * new instances of the original. It is similar to the {@link Object#clone()}
+	 * function but the {@link Object#clone()} function requires the returned instance to be
 	 * writable.
 	 * This function on the other hand allows for example the usage of factories.
 	 * 
@@ -169,8 +169,8 @@ public interface Tup4lR
 	 * <p>
 	 * This can be used for type continuety.
 	 * This way even while only using abstractions it is possible to create
-	 * new instances of the original. It is similar to the {@link #clone()}
-	 * function but the {@link #clone()} function requires the returned instance to be
+	 * new instances of the original. It is similar to the {@link Object#clone()}
+	 * function but the {@link Object#clone()} function requires the returned instance to be
 	 * writable. This function on the other hand allows for example the usage of factories.
 	 * 
 	 * @param x The value used for the x component.

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple4/Tup4lR.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple4/Tup4lR.java
@@ -119,4 +119,66 @@ public interface Tup4lR
 	{
 		return true;
 	}
+	
+	/**
+	 * Returns a new instance of the type of the origin instance with the components adopted
+	 * from t.
+	 * 
+	 * <p>
+	 * This can be used for type continuety.
+	 * This way even while only using abstractions it is possible to create
+	 * new instances of the original. It is similar to the {@link #clone()}
+	 * function but the {@link #clone()} function requires the returned instance to be
+	 * writable.
+	 * This function on the other hand allows for example the usage of factories.
+	 * 
+	 * @param t The tuple to adopt the components from.
+	 * 
+	 * @return A new instance of the type of the origin instance
+	 */
+	default Tup4lR getNewInstance(Tup4lR t)
+	{
+		return getNewInstance(t.getX(), t.getY(), t.getZ(), t.getW());
+	}
+	
+	/**
+	 * Returns a new instance of the type of the origin instance with the components set to
+	 * value.
+	 * 
+	 * <p>
+	 * This can be used for type continuety.
+	 * This way even while only using abstractions it is possible to create
+	 * new instances of the original. It is similar to the {@link #clone()}
+	 * function but the {@link #clone()} function requires the returned instance to be
+	 * writable.
+	 * This function on the other hand allows for example the usage of factories.
+	 * 
+	 * @param value The value used for all components.
+	 * 
+	 * @return A new instance of the type of the origin instance
+	 */
+	default Tup4lR getNewInstance(long value)
+	{
+		return getNewInstance(value, value, value, value);
+	}
+	
+	/**
+	 * Returns a new instance of the type of the origin instance with the components set to
+	 * the corresponding parameters.
+	 * 
+	 * <p>
+	 * This can be used for type continuety.
+	 * This way even while only using abstractions it is possible to create
+	 * new instances of the original. It is similar to the {@link #clone()}
+	 * function but the {@link #clone()} function requires the returned instance to be
+	 * writable. This function on the other hand allows for example the usage of factories.
+	 * 
+	 * @param x The value used for the x component.
+	 * @param y The value used for the y component.
+	 * @param z The value used for the z component.
+	 * @param w The value used for the w component.
+	 * 
+	 * @return A new instance of the type of the origin instance
+	 */
+	Tup4lR getNewInstance(long x, long y, long z, long w);
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple4/Tup4lRW.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple4/Tup4lRW.java
@@ -51,4 +51,19 @@ public interface Tup4lRW extends Tup4lR, Tup4lW
 	
 	@Override
 	Tup4lRW set(long x, long y, long z, long w);
+	
+	@Override
+	default Tup4lRW getNewInstance(Tup4lR t)
+	{
+		return getNewInstance(t.getX(), t.getY(), t.getZ(), t.getW());
+	}
+	
+	@Override
+	default Tup4lRW getNewInstance(long value)
+	{
+		return getNewInstance(value, value, value, value);
+	}
+	
+	@Override
+	Tup4lRW getNewInstance(long x, long y, long z, long w);
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple4/Tup4oR.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple4/Tup4oR.java
@@ -92,8 +92,8 @@ public interface Tup4oR<X,Y,Z,W>
 	 * <p>
 	 * This can be used for type continuety.
 	 * This way even while only using abstractions it is possible to create
-	 * new instances of the original. It is similar to the {@link #clone()}
-	 * function but the {@link #clone()} function requires the returned instance to be
+	 * new instances of the original. It is similar to the {@link Object#clone()}
+	 * function but the {@link Object#clone()} function requires the returned instance to be
 	 * writable.
 	 * This function on the other hand allows for example the usage of factories.
 	 * 
@@ -113,8 +113,8 @@ public interface Tup4oR<X,Y,Z,W>
 	 * <p>
 	 * This can be used for type continuety.
 	 * This way even while only using abstractions it is possible to create
-	 * new instances of the original. It is similar to the {@link #clone()}
-	 * function but the {@link #clone()} function requires the returned instance to be
+	 * new instances of the original. It is similar to the {@link Object#clone()}
+	 * function but the {@link Object#clone()} function requires the returned instance to be
 	 * writable. This function on the other hand allows for example the usage of factories.
 	 * 
 	 * @param x The value used for the x component.

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple4/Tup4oR.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple4/Tup4oR.java
@@ -84,4 +84,45 @@ public interface Tup4oR<X,Y,Z,W>
 				getZ() != null &&
 				getW() != null;
 	}
+	
+	/**
+	 * Returns a new instance of the type of the origin instance with the components adopted
+	 * from t.
+	 * 
+	 * <p>
+	 * This can be used for type continuety.
+	 * This way even while only using abstractions it is possible to create
+	 * new instances of the original. It is similar to the {@link #clone()}
+	 * function but the {@link #clone()} function requires the returned instance to be
+	 * writable.
+	 * This function on the other hand allows for example the usage of factories.
+	 * 
+	 * @param t The tuple to adopt the components from.
+	 * 
+	 * @return A new instance of the type of the origin instance
+	 */
+	default Tup4oR<X,Y,Z,W> getNewInstance(Tup4oR<X,Y,Z,W> t)
+	{
+		return getNewInstance(t.getX(), t.getY(), t.getZ(), t.getW());
+	}
+	
+	/**
+	 * Returns a new instance of the type of the origin instance with the components set to
+	 * the corresponding parameters.
+	 * 
+	 * <p>
+	 * This can be used for type continuety.
+	 * This way even while only using abstractions it is possible to create
+	 * new instances of the original. It is similar to the {@link #clone()}
+	 * function but the {@link #clone()} function requires the returned instance to be
+	 * writable. This function on the other hand allows for example the usage of factories.
+	 * 
+	 * @param x The value used for the x component.
+	 * @param y The value used for the y component.
+	 * @param z The value used for the z component.
+	 * @param w The value used for the w component.
+	 * 
+	 * @return A new instance of the type of the origin instance
+	 */
+	Tup4oR<X,Y,Z,W> getNewInstance(X x, Y y, Z z, W w);
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple4/Tup4oRW.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple4/Tup4oRW.java
@@ -48,4 +48,13 @@ public interface Tup4oRW<X,Y,Z,W> extends Tup4oR<X,Y,Z,W>, Tup4oW<X,Y,Z,W>
 	
 	@Override
 	Tup4oRW<X,Y,Z,W> set(X x, Y y, Z z, W w);
+	
+	@Override
+	default Tup4oRW<X,Y,Z,W> getNewInstance(Tup4oR<X,Y,Z,W> t)
+	{
+		return getNewInstance(t.getX(), t.getY(), t.getZ(), t.getW());
+	}
+	
+	@Override
+	Tup4oRW<X,Y,Z,W> getNewInstance(X x, Y y, Z z, W w);
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple4/Tup4objR.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple4/Tup4objR.java
@@ -84,4 +84,66 @@ public interface Tup4objR
 				getZ() != null &&
 				getW() != null;
 	}
+	
+	/**
+	 * Returns a new instance of the type of the origin instance with the components adopted
+	 * from t.
+	 * 
+	 * <p>
+	 * This can be used for type continuety.
+	 * This way even while only using abstractions it is possible to create
+	 * new instances of the original. It is similar to the {@link #clone()}
+	 * function but the {@link #clone()} function requires the returned instance to be
+	 * writable.
+	 * This function on the other hand allows for example the usage of factories.
+	 * 
+	 * @param t The tuple to adopt the components from.
+	 * 
+	 * @return A new instance of the type of the origin instance
+	 */
+	default Tup4objR getNewInstance(Tup4objR t)
+	{
+		return getNewInstance(t.getX(), t.getY(), t.getZ(), t.getW());
+	}
+	
+	/**
+	 * Returns a new instance of the type of the origin instance with the components set to
+	 * value.
+	 * 
+	 * <p>
+	 * This can be used for type continuety.
+	 * This way even while only using abstractions it is possible to create
+	 * new instances of the original. It is similar to the {@link #clone()}
+	 * function but the {@link #clone()} function requires the returned instance to be
+	 * writable.
+	 * This function on the other hand allows for example the usage of factories.
+	 * 
+	 * @param value The value used for all components.
+	 * 
+	 * @return A new instance of the type of the origin instance
+	 */
+	default Tup4objR getNewInstance(Object value)
+	{
+		return getNewInstance(value, value, value, value);
+	}
+	
+	/**
+	 * Returns a new instance of the type of the origin instance with the components set to
+	 * the corresponding parameters.
+	 * 
+	 * <p>
+	 * This can be used for type continuety.
+	 * This way even while only using abstractions it is possible to create
+	 * new instances of the original. It is similar to the {@link #clone()}
+	 * function but the {@link #clone()} function requires the returned instance to be
+	 * writable. This function on the other hand allows for example the usage of factories.
+	 * 
+	 * @param x The value used for the x component.
+	 * @param y The value used for the y component.
+	 * @param z The value used for the z component.
+	 * @param w The value used for the w component.
+	 * 
+	 * @return A new instance of the type of the origin instance
+	 */
+	Tup4objR getNewInstance(Object x, Object y, Object z, Object w);
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple4/Tup4objR.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple4/Tup4objR.java
@@ -92,8 +92,8 @@ public interface Tup4objR
 	 * <p>
 	 * This can be used for type continuety.
 	 * This way even while only using abstractions it is possible to create
-	 * new instances of the original. It is similar to the {@link #clone()}
-	 * function but the {@link #clone()} function requires the returned instance to be
+	 * new instances of the original. It is similar to the {@link Object#clone()}
+	 * function but the {@link Object#clone()} function requires the returned instance to be
 	 * writable.
 	 * This function on the other hand allows for example the usage of factories.
 	 * 
@@ -113,8 +113,8 @@ public interface Tup4objR
 	 * <p>
 	 * This can be used for type continuety.
 	 * This way even while only using abstractions it is possible to create
-	 * new instances of the original. It is similar to the {@link #clone()}
-	 * function but the {@link #clone()} function requires the returned instance to be
+	 * new instances of the original. It is similar to the {@link Object#clone()}
+	 * function but the {@link Object#clone()} function requires the returned instance to be
 	 * writable.
 	 * This function on the other hand allows for example the usage of factories.
 	 * 
@@ -134,8 +134,8 @@ public interface Tup4objR
 	 * <p>
 	 * This can be used for type continuety.
 	 * This way even while only using abstractions it is possible to create
-	 * new instances of the original. It is similar to the {@link #clone()}
-	 * function but the {@link #clone()} function requires the returned instance to be
+	 * new instances of the original. It is similar to the {@link Object#clone()}
+	 * function but the {@link Object#clone()} function requires the returned instance to be
 	 * writable. This function on the other hand allows for example the usage of factories.
 	 * 
 	 * @param x The value used for the x component.

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple4/Tup4objRW.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple4/Tup4objRW.java
@@ -51,4 +51,19 @@ public interface Tup4objRW extends Tup4objR, Tup4objW
 	
 	@Override
 	Tup4objRW set(Object x, Object y, Object z, Object w);
+	
+	@Override
+	default Tup4objRW getNewInstance(Tup4objR t)
+	{
+		return getNewInstance(t.getX(), t.getY(), t.getZ(), t.getW());
+	}
+	
+	@Override
+	default Tup4objRW getNewInstance(Object value)
+	{
+		return getNewInstance(value, value, value, value);
+	}
+	
+	@Override
+	Tup4objRW getNewInstance(Object x, Object y, Object z, Object w);
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple4/Tup4sR.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple4/Tup4sR.java
@@ -119,4 +119,66 @@ public interface Tup4sR
 	{
 		return true;
 	}
+	
+	/**
+	 * Returns a new instance of the type of the origin instance with the components adopted
+	 * from t.
+	 * 
+	 * <p>
+	 * This can be used for type continuety.
+	 * This way even while only using abstractions it is possible to create
+	 * new instances of the original. It is similar to the {@link #clone()}
+	 * function but the {@link #clone()} function requires the returned instance to be
+	 * writable.
+	 * This function on the other hand allows for example the usage of factories.
+	 * 
+	 * @param t The tuple to adopt the components from.
+	 * 
+	 * @return A new instance of the type of the origin instance
+	 */
+	default Tup4sR getNewInstance(Tup4sR t)
+	{
+		return getNewInstance(t.getX(), t.getY(), t.getZ(), t.getW());
+	}
+	
+	/**
+	 * Returns a new instance of the type of the origin instance with the components set to
+	 * value.
+	 * 
+	 * <p>
+	 * This can be used for type continuety.
+	 * This way even while only using abstractions it is possible to create
+	 * new instances of the original. It is similar to the {@link #clone()}
+	 * function but the {@link #clone()} function requires the returned instance to be
+	 * writable.
+	 * This function on the other hand allows for example the usage of factories.
+	 * 
+	 * @param value The value used for all components.
+	 * 
+	 * @return A new instance of the type of the origin instance
+	 */
+	default Tup4sR getNewInstance(short value)
+	{
+		return getNewInstance(value, value, value, value);
+	}
+	
+	/**
+	 * Returns a new instance of the type of the origin instance with the components set to
+	 * the corresponding parameters.
+	 * 
+	 * <p>
+	 * This can be used for type continuety.
+	 * This way even while only using abstractions it is possible to create
+	 * new instances of the original. It is similar to the {@link #clone()}
+	 * function but the {@link #clone()} function requires the returned instance to be
+	 * writable. This function on the other hand allows for example the usage of factories.
+	 * 
+	 * @param x The value used for the x component.
+	 * @param y The value used for the y component.
+	 * @param z The value used for the z component.
+	 * @param w The value used for the w component.
+	 * 
+	 * @return A new instance of the type of the origin instance
+	 */
+	Tup4sR getNewInstance(short x, short y, short z, short w);
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple4/Tup4sR.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple4/Tup4sR.java
@@ -127,8 +127,8 @@ public interface Tup4sR
 	 * <p>
 	 * This can be used for type continuety.
 	 * This way even while only using abstractions it is possible to create
-	 * new instances of the original. It is similar to the {@link #clone()}
-	 * function but the {@link #clone()} function requires the returned instance to be
+	 * new instances of the original. It is similar to the {@link Object#clone()}
+	 * function but the {@link Object#clone()} function requires the returned instance to be
 	 * writable.
 	 * This function on the other hand allows for example the usage of factories.
 	 * 
@@ -148,8 +148,8 @@ public interface Tup4sR
 	 * <p>
 	 * This can be used for type continuety.
 	 * This way even while only using abstractions it is possible to create
-	 * new instances of the original. It is similar to the {@link #clone()}
-	 * function but the {@link #clone()} function requires the returned instance to be
+	 * new instances of the original. It is similar to the {@link Object#clone()}
+	 * function but the {@link Object#clone()} function requires the returned instance to be
 	 * writable.
 	 * This function on the other hand allows for example the usage of factories.
 	 * 
@@ -169,8 +169,8 @@ public interface Tup4sR
 	 * <p>
 	 * This can be used for type continuety.
 	 * This way even while only using abstractions it is possible to create
-	 * new instances of the original. It is similar to the {@link #clone()}
-	 * function but the {@link #clone()} function requires the returned instance to be
+	 * new instances of the original. It is similar to the {@link Object#clone()}
+	 * function but the {@link Object#clone()} function requires the returned instance to be
 	 * writable. This function on the other hand allows for example the usage of factories.
 	 * 
 	 * @param x The value used for the x component.

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple4/Tup4sRW.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple4/Tup4sRW.java
@@ -51,4 +51,19 @@ public interface Tup4sRW extends Tup4sR, Tup4sW
 	
 	@Override
 	Tup4sRW set(short x, short y, short z, short w);
+	
+	@Override
+	default Tup4sRW getNewInstance(Tup4sR t)
+	{
+		return getNewInstance(t.getX(), t.getY(), t.getZ(), t.getW());
+	}
+	
+	@Override
+	default Tup4sRW getNewInstance(short value)
+	{
+		return getNewInstance(value, value, value, value);
+	}
+	
+	@Override
+	Tup4sRW getNewInstance(short x, short y, short z, short w);
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple4/Tup4strR.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple4/Tup4strR.java
@@ -92,8 +92,8 @@ public interface Tup4strR
 	 * <p>
 	 * This can be used for type continuety.
 	 * This way even while only using abstractions it is possible to create
-	 * new instances of the original. It is similar to the {@link #clone()}
-	 * function but the {@link #clone()} function requires the returned instance to be
+	 * new instances of the original. It is similar to the {@link Object#clone()}
+	 * function but the {@link Object#clone()} function requires the returned instance to be
 	 * writable.
 	 * This function on the other hand allows for example the usage of factories.
 	 * 
@@ -113,8 +113,8 @@ public interface Tup4strR
 	 * <p>
 	 * This can be used for type continuety.
 	 * This way even while only using abstractions it is possible to create
-	 * new instances of the original. It is similar to the {@link #clone()}
-	 * function but the {@link #clone()} function requires the returned instance to be
+	 * new instances of the original. It is similar to the {@link Object#clone()}
+	 * function but the {@link Object#clone()} function requires the returned instance to be
 	 * writable.
 	 * This function on the other hand allows for example the usage of factories.
 	 * 
@@ -134,8 +134,8 @@ public interface Tup4strR
 	 * <p>
 	 * This can be used for type continuety.
 	 * This way even while only using abstractions it is possible to create
-	 * new instances of the original. It is similar to the {@link #clone()}
-	 * function but the {@link #clone()} function requires the returned instance to be
+	 * new instances of the original. It is similar to the {@link Object#clone()}
+	 * function but the {@link Object#clone()} function requires the returned instance to be
 	 * writable. This function on the other hand allows for example the usage of factories.
 	 * 
 	 * @param x The value used for the x component.

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple4/Tup4strR.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple4/Tup4strR.java
@@ -84,4 +84,66 @@ public interface Tup4strR
 				getZ() != null &&
 				getW() != null;
 	}
+	
+	/**
+	 * Returns a new instance of the type of the origin instance with the components adopted
+	 * from t.
+	 * 
+	 * <p>
+	 * This can be used for type continuety.
+	 * This way even while only using abstractions it is possible to create
+	 * new instances of the original. It is similar to the {@link #clone()}
+	 * function but the {@link #clone()} function requires the returned instance to be
+	 * writable.
+	 * This function on the other hand allows for example the usage of factories.
+	 * 
+	 * @param t The tuple to adopt the components from.
+	 * 
+	 * @return A new instance of the type of the origin instance
+	 */
+	default Tup4strR getNewInstance(Tup4strR t)
+	{
+		return getNewInstance(t.getX(), t.getY(), t.getZ(), t.getW());
+	}
+	
+	/**
+	 * Returns a new instance of the type of the origin instance with the components set to
+	 * value.
+	 * 
+	 * <p>
+	 * This can be used for type continuety.
+	 * This way even while only using abstractions it is possible to create
+	 * new instances of the original. It is similar to the {@link #clone()}
+	 * function but the {@link #clone()} function requires the returned instance to be
+	 * writable.
+	 * This function on the other hand allows for example the usage of factories.
+	 * 
+	 * @param value The value used for all components.
+	 * 
+	 * @return A new instance of the type of the origin instance
+	 */
+	default Tup4strR getNewInstance(String value)
+	{
+		return getNewInstance(value, value, value, value);
+	}
+	
+	/**
+	 * Returns a new instance of the type of the origin instance with the components set to
+	 * the corresponding parameters.
+	 * 
+	 * <p>
+	 * This can be used for type continuety.
+	 * This way even while only using abstractions it is possible to create
+	 * new instances of the original. It is similar to the {@link #clone()}
+	 * function but the {@link #clone()} function requires the returned instance to be
+	 * writable. This function on the other hand allows for example the usage of factories.
+	 * 
+	 * @param x The value used for the x component.
+	 * @param y The value used for the y component.
+	 * @param z The value used for the z component.
+	 * @param w The value used for the w component.
+	 * 
+	 * @return A new instance of the type of the origin instance
+	 */
+	Tup4strR getNewInstance(String x, String y, String z, String w);
 }

--- a/barghos-core/src/main/java/org/barghos/core/api/tuple4/Tup4strRW.java
+++ b/barghos-core/src/main/java/org/barghos/core/api/tuple4/Tup4strRW.java
@@ -51,4 +51,19 @@ public interface Tup4strRW extends Tup4strR, Tup4strW
 	
 	@Override
 	Tup4strRW set(String x, String y, String z, String w);
+	
+	@Override
+	default Tup4strRW getNewInstance(Tup4strR t)
+	{
+		return getNewInstance(t.getX(), t.getY(), t.getZ(), t.getW());
+	}
+	
+	@Override
+	default Tup4strRW getNewInstance(String value)
+	{
+		return getNewInstance(value, value, value, value);
+	}
+	
+	@Override
+	Tup4strRW getNewInstance(String x, String y, String z, String w);
 }

--- a/barghos-core/src/main/java/org/barghos/core/color/HDRColor3.java
+++ b/barghos-core/src/main/java/org/barghos/core/color/HDRColor3.java
@@ -433,4 +433,10 @@ public class HDRColor3 implements HDRColor3R
 	{
 		return Math.round(this.b * 255);
 	}
+	
+	@Override
+	public HDRColor3 getNewInstance(float x, float y, float z)
+	{
+		return new HDRColor3(x, y, z);
+	}
 }

--- a/barghos-core/src/main/java/org/barghos/core/color/HDRColor3Colors.java
+++ b/barghos-core/src/main/java/org/barghos/core/color/HDRColor3Colors.java
@@ -45,6 +45,12 @@ public enum HDRColor3Colors implements HDRColor3R
 		public float getUnityR() { return 1; }
 		public float getUnityG() { return 1; }
 		public float getUnityB() { return 1; }
+		
+		@Override
+		public HDRColor3R getNewInstance(float x, float y, float z)
+		{
+			return new HDRColor3(x, y, z);
+		}
 	},
 	
 	/**
@@ -59,6 +65,12 @@ public enum HDRColor3Colors implements HDRColor3R
 		public float getUnityR() { return 0; }
 		public float getUnityG() { return 0; }
 		public float getUnityB() { return 0; }
+		
+		@Override
+		public HDRColor3R getNewInstance(float x, float y, float z)
+		{
+			return new HDRColor3(x, y, z);
+		}
 	},
 	
 	/**
@@ -73,6 +85,12 @@ public enum HDRColor3Colors implements HDRColor3R
 		public float getUnityR() { return 1; }
 		public float getUnityG() { return 0; }
 		public float getUnityB() { return 0; }
+		
+		@Override
+		public HDRColor3R getNewInstance(float x, float y, float z)
+		{
+			return new HDRColor3(x, y, z);
+		}
 	},
 	
 	/**
@@ -87,6 +105,12 @@ public enum HDRColor3Colors implements HDRColor3R
 		public float getUnityR() { return 0; }
 		public float getUnityG() { return 1; }
 		public float getUnityB() { return 0; }
+		
+		@Override
+		public HDRColor3R getNewInstance(float x, float y, float z)
+		{
+			return new HDRColor3(x, y, z);
+		}
 	},
 	
 	/**
@@ -101,6 +125,12 @@ public enum HDRColor3Colors implements HDRColor3R
 		public float getUnityR() { return 0; }
 		public float getUnityG() { return 0; }
 		public float getUnityB() { return 1; }
+		
+		@Override
+		public HDRColor3R getNewInstance(float x, float y, float z)
+		{
+			return new HDRColor3(x, y, z);
+		}
 	},
 	
 	/** 
@@ -115,6 +145,12 @@ public enum HDRColor3Colors implements HDRColor3R
 		public float getUnityR() { return 1; }
 		public float getUnityG() { return 1; }
 		public float getUnityB() { return 0; }
+		
+		@Override
+		public HDRColor3R getNewInstance(float x, float y, float z)
+		{
+			return new HDRColor3(x, y, z);
+		}
 	},
 	
 	/**
@@ -127,6 +163,12 @@ public enum HDRColor3Colors implements HDRColor3R
 		public int getG() { return 0; }
 		public int getB() { return 128; }
 		public float getUnityG() { return 0; }
+		
+		@Override
+		public HDRColor3R getNewInstance(float x, float y, float z)
+		{
+			return new HDRColor3(x, y, z);
+		}
 	},
 	
 	/** 
@@ -140,6 +182,12 @@ public enum HDRColor3Colors implements HDRColor3R
 		public int getB() { return 0; }
 		public float getUnityR() { return 1; }
 		public float getUnityB() { return 0; }
+		
+		@Override
+		public HDRColor3R getNewInstance(float x, float y, float z)
+		{
+			return new HDRColor3(x, y, z);
+		}
 	},
 	
 	/**
@@ -153,6 +201,12 @@ public enum HDRColor3Colors implements HDRColor3R
 		public int getB() { return 0; }
 		public float getUnityR() { return 1; }
 		public float getUnityB() { return 0; }
+		
+		@Override
+		public HDRColor3R getNewInstance(float x, float y, float z)
+		{
+			return new HDRColor3(x, y, z);
+		}
 	},
 	
 	/** 
@@ -164,6 +218,12 @@ public enum HDRColor3Colors implements HDRColor3R
 		public int getR() { return 128; }
 		public int getG() { return 128; }
 		public int getB() { return 128; }
+		
+		@Override
+		public HDRColor3R getNewInstance(float x, float y, float z)
+		{
+			return new HDRColor3(x, y, z);
+		}
 	},
 ;
 

--- a/barghos-core/src/main/java/org/barghos/core/color/HDRColor4.java
+++ b/barghos-core/src/main/java/org/barghos/core/color/HDRColor4.java
@@ -501,4 +501,16 @@ public class HDRColor4 implements HDRColor4R
 	{
 		return Math.round(this.a * 255);
 	}
+	
+	@Override
+	public HDRColor4 getNewInstance(float x, float y, float z)
+	{
+		return new HDRColor4(x, y, z, 1.0f);
+	}
+	
+	@Override
+	public HDRColor4 getNewInstance(float x, float y, float z, float w)
+	{
+		return new HDRColor4(x, y, z, w);
+	}
 }

--- a/barghos-core/src/main/java/org/barghos/core/color/HDRColor4Colors.java
+++ b/barghos-core/src/main/java/org/barghos/core/color/HDRColor4Colors.java
@@ -45,6 +45,18 @@ public enum HDRColor4Colors implements HDRColor4R
 		public float getUnityR() { return 1; }
 		public float getUnityG() { return 1; }
 		public float getUnityB() { return 1; }
+		
+		@Override
+		public HDRColor4R getNewInstance(float x, float y, float z)
+		{
+			return new HDRColor4(x, y, z, 1.0f);
+		}
+		
+		@Override
+		public HDRColor4R getNewInstance(float x, float y, float z, float w)
+		{
+			return new HDRColor4(x, y, z, w);
+		}
 	},
 	
 	/**
@@ -59,6 +71,18 @@ public enum HDRColor4Colors implements HDRColor4R
 		public float getUnityR() { return 0; }
 		public float getUnityG() { return 0; }
 		public float getUnityB() { return 0; }
+		
+		@Override
+		public HDRColor4R getNewInstance(float x, float y, float z)
+		{
+			return new HDRColor4(x, y, z, 1.0f);
+		}
+		
+		@Override
+		public HDRColor4R getNewInstance(float x, float y, float z, float w)
+		{
+			return new HDRColor4(x, y, z, w);
+		}
 	},
 	
 	/**
@@ -73,6 +97,18 @@ public enum HDRColor4Colors implements HDRColor4R
 		public float getUnityR() { return 1; }
 		public float getUnityG() { return 0; }
 		public float getUnityB() { return 0; }
+		
+		@Override
+		public HDRColor4R getNewInstance(float x, float y, float z)
+		{
+			return new HDRColor4(x, y, z, 1.0f);
+		}
+		
+		@Override
+		public HDRColor4R getNewInstance(float x, float y, float z, float w)
+		{
+			return new HDRColor4(x, y, z, w);
+		}
 	},
 	
 	/**
@@ -87,6 +123,18 @@ public enum HDRColor4Colors implements HDRColor4R
 		public float getUnityR() { return 0; }
 		public float getUnityG() { return 1; }
 		public float getUnityB() { return 0; }
+		
+		@Override
+		public HDRColor4R getNewInstance(float x, float y, float z)
+		{
+			return new HDRColor4(x, y, z, 1.0f);
+		}
+		
+		@Override
+		public HDRColor4R getNewInstance(float x, float y, float z, float w)
+		{
+			return new HDRColor4(x, y, z, w);
+		}
 	},
 	
 	/**
@@ -101,6 +149,18 @@ public enum HDRColor4Colors implements HDRColor4R
 		public float getUnityR() { return 0; }
 		public float getUnityG() { return 0; }
 		public float getUnityB() { return 1; }
+		
+		@Override
+		public HDRColor4R getNewInstance(float x, float y, float z)
+		{
+			return new HDRColor4(x, y, z, 1.0f);
+		}
+		
+		@Override
+		public HDRColor4R getNewInstance(float x, float y, float z, float w)
+		{
+			return new HDRColor4(x, y, z, w);
+		}
 	},
 	
 	/** 
@@ -115,6 +175,18 @@ public enum HDRColor4Colors implements HDRColor4R
 		public float getUnityR() { return 1; }
 		public float getUnityG() { return 1; }
 		public float getUnityB() { return 0; }
+		
+		@Override
+		public HDRColor4R getNewInstance(float x, float y, float z)
+		{
+			return new HDRColor4(x, y, z, 1.0f);
+		}
+		
+		@Override
+		public HDRColor4R getNewInstance(float x, float y, float z, float w)
+		{
+			return new HDRColor4(x, y, z, w);
+		}
 	},
 	
 	/**
@@ -127,6 +199,18 @@ public enum HDRColor4Colors implements HDRColor4R
 		public int getG() { return 0; }
 		public int getB() { return 128; }
 		public float getUnityG() { return 0; }
+		
+		@Override
+		public HDRColor4R getNewInstance(float x, float y, float z)
+		{
+			return new HDRColor4(x, y, z, 1.0f);
+		}
+		
+		@Override
+		public HDRColor4R getNewInstance(float x, float y, float z, float w)
+		{
+			return new HDRColor4(x, y, z, w);
+		}
 	},
 	
 	/** 
@@ -140,6 +224,18 @@ public enum HDRColor4Colors implements HDRColor4R
 		public int getB() { return 0; }
 		public float getUnityR() { return 1; }
 		public float getUnityB() { return 0; }
+		
+		@Override
+		public HDRColor4R getNewInstance(float x, float y, float z)
+		{
+			return new HDRColor4(x, y, z, 1.0f);
+		}
+		
+		@Override
+		public HDRColor4R getNewInstance(float x, float y, float z, float w)
+		{
+			return new HDRColor4(x, y, z, w);
+		}
 	},
 	
 	/**
@@ -153,6 +249,18 @@ public enum HDRColor4Colors implements HDRColor4R
 		public int getB() { return 0; }
 		public float getUnityR() { return 1; }
 		public float getUnityB() { return 0; }
+		
+		@Override
+		public HDRColor4R getNewInstance(float x, float y, float z)
+		{
+			return new HDRColor4(x, y, z, 1.0f);
+		}
+		
+		@Override
+		public HDRColor4R getNewInstance(float x, float y, float z, float w)
+		{
+			return new HDRColor4(x, y, z, w);
+		}
 	},
 	
 	/** 
@@ -164,6 +272,18 @@ public enum HDRColor4Colors implements HDRColor4R
 		public int getR() { return 128; }
 		public int getG() { return 128; }
 		public int getB() { return 128; }
+		
+		@Override
+		public HDRColor4R getNewInstance(float x, float y, float z)
+		{
+			return new HDRColor4(x, y, z, 1.0f);
+		}
+		
+		@Override
+		public HDRColor4R getNewInstance(float x, float y, float z, float w)
+		{
+			return new HDRColor4(x, y, z, w);
+		}
 	},
 ;
 	

--- a/barghos-core/src/main/java/org/barghos/core/color/LDRColor3.java
+++ b/barghos-core/src/main/java/org/barghos/core/color/LDRColor3.java
@@ -434,6 +434,12 @@ public class LDRColor3 implements LDRColor3R
 		return Math.round(this.b * 255);
 	}
 	
+	@Override
+	public LDRColor3 getNewInstance(float x, float y, float z)
+	{
+		return new LDRColor3(x, y, z);
+	}
+	
 	/**
 	 * Clamps the float value to unit space from 0.0 to 1.0.
 	 * 

--- a/barghos-core/src/main/java/org/barghos/core/color/LDRColor3Colors.java
+++ b/barghos-core/src/main/java/org/barghos/core/color/LDRColor3Colors.java
@@ -45,6 +45,12 @@ public enum LDRColor3Colors implements LDRColor3R
 		public float getUnityR() { return 1; }
 		public float getUnityG() { return 1; }
 		public float getUnityB() { return 1; }
+		
+		@Override
+		public LDRColor3R getNewInstance(float x, float y, float z)
+		{
+			return new LDRColor3(x, y, z);
+		}
 	},
 	
 	/**
@@ -59,6 +65,12 @@ public enum LDRColor3Colors implements LDRColor3R
 		public float getUnityR() { return 0; }
 		public float getUnityG() { return 0; }
 		public float getUnityB() { return 0; }
+		
+		@Override
+		public LDRColor3R getNewInstance(float x, float y, float z)
+		{
+			return new LDRColor3(x, y, z);
+		}
 	},
 	
 	/**
@@ -73,6 +85,12 @@ public enum LDRColor3Colors implements LDRColor3R
 		public float getUnityR() { return 1; }
 		public float getUnityG() { return 0; }
 		public float getUnityB() { return 0; }
+		
+		@Override
+		public LDRColor3R getNewInstance(float x, float y, float z)
+		{
+			return new LDRColor3(x, y, z);
+		}
 	},
 	
 	/**
@@ -87,6 +105,12 @@ public enum LDRColor3Colors implements LDRColor3R
 		public float getUnityR() { return 0; }
 		public float getUnityG() { return 1; }
 		public float getUnityB() { return 0; }
+		
+		@Override
+		public LDRColor3R getNewInstance(float x, float y, float z)
+		{
+			return new LDRColor3(x, y, z);
+		}
 	},
 	
 	/**
@@ -101,6 +125,12 @@ public enum LDRColor3Colors implements LDRColor3R
 		public float getUnityR() { return 0; }
 		public float getUnityG() { return 0; }
 		public float getUnityB() { return 1; }
+		
+		@Override
+		public LDRColor3R getNewInstance(float x, float y, float z)
+		{
+			return new LDRColor3(x, y, z);
+		}
 	},
 	
 	/** 
@@ -115,6 +145,12 @@ public enum LDRColor3Colors implements LDRColor3R
 		public float getUnityR() { return 1; }
 		public float getUnityG() { return 1; }
 		public float getUnityB() { return 0; }
+		
+		@Override
+		public LDRColor3R getNewInstance(float x, float y, float z)
+		{
+			return new LDRColor3(x, y, z);
+		}
 	},
 	
 	/**
@@ -127,6 +163,12 @@ public enum LDRColor3Colors implements LDRColor3R
 		public int getG() { return 0; }
 		public int getB() { return 128; }
 		public float getUnityG() { return 0; }
+		
+		@Override
+		public LDRColor3R getNewInstance(float x, float y, float z)
+		{
+			return new LDRColor3(x, y, z);
+		}
 	},
 	
 	/** 
@@ -140,6 +182,12 @@ public enum LDRColor3Colors implements LDRColor3R
 		public int getB() { return 0; }
 		public float getUnityR() { return 1; }
 		public float getUnityB() { return 0; }
+		
+		@Override
+		public LDRColor3R getNewInstance(float x, float y, float z)
+		{
+			return new LDRColor3(x, y, z);
+		}
 	},
 	
 	/**
@@ -153,6 +201,12 @@ public enum LDRColor3Colors implements LDRColor3R
 		public int getB() { return 0; }
 		public float getUnityR() { return 1; }
 		public float getUnityB() { return 0; }
+		
+		@Override
+		public LDRColor3R getNewInstance(float x, float y, float z)
+		{
+			return new LDRColor3(x, y, z);
+		}
 	},
 	
 	/** 
@@ -164,6 +218,12 @@ public enum LDRColor3Colors implements LDRColor3R
 		public int getR() { return 128; }
 		public int getG() { return 128; }
 		public int getB() { return 128; }
+		
+		@Override
+		public LDRColor3R getNewInstance(float x, float y, float z)
+		{
+			return new LDRColor3(x, y, z);
+		}
 	},
 ;
 	

--- a/barghos-core/src/main/java/org/barghos/core/color/LDRColor4.java
+++ b/barghos-core/src/main/java/org/barghos/core/color/LDRColor4.java
@@ -502,6 +502,18 @@ public class LDRColor4 implements LDRColor4R
 		return Math.round(this.a * 255);
 	}
 	
+	@Override
+	public LDRColor4 getNewInstance(float x, float y, float z)
+	{
+		return new LDRColor4(x, y, z, 1.0f);
+	}
+	
+	@Override
+	public LDRColor4 getNewInstance(float x, float y, float z, float w)
+	{
+		return new LDRColor4(x, y, z, w);
+	}
+	
 	/**
 	 * Clamps the float value to unit space from 0.0 to 1.0.
 	 * 

--- a/barghos-core/src/main/java/org/barghos/core/color/LDRColor4Colors.java
+++ b/barghos-core/src/main/java/org/barghos/core/color/LDRColor4Colors.java
@@ -45,6 +45,18 @@ public enum LDRColor4Colors implements LDRColor4R
 		public float getUnityR() { return 1; }
 		public float getUnityG() { return 1; }
 		public float getUnityB() { return 1; }
+		
+		@Override
+		public LDRColor4R getNewInstance(float x, float y, float z)
+		{
+			return new LDRColor4(x, y, z, 1.0f);
+		}
+		
+		@Override
+		public LDRColor4R getNewInstance(float x, float y, float z, float w)
+		{
+			return new LDRColor4(x, y, z, w);
+		}
 	},
 	
 	/**
@@ -59,6 +71,18 @@ public enum LDRColor4Colors implements LDRColor4R
 		public float getUnityR() { return 0; }
 		public float getUnityG() { return 0; }
 		public float getUnityB() { return 0; }
+		
+		@Override
+		public LDRColor4R getNewInstance(float x, float y, float z)
+		{
+			return new LDRColor4(x, y, z, 1.0f);
+		}
+		
+		@Override
+		public LDRColor4R getNewInstance(float x, float y, float z, float w)
+		{
+			return new LDRColor4(x, y, z, w);
+		}
 	},
 	
 	/**
@@ -73,6 +97,18 @@ public enum LDRColor4Colors implements LDRColor4R
 		public float getUnityR() { return 1; }
 		public float getUnityG() { return 0; }
 		public float getUnityB() { return 0; }
+		
+		@Override
+		public LDRColor4R getNewInstance(float x, float y, float z)
+		{
+			return new LDRColor4(x, y, z, 1.0f);
+		}
+		
+		@Override
+		public LDRColor4R getNewInstance(float x, float y, float z, float w)
+		{
+			return new LDRColor4(x, y, z, w);
+		}
 	},
 	
 	/**
@@ -87,6 +123,18 @@ public enum LDRColor4Colors implements LDRColor4R
 		public float getUnityR() { return 0; }
 		public float getUnityG() { return 1; }
 		public float getUnityB() { return 0; }
+		
+		@Override
+		public LDRColor4R getNewInstance(float x, float y, float z)
+		{
+			return new LDRColor4(x, y, z, 1.0f);
+		}
+		
+		@Override
+		public LDRColor4R getNewInstance(float x, float y, float z, float w)
+		{
+			return new LDRColor4(x, y, z, w);
+		}
 	},
 	
 	/**
@@ -101,6 +149,18 @@ public enum LDRColor4Colors implements LDRColor4R
 		public float getUnityR() { return 0; }
 		public float getUnityG() { return 0; }
 		public float getUnityB() { return 1; }
+		
+		@Override
+		public LDRColor4R getNewInstance(float x, float y, float z)
+		{
+			return new LDRColor4(x, y, z, 1.0f);
+		}
+		
+		@Override
+		public LDRColor4R getNewInstance(float x, float y, float z, float w)
+		{
+			return new LDRColor4(x, y, z, w);
+		}
 	},
 	
 	/** 
@@ -115,6 +175,18 @@ public enum LDRColor4Colors implements LDRColor4R
 		public float getUnityR() { return 1; }
 		public float getUnityG() { return 1; }
 		public float getUnityB() { return 0; }
+		
+		@Override
+		public LDRColor4R getNewInstance(float x, float y, float z)
+		{
+			return new LDRColor4(x, y, z, 1.0f);
+		}
+		
+		@Override
+		public LDRColor4R getNewInstance(float x, float y, float z, float w)
+		{
+			return new LDRColor4(x, y, z, w);
+		}
 	},
 	
 	/**
@@ -127,6 +199,18 @@ public enum LDRColor4Colors implements LDRColor4R
 		public int getG() { return 0; }
 		public int getB() { return 128; }
 		public float getUnityG() { return 0; }
+		
+		@Override
+		public LDRColor4R getNewInstance(float x, float y, float z)
+		{
+			return new LDRColor4(x, y, z, 1.0f);
+		}
+		
+		@Override
+		public LDRColor4R getNewInstance(float x, float y, float z, float w)
+		{
+			return new LDRColor4(x, y, z, w);
+		}
 	},
 	
 	/** 
@@ -140,6 +224,18 @@ public enum LDRColor4Colors implements LDRColor4R
 		public int getB() { return 0; }
 		public float getUnityR() { return 1; }
 		public float getUnityB() { return 0; }
+		
+		@Override
+		public LDRColor4R getNewInstance(float x, float y, float z)
+		{
+			return new LDRColor4(x, y, z, 1.0f);
+		}
+		
+		@Override
+		public LDRColor4R getNewInstance(float x, float y, float z, float w)
+		{
+			return new LDRColor4(x, y, z, w);
+		}
 	},
 	
 	/**
@@ -153,6 +249,18 @@ public enum LDRColor4Colors implements LDRColor4R
 		public int getB() { return 0; }
 		public float getUnityR() { return 1; }
 		public float getUnityB() { return 0; }
+		
+		@Override
+		public LDRColor4R getNewInstance(float x, float y, float z)
+		{
+			return new LDRColor4(x, y, z, 1.0f);
+		}
+		
+		@Override
+		public LDRColor4R getNewInstance(float x, float y, float z, float w)
+		{
+			return new LDRColor4(x, y, z, w);
+		}
 	},
 	
 	/** 
@@ -164,6 +272,18 @@ public enum LDRColor4Colors implements LDRColor4R
 		public int getR() { return 128; }
 		public int getG() { return 128; }
 		public int getB() { return 128; }
+		
+		@Override
+		public LDRColor4R getNewInstance(float x, float y, float z)
+		{
+			return new LDRColor4(x, y, z, 1.0f);
+		}
+		
+		@Override
+		public LDRColor4R getNewInstance(float x, float y, float z, float w)
+		{
+			return new LDRColor4(x, y, z, w);
+		}
 	},
 ;
 

--- a/barghos-core/src/main/java/org/barghos/core/color/PHDRColor3.java
+++ b/barghos-core/src/main/java/org/barghos/core/color/PHDRColor3.java
@@ -163,4 +163,10 @@ public abstract class PHDRColor3 implements HDRColor3R
 			public int getB() { return b; }
 		};
 	}
+	
+	@Override
+	public PHDRColor3 getNewInstance(float x, float y, float z)
+	{
+		return gen(x, y, z);
+	}
 }

--- a/barghos-core/src/main/java/org/barghos/core/color/PHDRColor4.java
+++ b/barghos-core/src/main/java/org/barghos/core/color/PHDRColor4.java
@@ -169,4 +169,16 @@ public abstract class PHDRColor4 implements HDRColor4R
 			public int getA() { return a; }
 		};
 	}
+	
+	@Override
+	public PHDRColor4 getNewInstance(float x, float y, float z)
+	{
+		return gen(x, y, z, 1.0f);
+	}
+	
+	@Override
+	public PHDRColor4 getNewInstance(float x, float y, float z, float w)
+	{
+		return gen(x, y, z, w);
+	}
 }

--- a/barghos-core/src/main/java/org/barghos/core/color/PLDRColor3.java
+++ b/barghos-core/src/main/java/org/barghos/core/color/PLDRColor3.java
@@ -220,6 +220,12 @@ public abstract class PLDRColor3 implements LDRColor3R
 		};
 	}
 	
+	@Override
+	public PLDRColor3 getNewInstance(float x, float y, float z)
+	{
+		return gen(x, y, z);
+	}
+	
 	/**
 	 * Clamps the float value to unit space from 0.0 to 1.0.
 	 * 

--- a/barghos-core/src/main/java/org/barghos/core/color/PLDRColor4.java
+++ b/barghos-core/src/main/java/org/barghos/core/color/PLDRColor4.java
@@ -246,6 +246,18 @@ public abstract class PLDRColor4 implements LDRColor4R
 		};
 	}
 	
+	@Override
+	public PLDRColor4 getNewInstance(float x, float y, float z)
+	{
+		return gen(x, y, z, 1.0f);
+	}
+	
+	@Override
+	public PLDRColor4 getNewInstance(float x, float y, float z, float w)
+	{
+		return gen(x, y, z, w);
+	}
+	
 	/**
 	 * Clamps the float value to unit space from 0.0 to 1.0.
 	 * 

--- a/barghos-core/src/main/java/org/barghos/core/tuple2/PTup2b.java
+++ b/barghos-core/src/main/java/org/barghos/core/tuple2/PTup2b.java
@@ -27,8 +27,6 @@ import java.util.Map;
 
 import org.barghos.core.api.formatting.FormattableToString;
 import org.barghos.core.api.tuple2.Tup2bR;
-import org.barghos.core.api.util.ArgumentNullException;
-import org.barghos.core.Barghos;
 
 /**
  * Represents a persistent 2-dimensional byte tuple.
@@ -63,11 +61,6 @@ public abstract class PTup2b implements Tup2bR, FormattableToString
 	 */
 	public static PTup2b gen(Tup2bR t)
 	{
-		if(Barghos.BUILD_FLAG__PARAMETER_CHECKS)
-		{
-			if(t == null) throw new ArgumentNullException("t");
-		}
-		
 		return gen(t.getX(), t.getY());
 	}
 	
@@ -145,5 +138,11 @@ public abstract class PTup2b implements Tup2bR, FormattableToString
 		values.put("y", getY());
 		
 		return values;
+	}
+	
+	@Override
+	public PTup2b getNewInstance(byte x, byte y)
+	{
+		return gen(x, y);
 	}
 }

--- a/barghos-core/src/main/java/org/barghos/core/tuple2/PTup2bigd.java
+++ b/barghos-core/src/main/java/org/barghos/core/tuple2/PTup2bigd.java
@@ -28,8 +28,6 @@ import java.util.Map;
 
 import org.barghos.core.api.formatting.FormattableToString;
 import org.barghos.core.api.tuple2.Tup2bigdR;
-import org.barghos.core.api.util.ArgumentNullException;
-import org.barghos.core.Barghos;
 
 /**
  * Represents a persistent 2-dimensional big decimal tuple.
@@ -64,13 +62,6 @@ public abstract class PTup2bigd implements Tup2bigdR, FormattableToString
 	 */
 	public static PTup2bigd gen(Tup2bigdR t)
 	{
-		if(Barghos.BUILD_FLAG__PARAMETER_CHECKS)
-		{
-			if(t == null) throw new ArgumentNullException("t");
-			if(t.getX() == null) throw new ArgumentNullException("t.getX()");
-			if(t.getY() == null) throw new ArgumentNullException("t.getY()");
-		}
-		
 		return gen(t.getX(), t.getY());
 	}
 	
@@ -85,11 +76,6 @@ public abstract class PTup2bigd implements Tup2bigdR, FormattableToString
 	 */
 	public static PTup2bigd gen(BigDecimal value)
 	{
-		if(Barghos.BUILD_FLAG__PARAMETER_CHECKS)
-		{
-			if(value == null) throw new ArgumentNullException("value");
-		}
-		
 		return gen(value, value);
 	}
 	
@@ -105,12 +91,6 @@ public abstract class PTup2bigd implements Tup2bigdR, FormattableToString
 	 */
 	public static PTup2bigd gen(BigDecimal x, BigDecimal y)
 	{
-		if(Barghos.BUILD_FLAG__PARAMETER_CHECKS)
-		{
-			if(x == null) throw new ArgumentNullException("x");
-			if(y == null) throw new ArgumentNullException("y");
-		}
-		
 		return new PTup2bigd()
 		{
 			@Override
@@ -159,5 +139,11 @@ public abstract class PTup2bigd implements Tup2bigdR, FormattableToString
 		values.put("y", getY());
 		
 		return values;
+	}
+	
+	@Override
+	public PTup2bigd getNewInstance(BigDecimal x, BigDecimal y)
+	{
+		return gen(x, y);
 	}
 }

--- a/barghos-core/src/main/java/org/barghos/core/tuple2/PTup2bigi.java
+++ b/barghos-core/src/main/java/org/barghos/core/tuple2/PTup2bigi.java
@@ -28,8 +28,6 @@ import java.util.Map;
 
 import org.barghos.core.api.formatting.FormattableToString;
 import org.barghos.core.api.tuple2.Tup2bigiR;
-import org.barghos.core.api.util.ArgumentNullException;
-import org.barghos.core.Barghos;
 
 /**
  * Represents a persistent 2-dimensional big integer tuple.
@@ -64,13 +62,6 @@ public abstract class PTup2bigi implements Tup2bigiR, FormattableToString
 	 */
 	public static PTup2bigi gen(Tup2bigiR t)
 	{
-		if(Barghos.BUILD_FLAG__PARAMETER_CHECKS)
-		{
-			if(t == null) throw new ArgumentNullException("t");
-			if(t.getX() == null) throw new ArgumentNullException("t.getX()");
-			if(t.getY() == null) throw new ArgumentNullException("t.getY()");
-		}
-		
 		return gen(t.getX(), t.getY());
 	}
 	
@@ -85,11 +76,6 @@ public abstract class PTup2bigi implements Tup2bigiR, FormattableToString
 	 */
 	public static PTup2bigi gen(BigInteger value)
 	{
-		if(Barghos.BUILD_FLAG__PARAMETER_CHECKS)
-		{
-			if(value == null) throw new ArgumentNullException("value");
-		}
-		
 		return gen(value, value);
 	}
 	
@@ -105,12 +91,6 @@ public abstract class PTup2bigi implements Tup2bigiR, FormattableToString
 	 */
 	public static PTup2bigi gen(BigInteger x, BigInteger y)
 	{
-		if(Barghos.BUILD_FLAG__PARAMETER_CHECKS)
-		{
-			if(x == null) throw new ArgumentNullException("x");
-			if(y == null) throw new ArgumentNullException("y");
-		}
-		
 		return new PTup2bigi()
 		{
 			@Override
@@ -159,5 +139,11 @@ public abstract class PTup2bigi implements Tup2bigiR, FormattableToString
 		values.put("y", getY());
 		
 		return values;
+	}
+	
+	@Override
+	public PTup2bigi getNewInstance(BigInteger x, BigInteger y)
+	{
+		return gen(x, y);
 	}
 }

--- a/barghos-core/src/main/java/org/barghos/core/tuple2/PTup2bo.java
+++ b/barghos-core/src/main/java/org/barghos/core/tuple2/PTup2bo.java
@@ -27,8 +27,6 @@ import java.util.Map;
 
 import org.barghos.core.api.formatting.FormattableToString;
 import org.barghos.core.api.tuple2.Tup2boR;
-import org.barghos.core.api.util.ArgumentNullException;
-import org.barghos.core.Barghos;
 
 /**
  * Represents a persistent 2-dimensional boolean tuple.
@@ -63,11 +61,6 @@ public abstract class PTup2bo implements Tup2boR, FormattableToString
 	 */
 	public static PTup2bo gen(Tup2boR t)
 	{
-		if(Barghos.BUILD_FLAG__PARAMETER_CHECKS)
-		{
-			if(t == null) throw new ArgumentNullException("t");
-		}
-		
 		return gen(t.getX(), t.getY());
 	}
 	
@@ -145,5 +138,11 @@ public abstract class PTup2bo implements Tup2boR, FormattableToString
 		values.put("y", getY());
 		
 		return values;
+	}
+	
+	@Override
+	public PTup2bo getNewInstance(boolean x, boolean y)
+	{
+		return gen(x, y);
 	}
 }

--- a/barghos-core/src/main/java/org/barghos/core/tuple2/PTup2c.java
+++ b/barghos-core/src/main/java/org/barghos/core/tuple2/PTup2c.java
@@ -27,8 +27,6 @@ import java.util.Map;
 
 import org.barghos.core.api.formatting.FormattableToString;
 import org.barghos.core.api.tuple2.Tup2cR;
-import org.barghos.core.api.util.ArgumentNullException;
-import org.barghos.core.Barghos;
 
 /**
  * Represents a persistent 2-dimensional char tuple.
@@ -63,11 +61,6 @@ public abstract class PTup2c implements Tup2cR, FormattableToString
 	 */
 	public static PTup2c gen(Tup2cR t)
 	{
-		if(Barghos.BUILD_FLAG__PARAMETER_CHECKS)
-		{
-			if(t == null) throw new ArgumentNullException("t");
-		}
-		
 		return gen(t.getX(), t.getY());
 	}
 	
@@ -145,5 +138,11 @@ public abstract class PTup2c implements Tup2cR, FormattableToString
 		values.put("y", getY());
 		
 		return values;
+	}
+	
+	@Override
+	public PTup2c getNewInstance(char x, char y)
+	{
+		return gen(x, y);
 	}
 }

--- a/barghos-core/src/main/java/org/barghos/core/tuple2/PTup2d.java
+++ b/barghos-core/src/main/java/org/barghos/core/tuple2/PTup2d.java
@@ -27,8 +27,6 @@ import java.util.Map;
 
 import org.barghos.core.api.formatting.FormattableToString;
 import org.barghos.core.api.tuple2.Tup2dR;
-import org.barghos.core.api.util.ArgumentNullException;
-import org.barghos.core.Barghos;
 
 /**
  * Represents a persistent 2-dimensional double tuple.
@@ -63,11 +61,6 @@ public abstract class PTup2d implements Tup2dR, FormattableToString
 	 */
 	public static PTup2d gen(Tup2dR t)
 	{
-		if(Barghos.BUILD_FLAG__PARAMETER_CHECKS)
-		{
-			if(t == null) throw new ArgumentNullException("t");
-		}
-		
 		return gen(t.getX(), t.getY());
 	}
 	
@@ -146,5 +139,11 @@ public abstract class PTup2d implements Tup2dR, FormattableToString
 		values.put("y", getY());
 		
 		return values;
+	}
+	
+	@Override
+	public PTup2d getNewInstance(double x, double y)
+	{
+		return gen(x, y);
 	}
 }

--- a/barghos-core/src/main/java/org/barghos/core/tuple2/PTup2f.java
+++ b/barghos-core/src/main/java/org/barghos/core/tuple2/PTup2f.java
@@ -27,8 +27,6 @@ import java.util.Map;
 
 import org.barghos.core.api.formatting.FormattableToString;
 import org.barghos.core.api.tuple2.Tup2fR;
-import org.barghos.core.api.util.ArgumentNullException;
-import org.barghos.core.Barghos;
 
 /**
  * Represents a persistent 2-dimensional float tuple.
@@ -63,11 +61,6 @@ public abstract class PTup2f implements Tup2fR, FormattableToString
 	 */
 	public static PTup2f gen(Tup2fR t)
 	{
-		if(Barghos.BUILD_FLAG__PARAMETER_CHECKS)
-		{
-			if(t == null) throw new ArgumentNullException("t");
-		}
-		
 		return gen(t.getX(), t.getY());
 	}
 	
@@ -106,7 +99,7 @@ public abstract class PTup2f implements Tup2fR, FormattableToString
 			public float getY() { return y; }
 		};
 	}
-
+	
 	@Override
 	public int hashCode()
 	{
@@ -144,5 +137,11 @@ public abstract class PTup2f implements Tup2fR, FormattableToString
 		values.put("y", getY());
 		
 		return values;
+	}
+	
+	@Override
+	public PTup2f getNewInstance(float x, float y)
+	{
+		return gen(x, y);
 	}
 }

--- a/barghos-core/src/main/java/org/barghos/core/tuple2/PTup2i.java
+++ b/barghos-core/src/main/java/org/barghos/core/tuple2/PTup2i.java
@@ -27,8 +27,6 @@ import java.util.Map;
 
 import org.barghos.core.api.formatting.FormattableToString;
 import org.barghos.core.api.tuple2.Tup2iR;
-import org.barghos.core.api.util.ArgumentNullException;
-import org.barghos.core.Barghos;
 
 /**
  * Represents a persistent 2-dimensional integer tuple.
@@ -63,11 +61,6 @@ public abstract class PTup2i implements Tup2iR, FormattableToString
 	 */
 	public static PTup2i gen(Tup2iR t)
 	{
-		if(Barghos.BUILD_FLAG__PARAMETER_CHECKS)
-		{
-			if(t == null) throw new ArgumentNullException("t");
-		}
-		
 		return gen(t.getX(), t.getY());
 	}
 	
@@ -145,5 +138,11 @@ public abstract class PTup2i implements Tup2iR, FormattableToString
 		values.put("y", getY());
 		
 		return values;
+	}
+	
+	@Override
+	public PTup2i getNewInstance(int x, int y)
+	{
+		return gen(x, y);
 	}
 }

--- a/barghos-core/src/main/java/org/barghos/core/tuple2/PTup2l.java
+++ b/barghos-core/src/main/java/org/barghos/core/tuple2/PTup2l.java
@@ -27,8 +27,6 @@ import java.util.Map;
 
 import org.barghos.core.api.formatting.FormattableToString;
 import org.barghos.core.api.tuple2.Tup2lR;
-import org.barghos.core.api.util.ArgumentNullException;
-import org.barghos.core.Barghos;
 
 /**
  * Represents a persistent 2-dimensional byte tuple.
@@ -63,11 +61,6 @@ public abstract class PTup2l implements Tup2lR, FormattableToString
 	 */
 	public static PTup2l gen(Tup2lR t)
 	{
-		if(Barghos.BUILD_FLAG__PARAMETER_CHECKS)
-		{
-			if(t == null) throw new ArgumentNullException("t");
-		}
-		
 		return gen(t.getX(), t.getY());
 	}
 	
@@ -145,5 +138,11 @@ public abstract class PTup2l implements Tup2lR, FormattableToString
 		values.put("y", getY());
 		
 		return values;
+	}
+	
+	@Override
+	public PTup2l getNewInstance(long x, long y)
+	{
+		return gen(x, y);
 	}
 }

--- a/barghos-core/src/main/java/org/barghos/core/tuple2/PTup2o.java
+++ b/barghos-core/src/main/java/org/barghos/core/tuple2/PTup2o.java
@@ -27,8 +27,6 @@ import java.util.Map;
 
 import org.barghos.core.api.formatting.FormattableToString;
 import org.barghos.core.api.tuple2.Tup2oR;
-import org.barghos.core.api.util.ArgumentNullException;
-import org.barghos.core.Barghos;
 
 /**
  * Represents a persistent 2-dimensional object tuple.
@@ -66,13 +64,6 @@ public abstract class PTup2o<X,Y> implements Tup2oR<X,Y>, FormattableToString
 	 */
 	public static <X,Y> PTup2o<X,Y> gen(Tup2oR<X,Y> t)
 	{
-		if(Barghos.BUILD_FLAG__PARAMETER_CHECKS)
-		{
-			if(t == null) throw new ArgumentNullException("t");
-			if(t.getX() == null) throw new ArgumentNullException("t.getX()");
-			if(t.getY() == null) throw new ArgumentNullException("t.getY()");
-		}
-		
 		return gen(t.getX(), t.getY());
 	}
 	
@@ -91,12 +82,6 @@ public abstract class PTup2o<X,Y> implements Tup2oR<X,Y>, FormattableToString
 	 */
 	public static <X,Y> PTup2o<X,Y> gen(X x, Y y)
 	{
-		if(Barghos.BUILD_FLAG__PARAMETER_CHECKS)
-		{
-			if(x == null) throw new ArgumentNullException("x");
-			if(y == null) throw new ArgumentNullException("y");
-		}
-		
 		return new PTup2o<>()
 		{
 			@Override
@@ -146,5 +131,11 @@ public abstract class PTup2o<X,Y> implements Tup2oR<X,Y>, FormattableToString
 		values.put("y", getY());
 		
 		return values;
+	}
+	
+	@Override
+	public PTup2o<X,Y> getNewInstance(X x, Y y)
+	{
+		return gen(x, y);
 	}
 }

--- a/barghos-core/src/main/java/org/barghos/core/tuple2/PTup2obj.java
+++ b/barghos-core/src/main/java/org/barghos/core/tuple2/PTup2obj.java
@@ -27,8 +27,6 @@ import java.util.Map;
 
 import org.barghos.core.api.formatting.FormattableToString;
 import org.barghos.core.api.tuple2.Tup2objR;
-import org.barghos.core.api.util.ArgumentNullException;
-import org.barghos.core.Barghos;
 
 /**
  * Represents a persistent 2-dimensional string tuple.
@@ -63,13 +61,6 @@ public abstract class PTup2obj implements Tup2objR, FormattableToString
 	 */
 	public static PTup2obj gen(Tup2objR t)
 	{
-		if(Barghos.BUILD_FLAG__PARAMETER_CHECKS)
-		{
-			if(t == null) throw new ArgumentNullException("t");
-			if(t.getX() == null) throw new ArgumentNullException("t.getX()");
-			if(t.getY() == null) throw new ArgumentNullException("t.getY()");
-		}
-		
 		return gen(t.getX(), t.getY());
 	}
 	
@@ -84,11 +75,6 @@ public abstract class PTup2obj implements Tup2objR, FormattableToString
 	 */
 	public static PTup2obj gen(Object value)
 	{
-		if(Barghos.BUILD_FLAG__PARAMETER_CHECKS)
-		{
-			if(value == null) throw new ArgumentNullException("value");
-		}
-		
 		return gen(value, value);
 	}
 	
@@ -104,12 +90,6 @@ public abstract class PTup2obj implements Tup2objR, FormattableToString
 	 */
 	public static PTup2obj gen(Object x, Object y)
 	{
-		if(Barghos.BUILD_FLAG__PARAMETER_CHECKS)
-		{
-			if(x == null) throw new ArgumentNullException("x");
-			if(y == null) throw new ArgumentNullException("y");
-		}
-		
 		return new PTup2obj()
 		{
 			@Override
@@ -158,5 +138,11 @@ public abstract class PTup2obj implements Tup2objR, FormattableToString
 		values.put("y", getY());
 		
 		return values;
+	}
+	
+	@Override
+	public PTup2obj getNewInstance(Object x, Object y)
+	{
+		return gen(x, y);
 	}
 }

--- a/barghos-core/src/main/java/org/barghos/core/tuple2/PTup2s.java
+++ b/barghos-core/src/main/java/org/barghos/core/tuple2/PTup2s.java
@@ -27,8 +27,6 @@ import java.util.Map;
 
 import org.barghos.core.api.formatting.FormattableToString;
 import org.barghos.core.api.tuple2.Tup2sR;
-import org.barghos.core.api.util.ArgumentNullException;
-import org.barghos.core.Barghos;
 
 /**
  * Represents a persistent 2-dimensional short tuple.
@@ -63,11 +61,6 @@ public abstract class PTup2s implements Tup2sR, FormattableToString
 	 */
 	public static PTup2s gen(Tup2sR t)
 	{
-		if(Barghos.BUILD_FLAG__PARAMETER_CHECKS)
-		{
-			if(t == null) throw new ArgumentNullException("t");
-		}
-		
 		return gen(t.getX(), t.getY());
 	}
 	
@@ -145,5 +138,11 @@ public abstract class PTup2s implements Tup2sR, FormattableToString
 		values.put("y", getY());
 		
 		return values;
+	}
+	
+	@Override
+	public PTup2s getNewInstance(short x, short y)
+	{
+		return gen(x, y);
 	}
 }

--- a/barghos-core/src/main/java/org/barghos/core/tuple2/PTup2str.java
+++ b/barghos-core/src/main/java/org/barghos/core/tuple2/PTup2str.java
@@ -27,8 +27,6 @@ import java.util.Map;
 
 import org.barghos.core.api.formatting.FormattableToString;
 import org.barghos.core.api.tuple2.Tup2strR;
-import org.barghos.core.api.util.ArgumentNullException;
-import org.barghos.core.Barghos;
 
 /**
  * Represents a persistent 2-dimensional string tuple.
@@ -63,13 +61,6 @@ public abstract class PTup2str implements Tup2strR, FormattableToString
 	 */
 	public static PTup2str gen(Tup2strR t)
 	{
-		if(Barghos.BUILD_FLAG__PARAMETER_CHECKS)
-		{
-			if(t == null) throw new ArgumentNullException("t");
-			if(t.getX() == null) throw new ArgumentNullException("t.getX()");
-			if(t.getY() == null) throw new ArgumentNullException("t.getY()");
-		}
-		
 		return gen(t.getX(), t.getY());
 	}
 	
@@ -84,11 +75,6 @@ public abstract class PTup2str implements Tup2strR, FormattableToString
 	 */
 	public static PTup2str gen(String value)
 	{
-		if(Barghos.BUILD_FLAG__PARAMETER_CHECKS)
-		{
-			if(value == null) throw new ArgumentNullException("value");
-		}
-		
 		return gen(value, value);
 	}
 	
@@ -104,12 +90,6 @@ public abstract class PTup2str implements Tup2strR, FormattableToString
 	 */
 	public static PTup2str gen(String x, String y)
 	{
-		if(Barghos.BUILD_FLAG__PARAMETER_CHECKS)
-		{
-			if(x == null) throw new ArgumentNullException("x");
-			if(y == null) throw new ArgumentNullException("y");
-		}
-		
 		return new PTup2str()
 		{
 			@Override
@@ -158,5 +138,11 @@ public abstract class PTup2str implements Tup2strR, FormattableToString
 		values.put("y", getY());
 		
 		return values;
+	}
+	
+	@Override
+	public PTup2str getNewInstance(String x, String y)
+	{
+		return gen(x, y);
 	}
 }

--- a/barghos-core/src/main/java/org/barghos/core/tuple2/Tup2b.java
+++ b/barghos-core/src/main/java/org/barghos/core/tuple2/Tup2b.java
@@ -29,8 +29,6 @@ import java.util.Map;
 import org.barghos.core.api.formatting.FormattableToString;
 import org.barghos.core.api.tuple2.Tup2bR;
 import org.barghos.core.api.tuple2.Tup2bRW;
-import org.barghos.core.api.util.ArgumentNullException;
-import org.barghos.core.Barghos;
 
 /**
  * This class represents a 2-dimensional byte tuple.
@@ -77,11 +75,6 @@ public class Tup2b implements Tup2bRW, Serializable, FormattableToString
 	 */
 	public Tup2b(Tup2bR t)
 	{
-		if(Barghos.BUILD_FLAG__PARAMETER_CHECKS)
-		{
-			if(t == null) throw new ArgumentNullException("t");
-		}
-		
 		set(t);
 	}
 	
@@ -141,11 +134,6 @@ public class Tup2b implements Tup2bRW, Serializable, FormattableToString
 	@Override
 	public Tup2b set(Tup2bR t)
 	{
-		if(Barghos.BUILD_FLAG__PARAMETER_CHECKS)
-		{
-			if(t == null) throw new ArgumentNullException("t");
-		}
-		
 		return set(t.getX(), t.getY());
 	}
 	
@@ -204,5 +192,11 @@ public class Tup2b implements Tup2bRW, Serializable, FormattableToString
 		values.put("y", getY());
 		
 		return values;
+	}
+	
+	@Override
+	public Tup2b getNewInstance(byte x, byte y)
+	{
+		return new Tup2b(x, y);
 	}
 }

--- a/barghos-core/src/main/java/org/barghos/core/tuple2/Tup2bigd.java
+++ b/barghos-core/src/main/java/org/barghos/core/tuple2/Tup2bigd.java
@@ -30,8 +30,6 @@ import java.util.Map;
 import org.barghos.core.api.formatting.FormattableToString;
 import org.barghos.core.api.tuple2.Tup2bigdR;
 import org.barghos.core.api.tuple2.Tup2bigdRW;
-import org.barghos.core.api.util.ArgumentNullException;
-import org.barghos.core.Barghos;
 
 /**
  * This class represents a 2-dimensional big decimal tuple.
@@ -80,13 +78,6 @@ public class Tup2bigd implements Tup2bigdRW, Serializable, FormattableToString
 	 */
 	public Tup2bigd(Tup2bigdR t)
 	{
-		if(Barghos.BUILD_FLAG__PARAMETER_CHECKS)
-		{
-			if(t == null) throw new ArgumentNullException("t");
-			if(t.getX() == null) throw new ArgumentNullException("t.getX()");
-			if(t.getY() == null) throw new ArgumentNullException("t.getY()");
-		}
-		
 		set(t);
 	}
 	
@@ -99,11 +90,6 @@ public class Tup2bigd implements Tup2bigdRW, Serializable, FormattableToString
 	 */
 	public Tup2bigd(BigDecimal value)
 	{
-		if(Barghos.BUILD_FLAG__PARAMETER_CHECKS)
-		{
-			if(value == null) throw new ArgumentNullException("value");
-		}
-		
 		set(value);
 	}
 	
@@ -117,12 +103,6 @@ public class Tup2bigd implements Tup2bigdRW, Serializable, FormattableToString
 	 */
 	public Tup2bigd(BigDecimal x, BigDecimal y)
 	{
-		if(Barghos.BUILD_FLAG__PARAMETER_CHECKS)
-		{
-			if(x == null) throw new ArgumentNullException("x");
-			if(y == null) throw new ArgumentNullException("y");
-		}
-		
 		set(x, y);
 	}
 	
@@ -141,11 +121,6 @@ public class Tup2bigd implements Tup2bigdRW, Serializable, FormattableToString
 	@Override
 	public Tup2bigd setX(BigDecimal x)
 	{
-		if(Barghos.BUILD_FLAG__PARAMETER_CHECKS)
-		{
-			if(x == null) throw new ArgumentNullException("x");
-		}
-		
 		this.x = x;
 		
 		return this;
@@ -154,11 +129,6 @@ public class Tup2bigd implements Tup2bigdRW, Serializable, FormattableToString
 	@Override
 	public Tup2bigd setY(BigDecimal y)
 	{
-		if(Barghos.BUILD_FLAG__PARAMETER_CHECKS)
-		{
-			if(y == null) throw new ArgumentNullException("y");
-		}
-		
 		this.y = y;
 		
 		return this;
@@ -167,36 +137,18 @@ public class Tup2bigd implements Tup2bigdRW, Serializable, FormattableToString
 	@Override
 	public Tup2bigd set(Tup2bigdR t)
 	{
-		if(Barghos.BUILD_FLAG__PARAMETER_CHECKS)
-		{
-			if(t == null) throw new ArgumentNullException("t");
-			if(t.getX() == null) throw new ArgumentNullException("t.getX()");
-			if(t.getY() == null) throw new ArgumentNullException("t.getY()");
-		}
-		
 		return set(t.getX(), t.getY());
 	}
 	
 	@Override
 	public Tup2bigd set(BigDecimal value)
 	{
-		if(Barghos.BUILD_FLAG__PARAMETER_CHECKS)
-		{
-			if(value == null) throw new ArgumentNullException("value");
-		}
-		
 		return set(value, value);
 	}
 	
 	@Override
 	public Tup2bigd set(BigDecimal x, BigDecimal y)
 	{
-		if(Barghos.BUILD_FLAG__PARAMETER_CHECKS)
-		{
-			if(x == null) throw new ArgumentNullException("x");
-			if(y == null) throw new ArgumentNullException("y");
-		}
-		
 		return setX(x).setY(y);
 	}
 	
@@ -243,5 +195,11 @@ public class Tup2bigd implements Tup2bigdRW, Serializable, FormattableToString
 		values.put("y", getY());
 		
 		return values;
+	}
+
+	@Override
+	public Tup2bigd getNewInstance(BigDecimal x, BigDecimal y)
+	{
+		return new Tup2bigd(x, y);
 	}
 }

--- a/barghos-core/src/main/java/org/barghos/core/tuple2/Tup2bigi.java
+++ b/barghos-core/src/main/java/org/barghos/core/tuple2/Tup2bigi.java
@@ -30,8 +30,6 @@ import java.util.Map;
 import org.barghos.core.api.formatting.FormattableToString;
 import org.barghos.core.api.tuple2.Tup2bigiR;
 import org.barghos.core.api.tuple2.Tup2bigiRW;
-import org.barghos.core.api.util.ArgumentNullException;
-import org.barghos.core.Barghos;
 
 /**
  * This class represents a 2-dimensional big integer tuple.
@@ -80,13 +78,6 @@ public class Tup2bigi implements Tup2bigiRW, Serializable, FormattableToString
 	 */
 	public Tup2bigi(Tup2bigiR t)
 	{
-		if(Barghos.BUILD_FLAG__PARAMETER_CHECKS)
-		{
-			if(t == null) throw new ArgumentNullException("t");
-			if(t.getX() == null) throw new ArgumentNullException("t.getX()");
-			if(t.getY() == null) throw new ArgumentNullException("t.getY()");
-		}
-		
 		set(t);
 	}
 	
@@ -99,11 +90,6 @@ public class Tup2bigi implements Tup2bigiRW, Serializable, FormattableToString
 	 */
 	public Tup2bigi(BigInteger value)
 	{
-		if(Barghos.BUILD_FLAG__PARAMETER_CHECKS)
-		{
-			if(value == null) throw new ArgumentNullException("value");
-		}
-		
 		set(value);
 	}
 	
@@ -117,12 +103,6 @@ public class Tup2bigi implements Tup2bigiRW, Serializable, FormattableToString
 	 */
 	public Tup2bigi(BigInteger x, BigInteger y)
 	{
-		if(Barghos.BUILD_FLAG__PARAMETER_CHECKS)
-		{
-			if(x == null) throw new ArgumentNullException("x");
-			if(y == null) throw new ArgumentNullException("y");
-		}
-		
 		set(x, y);
 	}
 	
@@ -141,11 +121,6 @@ public class Tup2bigi implements Tup2bigiRW, Serializable, FormattableToString
 	@Override
 	public Tup2bigi setX(BigInteger x)
 	{
-		if(Barghos.BUILD_FLAG__PARAMETER_CHECKS)
-		{
-			if(x == null) throw new ArgumentNullException("x");
-		}
-		
 		this.x = x;
 		
 		return this;
@@ -154,11 +129,6 @@ public class Tup2bigi implements Tup2bigiRW, Serializable, FormattableToString
 	@Override
 	public Tup2bigi setY(BigInteger y)
 	{
-		if(Barghos.BUILD_FLAG__PARAMETER_CHECKS)
-		{
-			if(y == null) throw new ArgumentNullException("y");
-		}
-		
 		this.y = y;
 		
 		return this;
@@ -167,36 +137,18 @@ public class Tup2bigi implements Tup2bigiRW, Serializable, FormattableToString
 	@Override
 	public Tup2bigi set(Tup2bigiR t)
 	{
-		if(Barghos.BUILD_FLAG__PARAMETER_CHECKS)
-		{
-			if(t == null) throw new ArgumentNullException("t");
-			if(t.getX() == null) throw new ArgumentNullException("t.getX()");
-			if(t.getY() == null) throw new ArgumentNullException("t.getY()");
-		}
-		
 		return set(t.getX(), t.getY());
 	}
 	
 	@Override
 	public Tup2bigi set(BigInteger value)
 	{
-		if(Barghos.BUILD_FLAG__PARAMETER_CHECKS)
-		{
-			if(value == null) throw new ArgumentNullException("value");
-		}
-		
 		return set(value, value);
 	}
 	
 	@Override
 	public Tup2bigi set(BigInteger x, BigInteger y)
 	{
-		if(Barghos.BUILD_FLAG__PARAMETER_CHECKS)
-		{
-			if(x == null) throw new ArgumentNullException("x");
-			if(y == null) throw new ArgumentNullException("y");
-		}
-		
 		return setX(x).setY(y);
 	}
 	
@@ -243,5 +195,11 @@ public class Tup2bigi implements Tup2bigiRW, Serializable, FormattableToString
 		values.put("y", getY());
 		
 		return values;
+	}
+
+	@Override
+	public Tup2bigi getNewInstance(BigInteger x, BigInteger y)
+	{
+		return new Tup2bigi(x, y);
 	}
 }

--- a/barghos-core/src/main/java/org/barghos/core/tuple2/Tup2bo.java
+++ b/barghos-core/src/main/java/org/barghos/core/tuple2/Tup2bo.java
@@ -29,8 +29,6 @@ import java.util.Map;
 import org.barghos.core.api.formatting.FormattableToString;
 import org.barghos.core.api.tuple2.Tup2boR;
 import org.barghos.core.api.tuple2.Tup2boRW;
-import org.barghos.core.api.util.ArgumentNullException;
-import org.barghos.core.Barghos;
 
 /**
  * This class represents a 2-dimensional boolean tuple.
@@ -77,11 +75,6 @@ public class Tup2bo implements Tup2boRW, Serializable, FormattableToString
 	 */
 	public Tup2bo(Tup2boR t)
 	{
-		if(Barghos.BUILD_FLAG__PARAMETER_CHECKS)
-		{
-			if(t == null) throw new ArgumentNullException("t");
-		}
-		
 		set(t);
 	}
 	
@@ -141,11 +134,6 @@ public class Tup2bo implements Tup2boRW, Serializable, FormattableToString
 	@Override
 	public Tup2bo set(Tup2boR t)
 	{
-		if(Barghos.BUILD_FLAG__PARAMETER_CHECKS)
-		{
-			if(t == null) throw new ArgumentNullException("t");
-		}
-		
 		return set(t.getX(), t.getY());
 	}
 	
@@ -204,5 +192,11 @@ public class Tup2bo implements Tup2boRW, Serializable, FormattableToString
 		values.put("y", getY());
 		
 		return values;
+	}
+	
+	@Override
+	public Tup2bo getNewInstance(boolean x, boolean y)
+	{
+		return new Tup2bo(x, y);
 	}
 }

--- a/barghos-core/src/main/java/org/barghos/core/tuple2/Tup2c.java
+++ b/barghos-core/src/main/java/org/barghos/core/tuple2/Tup2c.java
@@ -29,8 +29,6 @@ import java.util.Map;
 import org.barghos.core.api.formatting.FormattableToString;
 import org.barghos.core.api.tuple2.Tup2cR;
 import org.barghos.core.api.tuple2.Tup2cRW;
-import org.barghos.core.api.util.ArgumentNullException;
-import org.barghos.core.Barghos;
 
 /**
  * This class represents a 2-dimensional char tuple.
@@ -77,11 +75,6 @@ public class Tup2c implements Tup2cRW, Serializable, FormattableToString
 	 */
 	public Tup2c(Tup2cR t)
 	{
-		if(Barghos.BUILD_FLAG__PARAMETER_CHECKS)
-		{
-			if(t == null) throw new ArgumentNullException("t");
-		}
-		
 		set(t);
 	}
 	
@@ -141,11 +134,6 @@ public class Tup2c implements Tup2cRW, Serializable, FormattableToString
 	@Override
 	public Tup2c set(Tup2cR t)
 	{
-		if(Barghos.BUILD_FLAG__PARAMETER_CHECKS)
-		{
-			if(t == null) throw new ArgumentNullException("t");
-		}
-		
 		return set(t.getX(), t.getY());
 	}
 	
@@ -204,5 +192,11 @@ public class Tup2c implements Tup2cRW, Serializable, FormattableToString
 		values.put("y", getY());
 		
 		return values;
+	}
+	
+	@Override
+	public Tup2c getNewInstance(char x, char y)
+	{
+		return new Tup2c(x, y);
 	}
 }

--- a/barghos-core/src/main/java/org/barghos/core/tuple2/Tup2d.java
+++ b/barghos-core/src/main/java/org/barghos/core/tuple2/Tup2d.java
@@ -29,8 +29,6 @@ import java.util.Map;
 import org.barghos.core.api.formatting.FormattableToString;
 import org.barghos.core.api.tuple2.Tup2dR;
 import org.barghos.core.api.tuple2.Tup2dRW;
-import org.barghos.core.api.util.ArgumentNullException;
-import org.barghos.core.Barghos;
 
 /**
  * This class represents a 2-dimensional double tuple.
@@ -77,11 +75,6 @@ public class Tup2d implements Tup2dRW, Serializable, FormattableToString
 	 */
 	public Tup2d(Tup2dR t)
 	{
-		if(Barghos.BUILD_FLAG__PARAMETER_CHECKS)
-		{
-			if(t == null) throw new ArgumentNullException("t");
-		}
-		
 		set(t);
 	}
 	
@@ -141,11 +134,6 @@ public class Tup2d implements Tup2dRW, Serializable, FormattableToString
 	@Override
 	public Tup2d set(Tup2dR t)
 	{
-		if(Barghos.BUILD_FLAG__PARAMETER_CHECKS)
-		{
-			if(t == null) throw new ArgumentNullException("t");
-		}
-		
 		return set(t.getX(), t.getY());
 	}
 	
@@ -206,5 +194,11 @@ public class Tup2d implements Tup2dRW, Serializable, FormattableToString
 		values.put("y", getY());
 		
 		return values;
+	}
+	
+	@Override
+	public Tup2d getNewInstance(double x, double y)
+	{
+		return new Tup2d(x, y);
 	}
 }

--- a/barghos-core/src/main/java/org/barghos/core/tuple2/Tup2f.java
+++ b/barghos-core/src/main/java/org/barghos/core/tuple2/Tup2f.java
@@ -29,8 +29,6 @@ import java.util.Map;
 import org.barghos.core.api.formatting.FormattableToString;
 import org.barghos.core.api.tuple2.Tup2fR;
 import org.barghos.core.api.tuple2.Tup2fRW;
-import org.barghos.core.api.util.ArgumentNullException;
-import org.barghos.core.Barghos;
 
 /**
  * This class represents a 2-dimensional float tuple.
@@ -77,11 +75,6 @@ public class Tup2f implements Tup2fRW, Serializable, FormattableToString
 	 */
 	public Tup2f(Tup2fR t)
 	{
-		if(Barghos.BUILD_FLAG__PARAMETER_CHECKS)
-		{
-			if(t == null) throw new ArgumentNullException("t");
-		}
-		
 		set(t);
 	}
 	
@@ -141,11 +134,6 @@ public class Tup2f implements Tup2fRW, Serializable, FormattableToString
 	@Override
 	public Tup2f set(Tup2fR t)
 	{
-		if(Barghos.BUILD_FLAG__PARAMETER_CHECKS)
-		{
-			if(t == null) throw new ArgumentNullException("t");
-		}
-		
 		return set(t.getX(), t.getY());
 	}
 	
@@ -204,5 +192,11 @@ public class Tup2f implements Tup2fRW, Serializable, FormattableToString
 		values.put("y", getY());
 		
 		return values;
+	}
+	
+	@Override
+	public Tup2f getNewInstance(float x, float y)
+	{
+		return new Tup2f(x, y);
 	}
 }

--- a/barghos-core/src/main/java/org/barghos/core/tuple2/Tup2i.java
+++ b/barghos-core/src/main/java/org/barghos/core/tuple2/Tup2i.java
@@ -29,8 +29,6 @@ import java.util.Map;
 import org.barghos.core.api.formatting.FormattableToString;
 import org.barghos.core.api.tuple2.Tup2iR;
 import org.barghos.core.api.tuple2.Tup2iRW;
-import org.barghos.core.api.util.ArgumentNullException;
-import org.barghos.core.Barghos;
 
 /**
  * This class represents a 2-dimensional integer tuple.
@@ -77,11 +75,6 @@ public class Tup2i implements Tup2iRW, Serializable, FormattableToString
 	 */
 	public Tup2i(Tup2iR t)
 	{
-		if(Barghos.BUILD_FLAG__PARAMETER_CHECKS)
-		{
-			if(t == null) throw new ArgumentNullException("t");
-		}
-		
 		set(t);
 	}
 	
@@ -141,11 +134,6 @@ public class Tup2i implements Tup2iRW, Serializable, FormattableToString
 	@Override
 	public Tup2i set(Tup2iR t)
 	{
-		if(Barghos.BUILD_FLAG__PARAMETER_CHECKS)
-		{
-			if(t == null) throw new ArgumentNullException("t");
-		}
-		
 		return set(t.getX(), t.getY());
 	}
 	
@@ -204,5 +192,11 @@ public class Tup2i implements Tup2iRW, Serializable, FormattableToString
 		values.put("y", getY());
 		
 		return values;
+	}
+	
+	@Override
+	public Tup2i getNewInstance(int x, int y)
+	{
+		return new Tup2i(x, y);
 	}
 }

--- a/barghos-core/src/main/java/org/barghos/core/tuple2/Tup2l.java
+++ b/barghos-core/src/main/java/org/barghos/core/tuple2/Tup2l.java
@@ -29,8 +29,6 @@ import java.util.Map;
 import org.barghos.core.api.formatting.FormattableToString;
 import org.barghos.core.api.tuple2.Tup2lR;
 import org.barghos.core.api.tuple2.Tup2lRW;
-import org.barghos.core.api.util.ArgumentNullException;
-import org.barghos.core.Barghos;
 
 /**
  * This class represents a 2-dimensional long tuple.
@@ -77,11 +75,6 @@ public class Tup2l implements Tup2lRW, Serializable, FormattableToString
 	 */
 	public Tup2l(Tup2lR t)
 	{
-		if(Barghos.BUILD_FLAG__PARAMETER_CHECKS)
-		{
-			if(t == null) throw new ArgumentNullException("t");
-		}
-		
 		set(t);
 	}
 	
@@ -141,11 +134,6 @@ public class Tup2l implements Tup2lRW, Serializable, FormattableToString
 	@Override
 	public Tup2l set(Tup2lR t)
 	{
-		if(Barghos.BUILD_FLAG__PARAMETER_CHECKS)
-		{
-			if(t == null) throw new ArgumentNullException("t");
-		}
-		
 		return set(t.getX(), t.getY());
 	}
 	
@@ -204,5 +192,11 @@ public class Tup2l implements Tup2lRW, Serializable, FormattableToString
 		values.put("y", getY());
 		
 		return values;
+	}
+	
+	@Override
+	public Tup2l getNewInstance(long x, long y)
+	{
+		return new Tup2l(x, y);
 	}
 }

--- a/barghos-core/src/main/java/org/barghos/core/tuple2/Tup2o.java
+++ b/barghos-core/src/main/java/org/barghos/core/tuple2/Tup2o.java
@@ -28,8 +28,6 @@ import java.util.Map;
 import org.barghos.core.api.formatting.FormattableToString;
 import org.barghos.core.api.tuple2.Tup2oR;
 import org.barghos.core.api.tuple2.Tup2oRW;
-import org.barghos.core.api.util.ArgumentNullException;
-import org.barghos.core.Barghos;
 
 /**
  * This class represents a 2-dimensional object tuple.
@@ -70,13 +68,6 @@ public class Tup2o<X,Y> implements Tup2oRW<X,Y>, FormattableToString
 	 */
 	public Tup2o(Tup2oR<X,Y> t)
 	{
-		if(Barghos.BUILD_FLAG__PARAMETER_CHECKS)
-		{
-			if(t == null) throw new ArgumentNullException("t");
-			if(t.getX() == null) throw new ArgumentNullException("t.getX()");
-			if(t.getY() == null) throw new ArgumentNullException("t.getY()");
-		}
-		
 		set(t);
 	}
 	
@@ -90,12 +81,6 @@ public class Tup2o<X,Y> implements Tup2oRW<X,Y>, FormattableToString
 	 */
 	public Tup2o(X x, Y y)
 	{
-		if(Barghos.BUILD_FLAG__PARAMETER_CHECKS)
-		{
-			if(x == null) throw new ArgumentNullException("x");
-			if(y == null) throw new ArgumentNullException("y");
-		}
-		
 		set(x, y);
 	}
 	
@@ -114,11 +99,6 @@ public class Tup2o<X,Y> implements Tup2oRW<X,Y>, FormattableToString
 	@Override
 	public Tup2o<X,Y> setX(X x)
 	{
-		if(Barghos.BUILD_FLAG__PARAMETER_CHECKS)
-		{
-			if(x == null) throw new ArgumentNullException("x");
-		}
-		
 		this.x = x;
 		
 		return this;
@@ -127,11 +107,6 @@ public class Tup2o<X,Y> implements Tup2oRW<X,Y>, FormattableToString
 	@Override
 	public Tup2o<X,Y> setY(Y y)
 	{
-		if(Barghos.BUILD_FLAG__PARAMETER_CHECKS)
-		{
-			if(y == null) throw new ArgumentNullException("y");
-		}
-		
 		this.y = y;
 		
 		return this;
@@ -140,25 +115,12 @@ public class Tup2o<X,Y> implements Tup2oRW<X,Y>, FormattableToString
 	@Override
 	public Tup2o<X,Y> set(Tup2oR<X,Y> t)
 	{
-		if(Barghos.BUILD_FLAG__PARAMETER_CHECKS)
-		{
-			if(t == null) throw new ArgumentNullException("t");
-			if(t.getX() == null) throw new ArgumentNullException("t.getX()");
-			if(t.getY() == null) throw new ArgumentNullException("t.getY()");
-		}
-		
 		return set(t.getX(), t.getY());
 	}
 	
 	@Override
 	public Tup2o<X,Y> set(X x, Y y)
 	{
-		if(Barghos.BUILD_FLAG__PARAMETER_CHECKS)
-		{
-			if(x == null) throw new ArgumentNullException("x");
-			if(y == null) throw new ArgumentNullException("y");
-		}
-		
 		return setX(x).setY(y);
 	}
 	
@@ -206,5 +168,11 @@ public class Tup2o<X,Y> implements Tup2oRW<X,Y>, FormattableToString
 		values.put("y", getY());
 		
 		return values;
+	}
+	
+	@Override
+	public Tup2o<X,Y> getNewInstance(X x, Y y)
+	{
+		return new Tup2o<>(x, y);
 	}
 }

--- a/barghos-core/src/main/java/org/barghos/core/tuple2/Tup2obj.java
+++ b/barghos-core/src/main/java/org/barghos/core/tuple2/Tup2obj.java
@@ -29,8 +29,6 @@ import java.util.Map;
 import org.barghos.core.api.formatting.FormattableToString;
 import org.barghos.core.api.tuple2.Tup2objR;
 import org.barghos.core.api.tuple2.Tup2objRW;
-import org.barghos.core.api.util.ArgumentNullException;
-import org.barghos.core.Barghos;
 
 /**
  * This class represents a 2-dimensional string tuple.
@@ -76,13 +74,6 @@ public class Tup2obj implements Tup2objRW, Serializable, FormattableToString
 	 */
 	public Tup2obj(Tup2objR t)
 	{
-		if(Barghos.BUILD_FLAG__PARAMETER_CHECKS)
-		{
-			if(t == null) throw new ArgumentNullException("t");
-			if(t.getX() == null) throw new ArgumentNullException("t.getX()");
-			if(t.getY() == null) throw new ArgumentNullException("t.getY()");
-		}
-		
 		set(t);
 	}
 	
@@ -95,11 +86,6 @@ public class Tup2obj implements Tup2objRW, Serializable, FormattableToString
 	 */
 	public Tup2obj(Object value)
 	{
-		if(Barghos.BUILD_FLAG__PARAMETER_CHECKS)
-		{
-			if(value == null) throw new ArgumentNullException("value");
-		}
-		
 		set(value);
 	}
 	
@@ -113,12 +99,6 @@ public class Tup2obj implements Tup2objRW, Serializable, FormattableToString
 	 */
 	public Tup2obj(Object x, Object y)
 	{
-		if(Barghos.BUILD_FLAG__PARAMETER_CHECKS)
-		{
-			if(x == null) throw new ArgumentNullException("x");
-			if(y == null) throw new ArgumentNullException("y");
-		}
-		
 		set(x, y);
 	}
 	
@@ -137,11 +117,6 @@ public class Tup2obj implements Tup2objRW, Serializable, FormattableToString
 	@Override
 	public Tup2obj setX(Object x)
 	{
-		if(Barghos.BUILD_FLAG__PARAMETER_CHECKS)
-		{
-			if(x == null) throw new ArgumentNullException("x");
-		}
-		
 		this.x = x;
 		
 		return this;
@@ -150,11 +125,6 @@ public class Tup2obj implements Tup2objRW, Serializable, FormattableToString
 	@Override
 	public Tup2obj setY(Object y)
 	{
-		if(Barghos.BUILD_FLAG__PARAMETER_CHECKS)
-		{
-			if(y == null) throw new ArgumentNullException("y");
-		}
-		
 		this.y = y;
 		
 		return this;
@@ -163,36 +133,18 @@ public class Tup2obj implements Tup2objRW, Serializable, FormattableToString
 	@Override
 	public Tup2obj set(Tup2objR t)
 	{
-		if(Barghos.BUILD_FLAG__PARAMETER_CHECKS)
-		{
-			if(t == null) throw new ArgumentNullException("t");
-			if(t.getX() == null) throw new ArgumentNullException("t.getX()");
-			if(t.getY() == null) throw new ArgumentNullException("t.getY()");
-		}
-		
 		return set(t.getX(), t.getY());
 	}
 	
 	@Override
 	public Tup2obj set(Object value)
 	{
-		if(Barghos.BUILD_FLAG__PARAMETER_CHECKS)
-		{
-			if(value == null) throw new ArgumentNullException("value");
-		}
-		
 		return set(value, value);
 	}
 	
 	@Override
 	public Tup2obj set(Object x, Object y)
 	{
-		if(Barghos.BUILD_FLAG__PARAMETER_CHECKS)
-		{
-			if(x == null) throw new ArgumentNullException("x");
-			if(y == null) throw new ArgumentNullException("y");
-		}
-		
 		return setX(x).setY(y);
 	}
 	
@@ -239,5 +191,11 @@ public class Tup2obj implements Tup2objRW, Serializable, FormattableToString
 		values.put("y", getY());
 		
 		return values;
+	}
+	
+	@Override
+	public Tup2obj getNewInstance(Object x, Object y)
+	{
+		return new Tup2obj(x, y);
 	}
 }

--- a/barghos-core/src/main/java/org/barghos/core/tuple2/Tup2s.java
+++ b/barghos-core/src/main/java/org/barghos/core/tuple2/Tup2s.java
@@ -29,8 +29,6 @@ import java.util.Map;
 import org.barghos.core.api.formatting.FormattableToString;
 import org.barghos.core.api.tuple2.Tup2sR;
 import org.barghos.core.api.tuple2.Tup2sRW;
-import org.barghos.core.api.util.ArgumentNullException;
-import org.barghos.core.Barghos;
 
 /**
  * This class represents a 2-dimensional short tuple.
@@ -77,11 +75,6 @@ public class Tup2s implements Tup2sRW, Serializable, FormattableToString
 	 */
 	public Tup2s(Tup2sR t)
 	{
-		if(Barghos.BUILD_FLAG__PARAMETER_CHECKS)
-		{
-			if(t == null) throw new ArgumentNullException("t");
-		}
-		
 		set(t);
 	}
 	
@@ -141,11 +134,6 @@ public class Tup2s implements Tup2sRW, Serializable, FormattableToString
 	@Override
 	public Tup2s set(Tup2sR t)
 	{
-		if(Barghos.BUILD_FLAG__PARAMETER_CHECKS)
-		{
-			if(t == null) throw new ArgumentNullException("t");
-		}
-		
 		return set(t.getX(), t.getY());
 	}
 	
@@ -204,5 +192,11 @@ public class Tup2s implements Tup2sRW, Serializable, FormattableToString
 		values.put("y", getY());
 		
 		return values;
+	}
+	
+	@Override
+	public Tup2s getNewInstance(short x, short y)
+	{
+		return new Tup2s(x, y);
 	}
 }

--- a/barghos-core/src/main/java/org/barghos/core/tuple2/Tup2str.java
+++ b/barghos-core/src/main/java/org/barghos/core/tuple2/Tup2str.java
@@ -29,8 +29,6 @@ import java.util.Map;
 import org.barghos.core.api.formatting.FormattableToString;
 import org.barghos.core.api.tuple2.Tup2strR;
 import org.barghos.core.api.tuple2.Tup2strRW;
-import org.barghos.core.api.util.ArgumentNullException;
-import org.barghos.core.Barghos;
 
 /**
  * This class represents a 2-dimensional string tuple.
@@ -79,13 +77,6 @@ public class Tup2str implements Tup2strRW, Serializable, FormattableToString
 	 */
 	public Tup2str(Tup2strR t)
 	{
-		if(Barghos.BUILD_FLAG__PARAMETER_CHECKS)
-		{
-			if(t == null) throw new ArgumentNullException("t");
-			if(t.getX() == null) throw new ArgumentNullException("t.getX()");
-			if(t.getY() == null) throw new ArgumentNullException("t.getY()");
-		}
-		
 		set(t);
 	}
 	
@@ -98,11 +89,6 @@ public class Tup2str implements Tup2strRW, Serializable, FormattableToString
 	 */
 	public Tup2str(String value)
 	{
-		if(Barghos.BUILD_FLAG__PARAMETER_CHECKS)
-		{
-			if(value == null) throw new ArgumentNullException("value");
-		}
-		
 		set(value);
 	}
 	
@@ -116,12 +102,6 @@ public class Tup2str implements Tup2strRW, Serializable, FormattableToString
 	 */
 	public Tup2str(String x, String y)
 	{
-		if(Barghos.BUILD_FLAG__PARAMETER_CHECKS)
-		{
-			if(x == null) throw new ArgumentNullException("x");
-			if(y == null) throw new ArgumentNullException("y");
-		}
-		
 		set(x, y);
 	}
 	
@@ -140,11 +120,6 @@ public class Tup2str implements Tup2strRW, Serializable, FormattableToString
 	@Override
 	public Tup2str setX(String x)
 	{
-		if(Barghos.BUILD_FLAG__PARAMETER_CHECKS)
-		{
-			if(x == null) throw new ArgumentNullException("x");
-		}
-		
 		this.x = x;
 		
 		return this;
@@ -153,11 +128,6 @@ public class Tup2str implements Tup2strRW, Serializable, FormattableToString
 	@Override
 	public Tup2str setY(String y)
 	{
-		if(Barghos.BUILD_FLAG__PARAMETER_CHECKS)
-		{
-			if(y == null) throw new ArgumentNullException("y");
-		}
-		
 		this.y = y;
 		
 		return this;
@@ -166,36 +136,18 @@ public class Tup2str implements Tup2strRW, Serializable, FormattableToString
 	@Override
 	public Tup2str set(Tup2strR t)
 	{
-		if(Barghos.BUILD_FLAG__PARAMETER_CHECKS)
-		{
-			if(t == null) throw new ArgumentNullException("t");
-			if(t.getX() == null) throw new ArgumentNullException("t.getX()");
-			if(t.getY() == null) throw new ArgumentNullException("t.getY()");
-		}
-		
 		return set(t.getX(), t.getY());
 	}
 	
 	@Override
 	public Tup2str set(String value)
 	{
-		if(Barghos.BUILD_FLAG__PARAMETER_CHECKS)
-		{
-			if(value == null) throw new ArgumentNullException("value");
-		}
-		
 		return set(value, value);
 	}
 	
 	@Override
 	public Tup2str set(String x, String y)
 	{
-		if(Barghos.BUILD_FLAG__PARAMETER_CHECKS)
-		{
-			if(x == null) throw new ArgumentNullException("x");
-			if(y == null) throw new ArgumentNullException("y");
-		}
-		
 		return setX(x).setY(y);
 	}
 	
@@ -242,5 +194,11 @@ public class Tup2str implements Tup2strRW, Serializable, FormattableToString
 		values.put("y", getY());
 		
 		return values;
+	}
+	
+	@Override
+	public Tup2str getNewInstance(String x, String y)
+	{
+		return new Tup2str(x, y);
 	}
 }

--- a/barghos-core/src/main/java/org/barghos/core/tuple3/PTup3b.java
+++ b/barghos-core/src/main/java/org/barghos/core/tuple3/PTup3b.java
@@ -152,4 +152,10 @@ public abstract class PTup3b implements Tup3bR, FormattableToString
 		
 		return values;
 	}
+	
+	@Override
+	public PTup3b getNewInstance(byte x, byte y, byte z)
+	{
+		return gen(x, y, z);
+	}
 }

--- a/barghos-core/src/main/java/org/barghos/core/tuple3/PTup3bigd.java
+++ b/barghos-core/src/main/java/org/barghos/core/tuple3/PTup3bigd.java
@@ -168,4 +168,10 @@ public abstract class PTup3bigd implements Tup3bigdR, FormattableToString
 		
 		return values;
 	}
+	
+	@Override
+	public PTup3bigd getNewInstance(BigDecimal x, BigDecimal y, BigDecimal z)
+	{
+		return gen(x, y, z);
+	}
 }

--- a/barghos-core/src/main/java/org/barghos/core/tuple3/PTup3bigi.java
+++ b/barghos-core/src/main/java/org/barghos/core/tuple3/PTup3bigi.java
@@ -168,4 +168,10 @@ public abstract class PTup3bigi implements Tup3bigiR, FormattableToString
 		
 		return values;
 	}
+	
+	@Override
+	public PTup3bigi getNewInstance(BigInteger x, BigInteger y, BigInteger z)
+	{
+		return gen(x, y, z);
+	}
 }

--- a/barghos-core/src/main/java/org/barghos/core/tuple3/PTup3bo.java
+++ b/barghos-core/src/main/java/org/barghos/core/tuple3/PTup3bo.java
@@ -152,4 +152,10 @@ public abstract class PTup3bo implements Tup3boR, FormattableToString
 		
 		return values;
 	}
+	
+	@Override
+	public PTup3bo getNewInstance(boolean x, boolean y, boolean z)
+	{
+		return gen(x, y, z);
+	}
 }

--- a/barghos-core/src/main/java/org/barghos/core/tuple3/PTup3c.java
+++ b/barghos-core/src/main/java/org/barghos/core/tuple3/PTup3c.java
@@ -152,4 +152,10 @@ public abstract class PTup3c implements Tup3cR, FormattableToString
 		
 		return values;
 	}
+	
+	@Override
+	public PTup3c getNewInstance(char x, char y, char z)
+	{
+		return gen(x, y, z);
+	}
 }

--- a/barghos-core/src/main/java/org/barghos/core/tuple3/PTup3d.java
+++ b/barghos-core/src/main/java/org/barghos/core/tuple3/PTup3d.java
@@ -155,4 +155,10 @@ public abstract class PTup3d implements Tup3dR, FormattableToString
 		
 		return values;
 	}
+	
+	@Override
+	public PTup3d getNewInstance(double x, double y, double z)
+	{
+		return gen(x, y, z);
+	}
 }

--- a/barghos-core/src/main/java/org/barghos/core/tuple3/PTup3f.java
+++ b/barghos-core/src/main/java/org/barghos/core/tuple3/PTup3f.java
@@ -152,4 +152,10 @@ public abstract class PTup3f implements Tup3fR, FormattableToString
 		
 		return values;
 	}
+	
+	@Override
+	public PTup3f getNewInstance(float x, float y, float z)
+	{
+		return gen(x, y, z);
+	}
 }

--- a/barghos-core/src/main/java/org/barghos/core/tuple3/PTup3i.java
+++ b/barghos-core/src/main/java/org/barghos/core/tuple3/PTup3i.java
@@ -152,4 +152,10 @@ public abstract class PTup3i implements Tup3iR, FormattableToString
 		
 		return values;
 	}
+	
+	@Override
+	public PTup3i getNewInstance(int x, int y, int z)
+	{
+		return gen(x, y, z);
+	}
 }

--- a/barghos-core/src/main/java/org/barghos/core/tuple3/PTup3l.java
+++ b/barghos-core/src/main/java/org/barghos/core/tuple3/PTup3l.java
@@ -152,4 +152,10 @@ public abstract class PTup3l implements Tup3lR, FormattableToString
 		
 		return values;
 	}
+	
+	@Override
+	public PTup3l getNewInstance(long x, long y, long z)
+	{
+		return gen(x, y, z);
+	}
 }

--- a/barghos-core/src/main/java/org/barghos/core/tuple3/PTup3o.java
+++ b/barghos-core/src/main/java/org/barghos/core/tuple3/PTup3o.java
@@ -157,4 +157,10 @@ public abstract class PTup3o<X,Y,Z> implements Tup3oR<X,Y,Z>, FormattableToStrin
 		
 		return values;
 	}
+	
+	@Override
+	public PTup3o<X,Y,Z> getNewInstance(X x, Y y, Z z)
+	{
+		return gen(x, y, z);
+	}
 }

--- a/barghos-core/src/main/java/org/barghos/core/tuple3/PTup3obj.java
+++ b/barghos-core/src/main/java/org/barghos/core/tuple3/PTup3obj.java
@@ -167,4 +167,10 @@ public abstract class PTup3obj implements Tup3objR, FormattableToString
 		
 		return values;
 	}
+	
+	@Override
+	public PTup3obj getNewInstance(Object x, Object y, Object z)
+	{
+		return gen(x, y, z);
+	}
 }

--- a/barghos-core/src/main/java/org/barghos/core/tuple3/PTup3s.java
+++ b/barghos-core/src/main/java/org/barghos/core/tuple3/PTup3s.java
@@ -152,4 +152,10 @@ public abstract class PTup3s implements Tup3sR, FormattableToString
 		
 		return values;
 	}
+	
+	@Override
+	public PTup3s getNewInstance(short x, short y, short z)
+	{
+		return gen(x, y, z);
+	}
 }

--- a/barghos-core/src/main/java/org/barghos/core/tuple3/PTup3str.java
+++ b/barghos-core/src/main/java/org/barghos/core/tuple3/PTup3str.java
@@ -167,4 +167,10 @@ public abstract class PTup3str implements Tup3strR, FormattableToString
 		
 		return values;
 	}
+	
+	@Override
+	public PTup3str getNewInstance(String x, String y, String z)
+	{
+		return gen(x, y, z);
+	}
 }

--- a/barghos-core/src/main/java/org/barghos/core/tuple3/Tup3b.java
+++ b/barghos-core/src/main/java/org/barghos/core/tuple3/Tup3b.java
@@ -228,4 +228,10 @@ public class Tup3b implements Tup3bRW, Serializable, FormattableToString
 		
 		return values;
 	}
+	
+	@Override
+	public Tup3b getNewInstance(byte x, byte y, byte z)
+	{
+		return new Tup3b(x, y, z);
+	}
 }

--- a/barghos-core/src/main/java/org/barghos/core/tuple3/Tup3bigd.java
+++ b/barghos-core/src/main/java/org/barghos/core/tuple3/Tup3bigd.java
@@ -277,4 +277,10 @@ public class Tup3bigd implements Tup3bigdRW, Serializable, FormattableToString
 		
 		return values;
 	}
+	
+	@Override
+	public Tup3bigd getNewInstance(BigDecimal x, BigDecimal y, BigDecimal z)
+	{
+		return new Tup3bigd(x, y, z);
+	}
 }

--- a/barghos-core/src/main/java/org/barghos/core/tuple3/Tup3bigi.java
+++ b/barghos-core/src/main/java/org/barghos/core/tuple3/Tup3bigi.java
@@ -277,4 +277,10 @@ public class Tup3bigi implements Tup3bigiRW, Serializable, FormattableToString
 		
 		return values;
 	}
+	
+	@Override
+	public Tup3bigi getNewInstance(BigInteger x, BigInteger y, BigInteger z)
+	{
+		return new Tup3bigi(x, y, z);
+	}
 }

--- a/barghos-core/src/main/java/org/barghos/core/tuple3/Tup3bo.java
+++ b/barghos-core/src/main/java/org/barghos/core/tuple3/Tup3bo.java
@@ -228,4 +228,10 @@ public class Tup3bo implements Tup3boRW, Serializable, FormattableToString
 		
 		return values;
 	}
+	
+	@Override
+	public Tup3bo getNewInstance(boolean x, boolean y, boolean z)
+	{
+		return new Tup3bo(x, y, z);
+	}
 }

--- a/barghos-core/src/main/java/org/barghos/core/tuple3/Tup3c.java
+++ b/barghos-core/src/main/java/org/barghos/core/tuple3/Tup3c.java
@@ -228,4 +228,10 @@ public class Tup3c implements Tup3cRW, Serializable, FormattableToString
 		
 		return values;
 	}
+	
+	@Override
+	public Tup3c getNewInstance(char x, char y, char z)
+	{
+		return new Tup3c(x, y, z);
+	}
 }

--- a/barghos-core/src/main/java/org/barghos/core/tuple3/Tup3d.java
+++ b/barghos-core/src/main/java/org/barghos/core/tuple3/Tup3d.java
@@ -231,4 +231,10 @@ public class Tup3d implements Tup3dRW, Serializable, FormattableToString
 		
 		return values;
 	}
+	
+	@Override
+	public Tup3d getNewInstance(double x, double y, double z)
+	{
+		return new Tup3d(x, y, z);
+	}
 }

--- a/barghos-core/src/main/java/org/barghos/core/tuple3/Tup3f.java
+++ b/barghos-core/src/main/java/org/barghos/core/tuple3/Tup3f.java
@@ -228,4 +228,10 @@ public class Tup3f implements Tup3fRW, Serializable, FormattableToString
 		
 		return values;
 	}
+	
+	@Override
+	public Tup3f getNewInstance(float x, float y, float z)
+	{
+		return new Tup3f(x, y, z);
+	}
 }

--- a/barghos-core/src/main/java/org/barghos/core/tuple3/Tup3i.java
+++ b/barghos-core/src/main/java/org/barghos/core/tuple3/Tup3i.java
@@ -228,4 +228,10 @@ public class Tup3i implements Tup3iRW, Serializable, FormattableToString
 		
 		return values;
 	}
+	
+	@Override
+	public Tup3i getNewInstance(int x, int y, int z)
+	{
+		return new Tup3i(x, y, z);
+	}
 }

--- a/barghos-core/src/main/java/org/barghos/core/tuple3/Tup3l.java
+++ b/barghos-core/src/main/java/org/barghos/core/tuple3/Tup3l.java
@@ -228,4 +228,10 @@ public class Tup3l implements Tup3lRW, Serializable, FormattableToString
 		
 		return values;
 	}
+	
+	@Override
+	public Tup3l getNewInstance(long x, long y, long z)
+	{
+		return new Tup3l(x, y, z);
+	}
 }

--- a/barghos-core/src/main/java/org/barghos/core/tuple3/Tup3o.java
+++ b/barghos-core/src/main/java/org/barghos/core/tuple3/Tup3o.java
@@ -241,4 +241,10 @@ public class Tup3o<X,Y,Z> implements Tup3oRW<X,Y,Z>, FormattableToString
 		
 		return values;
 	}
+	
+	@Override
+	public Tup3o<X,Y,Z> getNewInstance(X x, Y y, Z z)
+	{
+		return new Tup3o<>(x, y, z);
+	}
 }

--- a/barghos-core/src/main/java/org/barghos/core/tuple3/Tup3obj.java
+++ b/barghos-core/src/main/java/org/barghos/core/tuple3/Tup3obj.java
@@ -273,4 +273,10 @@ public class Tup3obj implements Tup3objRW, Serializable, FormattableToString
 		
 		return values;
 	}
+	
+	@Override
+	public Tup3obj getNewInstance(Object x, Object y, Object z)
+	{
+		return new Tup3obj(x, y, z);
+	}
 }

--- a/barghos-core/src/main/java/org/barghos/core/tuple3/Tup3s.java
+++ b/barghos-core/src/main/java/org/barghos/core/tuple3/Tup3s.java
@@ -228,4 +228,10 @@ public class Tup3s implements Tup3sRW, Serializable, FormattableToString
 		
 		return values;
 	}
+	
+	@Override
+	public Tup3s getNewInstance(short x, short y, short z)
+	{
+		return new Tup3s(x, y, z);
+	}
 }

--- a/barghos-core/src/main/java/org/barghos/core/tuple3/Tup3str.java
+++ b/barghos-core/src/main/java/org/barghos/core/tuple3/Tup3str.java
@@ -276,4 +276,10 @@ public class Tup3str implements Tup3strRW, Serializable, FormattableToString
 		
 		return values;
 	}
+	
+	@Override
+	public Tup3str getNewInstance(String x, String y, String z)
+	{
+		return new Tup3str(x, y, z);
+	}
 }

--- a/barghos-core/src/main/java/org/barghos/core/tuple4/PTup4b.java
+++ b/barghos-core/src/main/java/org/barghos/core/tuple4/PTup4b.java
@@ -159,4 +159,10 @@ public abstract class PTup4b implements Tup4bR, FormattableToString
 		
 		return values;
 	}
+	
+	@Override
+	public PTup4b getNewInstance(byte x, byte y, byte z, byte w)
+	{
+		return gen(x, y, z, w);
+	}
 }

--- a/barghos-core/src/main/java/org/barghos/core/tuple4/PTup4bigd.java
+++ b/barghos-core/src/main/java/org/barghos/core/tuple4/PTup4bigd.java
@@ -177,4 +177,10 @@ public abstract class PTup4bigd implements Tup4bigdR, FormattableToString
 		
 		return values;
 	}
+	
+	@Override
+	public PTup4bigd getNewInstance(BigDecimal x, BigDecimal y, BigDecimal z, BigDecimal w)
+	{
+		return gen(x, y, z, w);
+	}
 }

--- a/barghos-core/src/main/java/org/barghos/core/tuple4/PTup4bigi.java
+++ b/barghos-core/src/main/java/org/barghos/core/tuple4/PTup4bigi.java
@@ -177,4 +177,10 @@ public abstract class PTup4bigi implements Tup4bigiR, FormattableToString
 		
 		return values;
 	}
+	
+	@Override
+	public PTup4bigi getNewInstance(BigInteger x, BigInteger y, BigInteger z, BigInteger w)
+	{
+		return gen(x, y, z, w);
+	}
 }

--- a/barghos-core/src/main/java/org/barghos/core/tuple4/PTup4bo.java
+++ b/barghos-core/src/main/java/org/barghos/core/tuple4/PTup4bo.java
@@ -159,4 +159,10 @@ public abstract class PTup4bo implements Tup4boR, FormattableToString
 		
 		return values;
 	}
+	
+	@Override
+	public PTup4bo getNewInstance(boolean x, boolean y, boolean z, boolean w)
+	{
+		return gen(x, y, z, w);
+	}
 }

--- a/barghos-core/src/main/java/org/barghos/core/tuple4/PTup4c.java
+++ b/barghos-core/src/main/java/org/barghos/core/tuple4/PTup4c.java
@@ -159,4 +159,10 @@ public abstract class PTup4c implements Tup4cR, FormattableToString
 		
 		return values;
 	}
+	
+	@Override
+	public PTup4c getNewInstance(char x, char y, char z, char w)
+	{
+		return gen(x, y, z, w);
+	}
 }

--- a/barghos-core/src/main/java/org/barghos/core/tuple4/PTup4d.java
+++ b/barghos-core/src/main/java/org/barghos/core/tuple4/PTup4d.java
@@ -163,4 +163,10 @@ public abstract class PTup4d implements Tup4dR, FormattableToString
 		
 		return values;
 	}
+	
+	@Override
+	public PTup4d getNewInstance(double x, double y, double z, double w)
+	{
+		return gen(x, y, z, w);
+	}
 }

--- a/barghos-core/src/main/java/org/barghos/core/tuple4/PTup4f.java
+++ b/barghos-core/src/main/java/org/barghos/core/tuple4/PTup4f.java
@@ -159,4 +159,10 @@ public abstract class PTup4f implements Tup4fR, FormattableToString
 		
 		return values;
 	}
+	
+	@Override
+	public PTup4f getNewInstance(float x, float y, float z, float w)
+	{
+		return gen(x, y, z, w);
+	}
 }

--- a/barghos-core/src/main/java/org/barghos/core/tuple4/PTup4i.java
+++ b/barghos-core/src/main/java/org/barghos/core/tuple4/PTup4i.java
@@ -159,4 +159,10 @@ public abstract class PTup4i implements Tup4iR, FormattableToString
 		
 		return values;
 	}
+	
+	@Override
+	public PTup4i getNewInstance(int x, int y, int z, int w)
+	{
+		return gen(x, y, z, w);
+	}
 }

--- a/barghos-core/src/main/java/org/barghos/core/tuple4/PTup4l.java
+++ b/barghos-core/src/main/java/org/barghos/core/tuple4/PTup4l.java
@@ -159,4 +159,10 @@ public abstract class PTup4l implements Tup4lR, FormattableToString
 		
 		return values;
 	}
+	
+	@Override
+	public PTup4l getNewInstance(long x, long y, long z, long w)
+	{
+		return gen(x, y, z, w);
+	}
 }

--- a/barghos-core/src/main/java/org/barghos/core/tuple4/PTup4o.java
+++ b/barghos-core/src/main/java/org/barghos/core/tuple4/PTup4o.java
@@ -168,4 +168,10 @@ public abstract class PTup4o<X,Y,Z,W> implements Tup4oR<X,Y,Z,W>, FormattableToS
 		
 		return values;
 	}
+	
+	@Override
+	public PTup4o<X,Y,Z,W> getNewInstance(X x, Y y, Z z, W w)
+	{
+		return gen(x, y, z, w);
+	}
 }

--- a/barghos-core/src/main/java/org/barghos/core/tuple4/PTup4obj.java
+++ b/barghos-core/src/main/java/org/barghos/core/tuple4/PTup4obj.java
@@ -176,4 +176,10 @@ public abstract class PTup4obj implements Tup4objR, FormattableToString
 		
 		return values;
 	}
+	
+	@Override
+	public PTup4obj getNewInstance(Object x, Object y, Object z, Object w)
+	{
+		return gen(x, y, z, w);
+	}
 }

--- a/barghos-core/src/main/java/org/barghos/core/tuple4/PTup4s.java
+++ b/barghos-core/src/main/java/org/barghos/core/tuple4/PTup4s.java
@@ -159,4 +159,10 @@ public abstract class PTup4s implements Tup4sR, FormattableToString
 		
 		return values;
 	}
+	
+	@Override
+	public PTup4s getNewInstance(short x, short y, short z, short w)
+	{
+		return gen(x, y, z, w);
+	}
 }

--- a/barghos-core/src/main/java/org/barghos/core/tuple4/PTup4str.java
+++ b/barghos-core/src/main/java/org/barghos/core/tuple4/PTup4str.java
@@ -176,4 +176,10 @@ public abstract class PTup4str implements Tup4strR, FormattableToString
 		
 		return values;
 	}
+	
+	@Override
+	public PTup4str getNewInstance(String x, String y, String z, String w)
+	{
+		return gen(x, y, z, w);
+	}
 }

--- a/barghos-core/src/main/java/org/barghos/core/tuple4/Tup4b.java
+++ b/barghos-core/src/main/java/org/barghos/core/tuple4/Tup4b.java
@@ -251,4 +251,10 @@ public class Tup4b implements Tup4bRW, Serializable, FormattableToString
 		
 		return values;
 	}
+	
+	@Override
+	public Tup4b getNewInstance(byte x, byte y, byte z, byte w)
+	{
+		return new Tup4b(x, y, z, w);
+	}
 }

--- a/barghos-core/src/main/java/org/barghos/core/tuple4/Tup4bigd.java
+++ b/barghos-core/src/main/java/org/barghos/core/tuple4/Tup4bigd.java
@@ -297,4 +297,10 @@ public class Tup4bigd implements Tup4bigdRW, Serializable, FormattableToString
 		
 		return values;
 	}
+	
+	@Override
+	public Tup4bigd getNewInstance(BigDecimal x, BigDecimal y, BigDecimal z, BigDecimal w)
+	{
+		return new Tup4bigd(x, y, z, w);
+	}
 }

--- a/barghos-core/src/main/java/org/barghos/core/tuple4/Tup4bigi.java
+++ b/barghos-core/src/main/java/org/barghos/core/tuple4/Tup4bigi.java
@@ -297,4 +297,10 @@ public class Tup4bigi implements Tup4bigiRW, Serializable, FormattableToString
 		
 		return values;
 	}
+	
+	@Override
+	public Tup4bigi getNewInstance(BigInteger x, BigInteger y, BigInteger z, BigInteger w)
+	{
+		return new Tup4bigi(x, y, z, w);
+	}
 }

--- a/barghos-core/src/main/java/org/barghos/core/tuple4/Tup4bo.java
+++ b/barghos-core/src/main/java/org/barghos/core/tuple4/Tup4bo.java
@@ -251,4 +251,10 @@ public class Tup4bo implements Tup4boRW, Serializable, FormattableToString
 		
 		return values;
 	}
+	
+	@Override
+	public Tup4bo getNewInstance(boolean x, boolean y, boolean z, boolean w)
+	{
+		return new Tup4bo(x, y, z, w);
+	}
 }

--- a/barghos-core/src/main/java/org/barghos/core/tuple4/Tup4c.java
+++ b/barghos-core/src/main/java/org/barghos/core/tuple4/Tup4c.java
@@ -251,4 +251,10 @@ public class Tup4c implements Tup4cRW, Serializable, FormattableToString
 		
 		return values;
 	}
+	
+	@Override
+	public Tup4c getNewInstance(char x, char y, char z, char w)
+	{
+		return new Tup4c(x, y, z, w);
+	}
 }

--- a/barghos-core/src/main/java/org/barghos/core/tuple4/Tup4d.java
+++ b/barghos-core/src/main/java/org/barghos/core/tuple4/Tup4d.java
@@ -255,4 +255,10 @@ public class Tup4d implements Tup4dRW, Serializable, FormattableToString
 		
 		return values;
 	}
+	
+	@Override
+	public Tup4d getNewInstance(double x, double y, double z, double w)
+	{
+		return new Tup4d(x, y, z, w);
+	}
 }

--- a/barghos-core/src/main/java/org/barghos/core/tuple4/Tup4f.java
+++ b/barghos-core/src/main/java/org/barghos/core/tuple4/Tup4f.java
@@ -251,4 +251,10 @@ public class Tup4f implements Tup4fRW, Serializable, FormattableToString
 		
 		return values;
 	}
+	
+	@Override
+	public Tup4f getNewInstance(float x, float y, float z, float w)
+	{
+		return new Tup4f(x, y, z, w);
+	}
 }

--- a/barghos-core/src/main/java/org/barghos/core/tuple4/Tup4i.java
+++ b/barghos-core/src/main/java/org/barghos/core/tuple4/Tup4i.java
@@ -251,4 +251,10 @@ public class Tup4i implements Tup4iRW, Serializable, FormattableToString
 		
 		return values;
 	}
+	
+	@Override
+	public Tup4i getNewInstance(int x, int y, int z, int w)
+	{
+		return new Tup4i(x, y, z, w);
+	}
 }

--- a/barghos-core/src/main/java/org/barghos/core/tuple4/Tup4l.java
+++ b/barghos-core/src/main/java/org/barghos/core/tuple4/Tup4l.java
@@ -251,4 +251,10 @@ public class Tup4l implements Tup4lRW, Serializable, FormattableToString
 		
 		return values;
 	}
+	
+	@Override
+	public Tup4l getNewInstance(long x, long y, long z, long w)
+	{
+		return new Tup4l(x, y, z, w);
+	}
 }

--- a/barghos-core/src/main/java/org/barghos/core/tuple4/Tup4o.java
+++ b/barghos-core/src/main/java/org/barghos/core/tuple4/Tup4o.java
@@ -271,4 +271,10 @@ public class Tup4o<X,Y,Z,W> implements Tup4oRW<X,Y,Z,W>, FormattableToString
 		
 		return values;
 	}
+	
+	@Override
+	public Tup4o<X,Y,Z,W> getNewInstance(X x, Y y, Z z, W w)
+	{
+		return new Tup4o<>(x, y, z, w);
+	}
 }

--- a/barghos-core/src/main/java/org/barghos/core/tuple4/Tup4obj.java
+++ b/barghos-core/src/main/java/org/barghos/core/tuple4/Tup4obj.java
@@ -293,4 +293,10 @@ public class Tup4obj implements Tup4objRW, Serializable, FormattableToString
 		
 		return values;
 	}
+	
+	@Override
+	public Tup4obj getNewInstance(Object x, Object y, Object z, Object w)
+	{
+		return new Tup4obj(x, y, z, w);
+	}
 }

--- a/barghos-core/src/main/java/org/barghos/core/tuple4/Tup4s.java
+++ b/barghos-core/src/main/java/org/barghos/core/tuple4/Tup4s.java
@@ -251,4 +251,10 @@ public class Tup4s implements Tup4sRW, Serializable, FormattableToString
 		
 		return values;
 	}
+	
+	@Override
+	public Tup4s getNewInstance(short x, short y, short z, short w)
+	{
+		return new Tup4s(x, y, z, w);
+	}
 }

--- a/barghos-core/src/main/java/org/barghos/core/tuple4/Tup4str.java
+++ b/barghos-core/src/main/java/org/barghos/core/tuple4/Tup4str.java
@@ -296,4 +296,10 @@ public class Tup4str implements Tup4strRW, Serializable, FormattableToString
 		
 		return values;
 	}
+	
+	@Override
+	public Tup4str getNewInstance(String x, String y, String z, String w)
+	{
+		return new Tup4str(x, y, z, w);
+	}
 }

--- a/barghos-core/src/test/java/org/barghos/core/test/api/color/Color3RTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/api/color/Color3RTest.java
@@ -60,6 +60,12 @@ class Color3RTest
 			{
 				return 0;
 			}
+			
+			@Override
+			public Color3R getNewInstance(float x, float y, float z)
+			{
+				return null;
+			}
 		};
 		
 		assertEquals(2.1f, c.getX());
@@ -111,6 +117,12 @@ class Color3RTest
 			{
 				return 0;
 			}
+			
+			@Override
+			public Color3R getNewInstance(float x, float y, float z)
+			{
+				return null;
+			}
 		};
 		
 		assertEquals(3.2f, c.getY());
@@ -161,6 +173,12 @@ class Color3RTest
 			public int getB()
 			{
 				return 0;
+			}
+			
+			@Override
+			public Color3R getNewInstance(float x, float y, float z)
+			{
+				return null;
 			}
 		};
 		

--- a/barghos-core/src/test/java/org/barghos/core/test/api/color/Color4RTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/api/color/Color4RTest.java
@@ -72,6 +72,18 @@ class Color4RTest
 			{
 				return 0;
 			}
+			
+			@Override
+			public Color4R getNewInstance(float x, float y, float z)
+			{
+				return null;
+			}
+			
+			@Override
+			public Color4R getNewInstance(float x, float y, float z, float w)
+			{
+				return null;
+			}
 		};
 		
 		assertEquals(2.1f, c.getX());
@@ -134,6 +146,18 @@ class Color4RTest
 			public int getA()
 			{
 				return 0;
+			}
+			
+			@Override
+			public Color4R getNewInstance(float x, float y, float z)
+			{
+				return null;
+			}
+			
+			@Override
+			public Color4R getNewInstance(float x, float y, float z, float w)
+			{
+				return null;
 			}
 		};
 		
@@ -198,6 +222,18 @@ class Color4RTest
 			{
 				return 0;
 			}
+			
+			@Override
+			public Color4R getNewInstance(float x, float y, float z)
+			{
+				return null;
+			}
+			
+			@Override
+			public Color4R getNewInstance(float x, float y, float z, float w)
+			{
+				return null;
+			}
 		};
 		
 		assertEquals(4.3f, c.getZ());
@@ -260,6 +296,18 @@ class Color4RTest
 			public int getA()
 			{
 				return 0;
+			}
+			
+			@Override
+			public Color4R getNewInstance(float x, float y, float z)
+			{
+				return null;
+			}
+			
+			@Override
+			public Color4R getNewInstance(float x, float y, float z, float w)
+			{
+				return null;
 			}
 		};
 		

--- a/barghos-core/src/test/java/org/barghos/core/test/api/tuple2/Tup2bRTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/api/tuple2/Tup2bRTest.java
@@ -2,6 +2,7 @@ package org.barghos.core.test.api.tuple2;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import org.barghos.core.api.testing.ValueRelay;
@@ -15,25 +16,24 @@ import org.barghos.core.api.tuple2.Tup2bR;
 class Tup2bRTest
 {
 	/**
+	 * This method is called after each test in this class.
+	 */
+	@AfterEach
+	void cleanup()
+	{
+		ValueRelay.clear();
+	}
+	
+	/**
 	 * This test ensures, that the function {@link Tup2bR#isValid()} returns
 	 * the corrct values for different situations.
 	 */
 	@Test
 	void isValidTest()
 	{
-		Tup2bR t = new Tup2bR() {
-			public byte getX()
-			{
-				ValueRelay.relayCall("getX");
-				return (byte)0;
-			}
-
-			public byte getY()
-			{
-				ValueRelay.relayCall("getY");
-				return (byte)0;
-			}
-		};
+		final byte zero = (byte)0;
+		
+		Tup2bR t = new TestTup(zero, zero);
 		
 		assertEquals(true, t.isValid());
 		assertEquals(false, ValueRelay.get("getX", false));
@@ -47,19 +47,9 @@ class Tup2bRTest
 	@Test
 	void isFiniteTest()
 	{
-		Tup2bR t = new Tup2bR() {
-			public byte getX()
-			{
-				ValueRelay.relayCall("getX");
-				return (byte)0;
-			}
-
-			public byte getY()
-			{
-				ValueRelay.relayCall("getY");
-				return (byte)0;
-			}
-		};
+		final byte zero = (byte)0;
+		
+		Tup2bR t = new TestTup(zero, zero);
 		
 		assertEquals(true, t.isFinite());
 		assertEquals(false, ValueRelay.get("getX", false));
@@ -119,6 +109,51 @@ class Tup2bRTest
 	}
 	
 	/**
+	 * This test ensures, that the default implementation of the function {@link Tup2bR#getNewInstance(Tup2bR)} calls
+	 * the function {@link Tup2bR#getNewInstance(byte, byte)} with the correct components.
+	 */
+	@Test
+	void getNewInstance_TupleTest()
+	{
+		final byte zero = (byte)0;
+		final byte one = (byte)1;
+		final byte two = (byte)2;
+		final byte three = (byte)3;
+
+		Tup2bR t = new TestTup(one, one);
+		
+		t.getNewInstance(new TestTup(two, three));
+		
+		assertEquals(true, ValueRelay.get("getNewInstanceC", false));
+		assertEquals(two, ValueRelay.get("getNewInstanceC_X", zero));
+		assertEquals(three, ValueRelay.get("getNewInstanceC_Y", zero));
+		
+		// Can't test for the result here, as the relaying and adopting of the values are implementation specific.
+	}
+	
+	/**
+	 * This test ensures, that the default implementation of the function {@link Tup2bR#getNewInstance(byte)} calls
+	 * the function {@link Tup2bR#getNewInstance(byte, byte)} with the correct components.
+	 */
+	@Test
+	void getNewInstance_ValueTest()
+	{
+		final byte zero = (byte)0;
+		final byte one = (byte)1;
+		final byte two = (byte)2;
+		
+		Tup2bR t = new TestTup(one, one);
+		
+		t.getNewInstance(two);
+		
+		assertEquals(true, ValueRelay.get("getNewInstanceC", false));
+		assertEquals(two, ValueRelay.get("getNewInstanceC_X", zero));
+		assertEquals(two, ValueRelay.get("getNewInstanceC_Y", zero));
+		
+		// Can't test for the result here, as the relaying and adopting of the values are implementation specific.
+	}
+	
+	/**
 	 * This class is a test implementation of the interface {@link Tup2bR}.
 	 * 
 	 * @author picatrix1899
@@ -137,13 +172,24 @@ class Tup2bRTest
 		@Override
 		public byte getX()
 		{
+			ValueRelay.relayCall("getX");
 			return this.x;
 		}
 		
 		@Override
 		public byte getY()
 		{
+			ValueRelay.relayCall("getY");
 			return this.y;
+		}
+		
+		@Override
+		public TestTup getNewInstance(byte x, byte y)
+		{
+			ValueRelay.relayCall("getNewInstanceC");
+			ValueRelay.relay("getNewInstanceC_X", x);
+			ValueRelay.relay("getNewInstanceC_Y", y);
+			return new TestTup(x, y);
 		}
 	}
 }

--- a/barghos-core/src/test/java/org/barghos/core/test/api/tuple2/Tup2bigdRTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/api/tuple2/Tup2bigdRTest.java
@@ -2,6 +2,7 @@ package org.barghos.core.test.api.tuple2;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
@@ -16,6 +17,15 @@ import org.barghos.core.api.tuple2.Tup2bigdR;
  */
 class Tup2bigdRTest
 {
+	/**
+	 * This method is called after each test in this class.
+	 */
+	@AfterEach
+	void cleanup()
+	{
+		ValueRelay.clear();
+	}
+	
 	/**
 	 * This test ensures, that the function {@link Tup2bigdR#isValid()} returns
 	 * the corrct values for different situations.
@@ -45,19 +55,9 @@ class Tup2bigdRTest
 	@Test
 	void isFiniteTest()
 	{
-		Tup2bigdR t = new Tup2bigdR() {
-			public BigDecimal getX()
-			{
-				ValueRelay.relayCall("getX");
-				return null;
-			}
-
-			public BigDecimal getY()
-			{
-				ValueRelay.relayCall("getY");
-				return null;
-			}
-		};
+		final BigDecimal zero = BigDecimal.ZERO;
+		
+		Tup2bigdR t = new TestTup(zero, zero);
 		
 		assertEquals(true, t.isFinite());
 		assertEquals(false, ValueRelay.get("getX", false));
@@ -117,6 +117,51 @@ class Tup2bigdRTest
 	}
 	
 	/**
+	 * This test ensures, that the default implementation of the function {@link Tup2bigdR#getNewInstance(Tup2bigdR)} calls
+	 * the function {@link Tup2bigdR#getNewInstance(BigDecimal, BigDecimal)} with the correct components.
+	 */
+	@Test
+	void getNewInstance_TupleTest()
+	{
+		final BigDecimal zero = BigDecimal.ZERO;
+		final BigDecimal one = BigDecimal.ONE;
+		final BigDecimal two = BigDecimal.valueOf(2.0);
+		final BigDecimal three = BigDecimal.valueOf(3.0);
+		
+		Tup2bigdR t = new TestTup(one, one);
+		
+		t.getNewInstance(new TestTup(two, three));
+		
+		assertEquals(true, ValueRelay.get("getNewInstanceC", false));
+		assertEquals(two, ValueRelay.get("getNewInstanceC_X", zero));
+		assertEquals(three, ValueRelay.get("getNewInstanceC_Y", zero));
+		
+		// Can't test for the result here, as the relaying and adopting of the values are implementation specific.
+	}
+	
+	/**
+	 * This test ensures, that the default implementation of the function {@link Tup2bigdR#getNewInstance(BigDecimal)} calls
+	 * the function {@link Tup2bigdR#getNewInstance(BigDecimal, BigDecimal)} with the correct components.
+	 */
+	@Test
+	void getNewInstance_ValueTest()
+	{
+		final BigDecimal zero = BigDecimal.ZERO;
+		final BigDecimal one = BigDecimal.ONE;
+		final BigDecimal two = BigDecimal.valueOf(2.0);
+
+		Tup2bigdR t = new TestTup(one, one);
+		
+		t.getNewInstance(two);
+		
+		assertEquals(true, ValueRelay.get("getNewInstanceC", false));
+		assertEquals(two, ValueRelay.get("getNewInstanceC_X", zero));
+		assertEquals(two, ValueRelay.get("getNewInstanceC_Y", zero));
+		
+		// Can't test for the result here, as the relaying and adopting of the values are implementation specific.
+	}
+	
+	/**
 	 * This class is a test implementation of the interface {@link Tup2bigdR}.
 	 * 
 	 * @author picatrix1899
@@ -135,13 +180,24 @@ class Tup2bigdRTest
 		@Override
 		public BigDecimal getX()
 		{
+			ValueRelay.relayCall("getX");
 			return this.x;
 		}
 		
 		@Override
 		public BigDecimal getY()
 		{
+			ValueRelay.relayCall("getY");
 			return this.y;
+		}
+		
+		@Override
+		public TestTup getNewInstance(BigDecimal x, BigDecimal y)
+		{
+			ValueRelay.relayCall("getNewInstanceC");
+			ValueRelay.relay("getNewInstanceC_X", x);
+			ValueRelay.relay("getNewInstanceC_Y", y);
+			return new TestTup(x, y);
 		}
 	}
 }

--- a/barghos-core/src/test/java/org/barghos/core/test/api/tuple2/Tup2bigiRTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/api/tuple2/Tup2bigiRTest.java
@@ -2,9 +2,9 @@ package org.barghos.core.test.api.tuple2;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
-import java.math.BigDecimal;
 import java.math.BigInteger;
 
 import org.barghos.core.api.testing.ValueRelay;
@@ -17,6 +17,15 @@ import org.barghos.core.api.tuple2.Tup2bigiR;
  */
 class Tup2bigiRTest
 {
+	/**
+	 * This method is called after each test in this class.
+	 */
+	@AfterEach
+	void cleanup()
+	{
+		ValueRelay.clear();
+	}
+	
 	/**
 	 * This test ensures, that the function {@link Tup2bigiR#isValid()} returns
 	 * the corrct values for different situations.
@@ -46,19 +55,9 @@ class Tup2bigiRTest
 	@Test
 	void isFiniteTest()
 	{
-		Tup2bigiR t = new Tup2bigiR() {
-			public BigInteger getX()
-			{
-				ValueRelay.relayCall("getX");
-				return null;
-			}
-
-			public BigInteger getY()
-			{
-				ValueRelay.relayCall("getY");
-				return null;
-			}
-		};
+		final BigInteger zero = BigInteger.ZERO;
+		
+		Tup2bigiR t = new TestTup(zero, zero);
 		
 		assertEquals(true, t.isFinite());
 		assertEquals(false, ValueRelay.get("getX", false));
@@ -89,7 +88,7 @@ class Tup2bigiRTest
 	}
 	
 	/**
-	 * This test ensures, that the function {@link Tup2bigiR#isZero(BigDecimal)} returns the correct
+	 * This test ensures, that the function {@link Tup2bigiR#isZero(BigInteger)} returns the correct
 	 * value based on the situation.
 	 */
 	@Test
@@ -118,6 +117,51 @@ class Tup2bigiRTest
 	}
 	
 	/**
+	 * This test ensures, that the default implementation of the function {@link Tup2bigiR#getNewInstance(Tup2bigiR)} calls
+	 * the function {@link Tup2bigiR#getNewInstance(BigInteger, BigInteger)} with the correct components.
+	 */
+	@Test
+	void getNewInstance_TupleTest()
+	{
+		final BigInteger zero = BigInteger.ZERO;
+		final BigInteger one = BigInteger.ONE;
+		final BigInteger two = BigInteger.valueOf(2);
+		final BigInteger three = BigInteger.valueOf(3);
+
+		Tup2bigiR t = new TestTup(one, one);
+	
+		t.getNewInstance(new TestTup(two, three));
+		
+		assertEquals(true, ValueRelay.get("getNewInstanceC", false));
+		assertEquals(two, ValueRelay.get("getNewInstanceC_X", zero));
+		assertEquals(three, ValueRelay.get("getNewInstanceC_Y", zero));
+		
+		// Can't test for the result here, as the relaying and adopting of the values are implementation specific.
+	}
+	
+	/**
+	 * This test ensures, that the default implementation of the function {@link Tup2bigiR#getNewInstance(BigInteger)} calls
+	 * the function {@link Tup2bigiR#getNewInstance(BigInteger, BigInteger)} with the correct components.
+	 */
+	@Test
+	void getNewInstance_ValueTest()
+	{
+		final BigInteger zero = BigInteger.ZERO;
+		final BigInteger one = BigInteger.ONE;
+		final BigInteger two = BigInteger.valueOf(2);
+		
+		Tup2bigiR t = new TestTup(one, one);
+		
+		t.getNewInstance(two);
+		
+		assertEquals(true, ValueRelay.get("getNewInstanceC", false));
+		assertEquals(two, ValueRelay.get("getNewInstanceC_X", zero));
+		assertEquals(two, ValueRelay.get("getNewInstanceC_Y", zero));
+		
+		// Can't test for the result here, as the relaying and adopting of the values are implementation specific.
+	}
+	
+	/**
 	 * This class is a test implementation of the interface {@link Tup2bigiR}.
 	 * 
 	 * @author picatrix1899
@@ -136,13 +180,24 @@ class Tup2bigiRTest
 		@Override
 		public BigInteger getX()
 		{
+			ValueRelay.relayCall("getX");
 			return this.x;
 		}
 		
 		@Override
 		public BigInteger getY()
 		{
+			ValueRelay.relayCall("getY");
 			return this.y;
+		}
+		
+		@Override
+		public TestTup getNewInstance(BigInteger x, BigInteger y)
+		{
+			ValueRelay.relayCall("getNewInstanceC");
+			ValueRelay.relay("getNewInstanceC_X", x);
+			ValueRelay.relay("getNewInstanceC_Y", y);
+			return new TestTup(x, y);
 		}
 	}
 }

--- a/barghos-core/src/test/java/org/barghos/core/test/api/tuple2/Tup2boRTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/api/tuple2/Tup2boRTest.java
@@ -31,22 +31,86 @@ class Tup2boRTest
 	@Test
 	void isValidTest()
 	{
-		Tup2boR t = new Tup2boR() {
-			public boolean getX()
-			{
-				ValueRelay.relayCall("getX");
-				return false;
-			}
-
-			public boolean getY()
-			{
-				ValueRelay.relayCall("getY");
-				return false;
-			}
-		};
+		Tup2boR t = new TestTup(false, false);
 		
 		assertEquals(true, t.isValid());
 		assertEquals(false, ValueRelay.get("getX", false));
 		assertEquals(false, ValueRelay.get("getY", false));
+	}
+	
+	/**
+	 * This test ensures, that the default implementation of the function {@link Tup2boR#getNewInstance(Tup2boR)} calls
+	 * the function {@link Tup2boR#getNewInstance(boolean, boolean)} with the correct components.
+	 */
+	@Test
+	void getNewInstance_TupleTest()
+	{
+		Tup2boR t = new TestTup(false, false);
+		
+		t.getNewInstance(new TestTup(true, true));
+		
+		assertEquals(true, ValueRelay.get("getNewInstanceC", false));
+		assertEquals(true, ValueRelay.get("getNewInstanceC_X", false));
+		assertEquals(true, ValueRelay.get("getNewInstanceC_Y", false));
+		
+		// Can't test for the result here, as the relaying and adopting of the values are implementation specific.
+	}
+	
+	/**
+	 * This test ensures, that the default implementation of the function {@link Tup2boR#getNewInstance(boolean)} calls
+	 * the function {@link Tup2boR#getNewInstance(boolean, boolean)} with the correct components.
+	 */
+	@Test
+	void getNewInstance_ValueTest()
+	{
+		Tup2boR t = new TestTup(false, false);
+		
+		t.getNewInstance(true);
+		
+		assertEquals(true, ValueRelay.get("getNewInstanceC", false));
+		assertEquals(true, ValueRelay.get("getNewInstanceC_X", false));
+		assertEquals(true, ValueRelay.get("getNewInstanceC_Y", false));
+		
+		// Can't test for the result here, as the relaying and adopting of the values are implementation specific.
+	}
+	
+	/**
+	 * This class is a test implementation of the interface {@link Tup2boR}.
+	 * 
+	 * @author picatrix1899
+	 */
+	private static class TestTup implements Tup2boR
+	{
+		private final boolean x;
+		private final boolean y;
+		
+		public TestTup(boolean x, boolean y)
+		{
+			this.x = x;
+			this.y = y;
+		}
+		
+		@Override
+		public boolean getX()
+		{
+			ValueRelay.relayCall("getX");
+			return this.x;
+		}
+		
+		@Override
+		public boolean getY()
+		{
+			ValueRelay.relayCall("getY");
+			return this.y;
+		}
+		
+		@Override
+		public TestTup getNewInstance(boolean x, boolean y)
+		{
+			ValueRelay.relayCall("getNewInstanceC");
+			ValueRelay.relay("getNewInstanceC_X", x);
+			ValueRelay.relay("getNewInstanceC_Y", y);
+			return new TestTup(x, y);
+		}
 	}
 }

--- a/barghos-core/src/test/java/org/barghos/core/test/api/tuple2/Tup2cRTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/api/tuple2/Tup2cRTest.java
@@ -31,19 +31,7 @@ class Tup2cRTest
 	@Test
 	void isValidTest()
 	{
-		Tup2cR t = new Tup2cR() {
-			public char getX()
-			{
-				ValueRelay.relayCall("getX");
-				return 'a';
-			}
-
-			public char getY()
-			{
-				ValueRelay.relayCall("getY");
-				return 'a';
-			}
-		};
+		Tup2cR t = new TestTup('a', 'a');
 		
 		assertEquals(true, t.isValid());
 		assertEquals(false, ValueRelay.get("getX", false));
@@ -57,22 +45,86 @@ class Tup2cRTest
 	@Test
 	void isFiniteTest()
 	{
-		Tup2cR t = new Tup2cR() {
-			public char getX()
-			{
-				ValueRelay.relayCall("getX");
-				return 'a';
-			}
-
-			public char getY()
-			{
-				ValueRelay.relayCall("getY");
-				return 'a';
-			}
-		};
+		Tup2cR t = new TestTup('a', 'a');
 		
 		assertEquals(true, t.isFinite());
 		assertEquals(false, ValueRelay.get("getX", false));
 		assertEquals(false, ValueRelay.get("getY", false));
+	}
+	
+	/**
+	 * This test ensures, that the default implementation of the function {@link Tup2cR#getNewInstance(Tup2cR)} calls
+	 * the function {@link Tup2cR#getNewInstance(char, char)} with the correct components.
+	 */
+	@Test
+	void getNewInstance_TupleTest()
+	{
+		Tup2cR t = new TestTup('b', 'b');
+		
+		t.getNewInstance(new TestTup('c', 'd'));
+		
+		assertEquals(true, ValueRelay.get("getNewInstanceC", false));
+		assertEquals('c', ValueRelay.get("getNewInstanceC_X", 'a'));
+		assertEquals('d', ValueRelay.get("getNewInstanceC_Y", 'a'));
+		
+		// Can't test for the result here, as the relaying and adopting of the values are implementation specific.
+	}
+	
+	/**
+	 * This test ensures, that the default implementation of the function {@link Tup2cR#getNewInstance(char)} calls
+	 * the function {@link Tup2cR#getNewInstance(char, char)} with the correct components.
+	 */
+	@Test
+	void getNewInstance_ValueTest()
+	{
+		Tup2cR t = new TestTup('b', 'b');
+		
+		t.getNewInstance('c');
+		
+		assertEquals(true, ValueRelay.get("getNewInstanceC", false));
+		assertEquals('c', ValueRelay.get("getNewInstanceC_X", 'a'));
+		assertEquals('c', ValueRelay.get("getNewInstanceC_Y", 'a'));
+		
+		// Can't test for the result here, as the relaying and adopting of the values are implementation specific.
+	}
+	
+	/**
+	 * This class is a test implementation of the interface {@link Tup2cR}.
+	 * 
+	 * @author picatrix1899
+	 */
+	private static class TestTup implements Tup2cR
+	{
+		private final char x;
+		private final char y;
+		
+		public TestTup(char x, char y)
+		{
+			this.x = x;
+			this.y = y;
+		}
+		
+		@Override
+		public char getX()
+		{
+			ValueRelay.relayCall("getX");
+			return this.x;
+		}
+		
+		@Override
+		public char getY()
+		{
+			ValueRelay.relayCall("getY");
+			return this.y;
+		}
+		
+		@Override
+		public TestTup getNewInstance(char x, char y)
+		{
+			ValueRelay.relayCall("getNewInstanceC");
+			ValueRelay.relay("getNewInstanceC_X", x);
+			ValueRelay.relay("getNewInstanceC_Y", y);
+			return new TestTup(x, y);
+		}
 	}
 }

--- a/barghos-core/src/test/java/org/barghos/core/test/api/tuple2/Tup2dRTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/api/tuple2/Tup2dRTest.java
@@ -2,6 +2,7 @@ package org.barghos.core.test.api.tuple2;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import org.barghos.core.api.testing.ValueRelay;
@@ -15,25 +16,22 @@ import org.barghos.core.api.tuple2.Tup2dR;
 class Tup2dRTest
 {
 	/**
+	 * This method is called after each test in this class.
+	 */
+	@AfterEach
+	void cleanup()
+	{
+		ValueRelay.clear();
+	}
+	
+	/**
 	 * This test ensures, that the function {@link Tup2dR#isValid()} returns
 	 * the corrct values for different situations.
 	 */
 	@Test
 	void isValidTest()
 	{
-		Tup2dR t = new Tup2dR() {
-			public double getX()
-			{
-				ValueRelay.relayCall("getX");
-				return 0.0;
-			}
-
-			public double getY()
-			{
-				ValueRelay.relayCall("getY");
-				return 0.0;
-			}
-		};
+		Tup2dR t = new TestTup(0.0, 0.0);
 		
 		assertEquals(true, t.isValid());
 		assertEquals(false, ValueRelay.get("getX", false));
@@ -114,6 +112,42 @@ class Tup2dRTest
 	}
 	
 	/**
+	 * This test ensures, that the default implementation of the function {@link Tup2dR#getNewInstance(Tup2dR)} calls
+	 * the function {@link Tup2dR#getNewInstance(double, double)} with the correct components.
+	 */
+	@Test
+	void getNewInstance_TupleTest()
+	{
+		Tup2dR t = new TestTup(1.0, 1.0);
+		
+		t.getNewInstance(new TestTup(2.0, 3.0));
+		
+		assertEquals(true, ValueRelay.get("getNewInstanceC", false));
+		assertEquals(2.0, ValueRelay.get("getNewInstanceC_X", 0.0));
+		assertEquals(3.0, ValueRelay.get("getNewInstanceC_Y", 0.0));
+		
+		// Can't test for the result here, as the relaying and adopting of the values are implementation specific.
+	}
+	
+	/**
+	 * This test ensures, that the default implementation of the function {@link Tup2dR#getNewInstance(double)} calls
+	 * the function {@link Tup2dR#getNewInstance(double, double)} with the correct components.
+	 */
+	@Test
+	void getNewInstance_ValueTest()
+	{
+		Tup2dR t = new TestTup(1.0, 1.0);
+		
+		t.getNewInstance(2.0);
+		
+		assertEquals(true, ValueRelay.get("getNewInstanceC", false));
+		assertEquals(2.0, ValueRelay.get("getNewInstanceC_X", 0.0));
+		assertEquals(2.0, ValueRelay.get("getNewInstanceC_Y", 0.0));
+		
+		// Can't test for the result here, as the relaying and adopting of the values are implementation specific.
+	}
+	
+	/**
 	 * This class is a test implementation of the interface {@link Tup2dR}.
 	 * 
 	 * @author picatrix1899
@@ -132,13 +166,24 @@ class Tup2dRTest
 		@Override
 		public double getX()
 		{
+			ValueRelay.relayCall("getX");
 			return this.x;
 		}
 		
 		@Override
 		public double getY()
 		{
+			ValueRelay.relayCall("getY");
 			return this.y;
+		}
+		
+		@Override
+		public TestTup getNewInstance(double x, double y)
+		{
+			ValueRelay.relayCall("getNewInstanceC");
+			ValueRelay.relay("getNewInstanceC_X", x);
+			ValueRelay.relay("getNewInstanceC_Y", y);
+			return new TestTup(x, y);
 		}
 	}
 }

--- a/barghos-core/src/test/java/org/barghos/core/test/api/tuple2/Tup2fRTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/api/tuple2/Tup2fRTest.java
@@ -2,6 +2,7 @@ package org.barghos.core.test.api.tuple2;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import org.barghos.core.api.testing.ValueRelay;
@@ -15,25 +16,22 @@ import org.barghos.core.api.tuple2.Tup2fR;
 class Tup2fRTest
 {
 	/**
+	 * This method is called after each test in this class.
+	 */
+	@AfterEach
+	void cleanup()
+	{
+		ValueRelay.clear();
+	}
+	
+	/**
 	 * This test ensures, that the function {@link Tup2fR#isValid()} returns
 	 * the corrct values for different situations.
 	 */
 	@Test
 	void isValidTest()
 	{
-		Tup2fR t = new Tup2fR() {
-			public float getX()
-			{
-				ValueRelay.relayCall("getX");
-				return 0.0f;
-			}
-
-			public float getY()
-			{
-				ValueRelay.relayCall("getY");
-				return 0.0f;
-			}
-		};
+		Tup2fR t = new TestTup(0.0f, 0.0f);
 		
 		assertEquals(true, t.isValid());
 		assertEquals(false, ValueRelay.get("getX", false));
@@ -114,6 +112,42 @@ class Tup2fRTest
 	}
 	
 	/**
+	 * This test ensures, that the default implementation of the function {@link Tup2fR#getNewInstance(Tup2fR)} calls
+	 * the function {@link Tup2fR#getNewInstance(float, float)} with the correct components.
+	 */
+	@Test
+	void getNewInstance_TupleTest()
+	{
+		Tup2fR t = new TestTup(1.0f, 1.0f);
+		
+		t.getNewInstance(new TestTup(2.0f, 3.0f));
+		
+		assertEquals(true, ValueRelay.get("getNewInstanceC", false));
+		assertEquals(2.0f, ValueRelay.get("getNewInstanceC_X", 0.0f));
+		assertEquals(3.0f, ValueRelay.get("getNewInstanceC_Y", 0.0f));
+		
+		// Can't test for the result here, as the relaying and adopting of the values are implementation specific.
+	}
+	
+	/**
+	 * This test ensures, that the default implementation of the function {@link Tup2fR#getNewInstance(float)} calls
+	 * the function {@link Tup2fR#getNewInstance(float, float)} with the correct components.
+	 */
+	@Test
+	void getNewInstance_ValueTest()
+	{
+		Tup2fR t = new TestTup(1.0f, 1.0f);
+		
+		t.getNewInstance(2.0f);
+		
+		assertEquals(true, ValueRelay.get("getNewInstanceC", false));
+		assertEquals(2.0f, ValueRelay.get("getNewInstanceC_X", 0.0f));
+		assertEquals(2.0f, ValueRelay.get("getNewInstanceC_Y", 0.0f));
+		
+		// Can't test for the result here, as the relaying and adopting of the values are implementation specific.
+	}
+	
+	/**
 	 * This class is a test implementation of the interface {@link Tup2fR}.
 	 * 
 	 * @author picatrix1899
@@ -132,13 +166,24 @@ class Tup2fRTest
 		@Override
 		public float getX()
 		{
+			ValueRelay.relayCall("getX");
 			return this.x;
 		}
 		
 		@Override
 		public float getY()
 		{
+			ValueRelay.relayCall("getY");
 			return this.y;
+		}
+		
+		@Override
+		public TestTup getNewInstance(float x, float y)
+		{
+			ValueRelay.relayCall("getNewInstanceC");
+			ValueRelay.relay("getNewInstanceC_X", x);
+			ValueRelay.relay("getNewInstanceC_Y", y);
+			return new TestTup(x, y);
 		}
 	}
 }

--- a/barghos-core/src/test/java/org/barghos/core/test/api/tuple2/Tup2iRTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/api/tuple2/Tup2iRTest.java
@@ -2,6 +2,7 @@ package org.barghos.core.test.api.tuple2;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import org.barghos.core.api.testing.ValueRelay;
@@ -15,25 +16,22 @@ import org.barghos.core.api.tuple2.Tup2iR;
 class Tup2iRTest
 {
 	/**
+	 * This method is called after each test in this class.
+	 */
+	@AfterEach
+	void cleanup()
+	{
+		ValueRelay.clear();
+	}
+	
+	/**
 	 * This test ensures, that the function {@link Tup2iR#isValid()} returns
 	 * the corrct values for different situations.
 	 */
 	@Test
 	void isValidTest()
 	{
-		Tup2iR t = new Tup2iR() {
-			public int getX()
-			{
-				ValueRelay.relayCall("getX");
-				return 0;
-			}
-
-			public int getY()
-			{
-				ValueRelay.relayCall("getY");
-				return 0;
-			}
-		};
+		Tup2iR t = new TestTup(0, 0);
 		
 		assertEquals(true, t.isValid());
 		assertEquals(false, ValueRelay.get("getX", false));
@@ -47,19 +45,7 @@ class Tup2iRTest
 	@Test
 	void isFiniteTest()
 	{
-		Tup2iR t = new Tup2iR() {
-			public int getX()
-			{
-				ValueRelay.relayCall("getX");
-				return 0;
-			}
-
-			public int getY()
-			{
-				ValueRelay.relayCall("getY");
-				return 0;
-			}
-		};
+		Tup2iR t = new TestTup(0, 0);
 		
 		assertEquals(true, t.isFinite());
 		assertEquals(false, ValueRelay.get("getX", false));
@@ -114,6 +100,42 @@ class Tup2iRTest
 	}
 	
 	/**
+	 * This test ensures, that the default implementation of the function {@link Tup2iR#getNewInstance(Tup2iR)} calls
+	 * the function {@link Tup2iR#getNewInstance(int, int)} with the correct components.
+	 */
+	@Test
+	void getNewInstance_TupleTest()
+	{
+		Tup2iR t = new TestTup(1, 1);
+		
+		t.getNewInstance(new TestTup(2, 3));
+		
+		assertEquals(true, ValueRelay.get("getNewInstanceC", false));
+		assertEquals(2, ValueRelay.get("getNewInstanceC_X", 0));
+		assertEquals(3, ValueRelay.get("getNewInstanceC_Y", 0));
+		
+		// Can't test for the result here, as the relaying and adopting of the values are implementation specific.
+	}
+	
+	/**
+	 * This test ensures, that the default implementation of the function {@link Tup2iR#getNewInstance(int)} calls
+	 * the function {@link Tup2dR#getNewInstance(int, int)} with the correct components.
+	 */
+	@Test
+	void getNewInstance_ValueTest()
+	{
+		Tup2iR t = new TestTup(1, 1);
+		
+		t.getNewInstance(2);
+		
+		assertEquals(true, ValueRelay.get("getNewInstanceC", false));
+		assertEquals(2, ValueRelay.get("getNewInstanceC_X", 0));
+		assertEquals(2, ValueRelay.get("getNewInstanceC_Y", 0));
+		
+		// Can't test for the result here, as the relaying and adopting of the values are implementation specific.
+	}
+	
+	/**
 	 * This class is a test implementation of the interface {@link Tup2iR}.
 	 * 
 	 * @author picatrix1899
@@ -132,13 +154,24 @@ class Tup2iRTest
 		@Override
 		public int getX()
 		{
+			ValueRelay.relayCall("getX");
 			return this.x;
 		}
 		
 		@Override
 		public int getY()
 		{
+			ValueRelay.relayCall("getY");
 			return this.y;
+		}
+		
+		@Override
+		public TestTup getNewInstance(int x, int y)
+		{
+			ValueRelay.relayCall("getNewInstanceC");
+			ValueRelay.relay("getNewInstanceC_X", x);
+			ValueRelay.relay("getNewInstanceC_Y", y);
+			return new TestTup(x, y);
 		}
 	}
 }

--- a/barghos-core/src/test/java/org/barghos/core/test/api/tuple2/Tup2lRTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/api/tuple2/Tup2lRTest.java
@@ -2,6 +2,7 @@ package org.barghos.core.test.api.tuple2;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import org.barghos.core.api.testing.ValueRelay;
@@ -15,25 +16,22 @@ import org.barghos.core.api.tuple2.Tup2lR;
 class Tup2lRTest
 {
 	/**
+	 * This method is called after each test in this class.
+	 */
+	@AfterEach
+	void cleanup()
+	{
+		ValueRelay.clear();
+	}
+	
+	/**
 	 * This test ensures, that the function {@link Tup2lR#isValid()} returns
 	 * the corrct values for different situations.
 	 */
 	@Test
 	void isValidTest()
 	{
-		Tup2lR t = new Tup2lR() {
-			public long getX()
-			{
-				ValueRelay.relayCall("getX");
-				return 0l;
-			}
-
-			public long getY()
-			{
-				ValueRelay.relayCall("getY");
-				return 0l;
-			}
-		};
+		Tup2lR t = new TestTup(0l, 0l);
 		
 		assertEquals(true, t.isValid());
 		assertEquals(false, ValueRelay.get("getX", false));
@@ -47,19 +45,7 @@ class Tup2lRTest
 	@Test
 	void isFiniteTest()
 	{
-		Tup2lR t = new Tup2lR() {
-			public long getX()
-			{
-				ValueRelay.relayCall("getX");
-				return 0l;
-			}
-
-			public long getY()
-			{
-				ValueRelay.relayCall("getY");
-				return 0l;
-			}
-		};
+		Tup2lR t = new TestTup(0l, 0l);
 		
 		assertEquals(true, t.isFinite());
 		assertEquals(false, ValueRelay.get("getX", false));
@@ -114,6 +100,42 @@ class Tup2lRTest
 	}
 	
 	/**
+	 * This test ensures, that the default implementation of the function {@link Tup2lR#getNewInstance(Tup2lR)} calls
+	 * the function {@link Tup2lR#getNewInstance(long, long)} with the correct components.
+	 */
+	@Test
+	void getNewInstance_TupleTest()
+	{
+		Tup2lR t = new TestTup(1l, 1l);
+		
+		t.getNewInstance(new TestTup(2l, 3l));
+		
+		assertEquals(true, ValueRelay.get("getNewInstanceC", false));
+		assertEquals(2l, ValueRelay.get("getNewInstanceC_X", 0l));
+		assertEquals(3l, ValueRelay.get("getNewInstanceC_Y", 0l));
+		
+		// Can't test for the result here, as the relaying and adopting of the values are implementation specific.
+	}
+	
+	/**
+	 * This test ensures, that the default implementation of the function {@link Tup2lR#getNewInstance(long)} calls
+	 * the function {@link Tup2lR#getNewInstance(long, long)} with the correct components.
+	 */
+	@Test
+	void getNewInstance_ValueTest()
+	{
+		Tup2lR t = new TestTup(1l, 1l);
+		
+		t.getNewInstance(2l);
+		
+		assertEquals(true, ValueRelay.get("getNewInstanceC", false));
+		assertEquals(2l, ValueRelay.get("getNewInstanceC_X", 0l));
+		assertEquals(2l, ValueRelay.get("getNewInstanceC_Y", 0l));
+		
+		// Can't test for the result here, as the relaying and adopting of the values are implementation specific.
+	}
+	
+	/**
 	 * This class is a test implementation of the interface {@link Tup2lR}.
 	 * 
 	 * @author picatrix1899
@@ -132,13 +154,24 @@ class Tup2lRTest
 		@Override
 		public long getX()
 		{
+			ValueRelay.relayCall("getX");
 			return this.x;
 		}
 		
 		@Override
 		public long getY()
 		{
+			ValueRelay.relayCall("getY");
 			return this.y;
+		}
+		
+		@Override
+		public TestTup getNewInstance(long x, long y)
+		{
+			ValueRelay.relayCall("getNewInstanceC");
+			ValueRelay.relay("getNewInstanceC_X", x);
+			ValueRelay.relay("getNewInstanceC_Y", y);
+			return new TestTup(x, y);
 		}
 	}
 }

--- a/barghos-core/src/test/java/org/barghos/core/test/api/tuple2/Tup2oRTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/api/tuple2/Tup2oRTest.java
@@ -2,8 +2,10 @@ package org.barghos.core.test.api.tuple2;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
+import org.barghos.core.api.testing.ValueRelay;
 import org.barghos.core.api.tuple2.Tup2oR;
 
 /**
@@ -13,6 +15,15 @@ import org.barghos.core.api.tuple2.Tup2oR;
  */
 class Tup2oRTest
 {
+	/**
+	 * This method is called after each test in this class.
+	 */
+	@AfterEach
+	void cleanup()
+	{
+		ValueRelay.clear();
+	}
+	
 	/**
 	 * This test ensures, that the function {@link Tup2oR#isValid()} returns
 	 * the corrct values for different situations.
@@ -31,6 +42,24 @@ class Tup2oRTest
 		
 		t = new TestTup<>(new Object(), new Object());
 		assertEquals(true, t.isValid());
+	}
+	
+	/**
+	 * This test ensures, that the default implementation of the function {@link Tup2oR#getNewInstance(Tup2objR)} calls
+	 * the function {@link Tup2oR#getNewInstance(Object, Object)} with the correct components.
+	 */
+	@Test
+	void getNewInstance_TupleTest()
+	{
+		Tup2oR<Long,Long> t = new TestTup<>(1l, 1l);
+		
+		t.getNewInstance(new TestTup<>(2l, 3l));
+		
+		assertEquals(true, ValueRelay.get("getNewInstanceC", false));
+		assertEquals(2l, ValueRelay.get("getNewInstanceC_X", 0l));
+		assertEquals(3l, ValueRelay.get("getNewInstanceC_Y", 0l));
+		
+		// Can't test for the result here, as the relaying and adopting of the values are implementation specific.
 	}
 	
 	/**
@@ -59,6 +88,15 @@ class Tup2oRTest
 		public Y getY()
 		{
 			return this.y;
+		}
+		
+		@Override
+		public TestTup<X,Y> getNewInstance(X x, Y y)
+		{
+			ValueRelay.relayCall("getNewInstanceC");
+			ValueRelay.relay("getNewInstanceC_X", x);
+			ValueRelay.relay("getNewInstanceC_Y", y);
+			return new TestTup<>(x, y);
 		}
 	}
 }

--- a/barghos-core/src/test/java/org/barghos/core/test/api/tuple2/Tup2objRTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/api/tuple2/Tup2objRTest.java
@@ -2,8 +2,10 @@ package org.barghos.core.test.api.tuple2;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
+import org.barghos.core.api.testing.ValueRelay;
 import org.barghos.core.api.tuple2.Tup2objR;
 
 /**
@@ -13,6 +15,15 @@ import org.barghos.core.api.tuple2.Tup2objR;
  */
 class Tup2objRTest
 {
+	/**
+	 * This method is called after each test in this class.
+	 */
+	@AfterEach
+	void cleanup()
+	{
+		ValueRelay.clear();
+	}
+	
 	/**
 	 * This test ensures, that the function {@link Tup2objR#isValid()} returns
 	 * the corrct values for different situations.
@@ -31,6 +42,42 @@ class Tup2objRTest
 		
 		t = new TestTup(new Object(), new Object());
 		assertEquals(true, t.isValid());
+	}
+	
+	/**
+	 * This test ensures, that the default implementation of the function {@link Tup2objR#getNewInstance(Tup2objR)} calls
+	 * the function {@link Tup2objR#getNewInstance(Object, Object)} with the correct components.
+	 */
+	@Test
+	void getNewInstance_TupleTest()
+	{
+		Tup2objR t = new TestTup(1l, 1l);
+		
+		t.getNewInstance(new TestTup(2l, 3l));
+		
+		assertEquals(true, ValueRelay.get("getNewInstanceC", false));
+		assertEquals(2l, ValueRelay.get("getNewInstanceC_X", 0l));
+		assertEquals(3l, ValueRelay.get("getNewInstanceC_Y", 0l));
+		
+		// Can't test for the result here, as the relaying and adopting of the values are implementation specific.
+	}
+	
+	/**
+	 * This test ensures, that the default implementation of the function {@link Tup2objR#getNewInstance(Object)} calls
+	 * the function {@link Tup2objR#getNewInstance(Object, Object)} with the correct components.
+	 */
+	@Test
+	void getNewInstance_ValueTest()
+	{
+		Tup2objR t = new TestTup(1l, 1l);
+		
+		t.getNewInstance(2l);
+		
+		assertEquals(true, ValueRelay.get("getNewInstanceC", false));
+		assertEquals(2l, ValueRelay.get("getNewInstanceC_X", 0l));
+		assertEquals(2l, ValueRelay.get("getNewInstanceC_Y", 0l));
+		
+		// Can't test for the result here, as the relaying and adopting of the values are implementation specific.
 	}
 	
 	/**
@@ -59,6 +106,15 @@ class Tup2objRTest
 		public Object getY()
 		{
 			return this.y;
+		}
+		
+		@Override
+		public TestTup getNewInstance(Object x, Object y)
+		{
+			ValueRelay.relayCall("getNewInstanceC");
+			ValueRelay.relay("getNewInstanceC_X", x);
+			ValueRelay.relay("getNewInstanceC_Y", y);
+			return new TestTup(x, y);
 		}
 	}
 }

--- a/barghos-core/src/test/java/org/barghos/core/test/api/tuple2/Tup2sRTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/api/tuple2/Tup2sRTest.java
@@ -2,6 +2,7 @@ package org.barghos.core.test.api.tuple2;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import org.barghos.core.api.testing.ValueRelay;
@@ -15,25 +16,24 @@ import org.barghos.core.api.tuple2.Tup2sR;
 class Tup2sRTest
 {
 	/**
+	 * This method is called after each test in this class.
+	 */
+	@AfterEach
+	void cleanup()
+	{
+		ValueRelay.clear();
+	}
+	
+	/**
 	 * This test ensures, that the function {@link Tup2sR#isValid()} returns
 	 * the corrct values for different situations.
 	 */
 	@Test
 	void isValidTest()
 	{
-		Tup2sR t = new Tup2sR() {
-			public short getX()
-			{
-				ValueRelay.relayCall("getX");
-				return (short)0;
-			}
-
-			public short getY()
-			{
-				ValueRelay.relayCall("getY");
-				return (short)0;
-			}
-		};
+		final short zero = (short)0;
+		
+		Tup2sR t = new TestTup(zero, zero);
 		
 		assertEquals(true, t.isValid());
 		assertEquals(false, ValueRelay.get("getX", false));
@@ -47,19 +47,9 @@ class Tup2sRTest
 	@Test
 	void isFiniteTest()
 	{
-		Tup2sR t = new Tup2sR() {
-			public short getX()
-			{
-				ValueRelay.relayCall("getX");
-				return (short)0;
-			}
-
-			public short getY()
-			{
-				ValueRelay.relayCall("getY");
-				return (short)0;
-			}
-		};
+		final short zero = (short)0;
+		
+		Tup2sR t = new TestTup(zero, zero);
 		
 		assertEquals(true, t.isFinite());
 		assertEquals(false, ValueRelay.get("getX", false));
@@ -119,6 +109,51 @@ class Tup2sRTest
 	}
 	
 	/**
+	 * This test ensures, that the default implementation of the function {@link Tup2sR#getNewInstance(Tup2sR)} calls
+	 * the function {@link Tup2sR#getNewInstance(short, short)} with the correct components.
+	 */
+	@Test
+	void getNewInstance_TupleTest()
+	{
+		final short zero = (short)0;
+		final short one = (short)1;
+		final short two = (short)2;
+		final short three = (short)3;
+		
+		Tup2sR t = new TestTup(one, one);
+		
+		t.getNewInstance(new TestTup(two, three));
+		
+		assertEquals(true, ValueRelay.get("getNewInstanceC", false));
+		assertEquals(two, ValueRelay.get("getNewInstanceC_X", zero));
+		assertEquals(three, ValueRelay.get("getNewInstanceC_Y", zero));
+		
+		// Can't test for the result here, as the relaying and adopting of the values are implementation specific.
+	}
+	
+	/**
+	 * This test ensures, that the default implementation of the function {@link Tup2sR#getNewInstance(short)} calls
+	 * the function {@link Tup2sR#getNewInstance(short, short)} with the correct components.
+	 */
+	@Test
+	void getNewInstance_ValueTest()
+	{
+		final short zero = (short)0;
+		final short one = (short)1;
+		final short two = (short)2;
+
+		Tup2sR t = new TestTup(one, one);
+		
+		t.getNewInstance(two);
+		
+		assertEquals(true, ValueRelay.get("getNewInstanceC", false));
+		assertEquals(two, ValueRelay.get("getNewInstanceC_X", zero));
+		assertEquals(two, ValueRelay.get("getNewInstanceC_Y", zero));
+		
+		// Can't test for the result here, as the relaying and adopting of the values are implementation specific.
+	}
+	
+	/**
 	 * This class is a test implementation of the interface {@link Tup2sR}.
 	 * 
 	 * @author picatrix1899
@@ -137,13 +172,24 @@ class Tup2sRTest
 		@Override
 		public short getX()
 		{
+			ValueRelay.relayCall("getX");
 			return this.x;
 		}
 		
 		@Override
 		public short getY()
 		{
+			ValueRelay.relayCall("getY");
 			return this.y;
+		}
+		
+		@Override
+		public TestTup getNewInstance(short x, short y)
+		{
+			ValueRelay.relayCall("getNewInstanceC");
+			ValueRelay.relay("getNewInstanceC_X", x);
+			ValueRelay.relay("getNewInstanceC_Y", y);
+			return new TestTup(x, y);
 		}
 	}
 }

--- a/barghos-core/src/test/java/org/barghos/core/test/api/tuple2/Tup2strRTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/api/tuple2/Tup2strRTest.java
@@ -2,8 +2,10 @@ package org.barghos.core.test.api.tuple2;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
+import org.barghos.core.api.testing.ValueRelay;
 import org.barghos.core.api.tuple2.Tup2strR;
 
 /**
@@ -13,6 +15,15 @@ import org.barghos.core.api.tuple2.Tup2strR;
  */
 class Tup2strRTest
 {
+	/**
+	 * This method is called after each test in this class.
+	 */
+	@AfterEach
+	void cleanup()
+	{
+		ValueRelay.clear();
+	}
+	
 	/**
 	 * This test ensures, that the function {@link Tup2strR#isValid()} returns
 	 * the corrct values for different situations.
@@ -31,6 +42,42 @@ class Tup2strRTest
 		
 		t = new TestTup("", "");
 		assertEquals(true, t.isValid());
+	}
+	
+	/**
+	 * This test ensures, that the default implementation of the function {@link Tup2strR#getNewInstance(Tup2strR)} calls
+	 * the function {@link Tup2strR#getNewInstance(String, String)} with the correct components.
+	 */
+	@Test
+	void getNewInstance_TupleTest()
+	{
+		Tup2strR t = new TestTup("a", "a");
+		
+		t.getNewInstance(new TestTup("b", "c"));
+		
+		assertEquals(true, ValueRelay.get("getNewInstanceC", false));
+		assertEquals("b", ValueRelay.get("getNewInstanceC_X", ""));
+		assertEquals("c", ValueRelay.get("getNewInstanceC_Y", ""));
+		
+		// Can't test for the result here, as the relaying and adopting of the values are implementation specific.
+	}
+	
+	/**
+	 * This test ensures, that the default implementation of the function {@link Tup2strR#getNewInstance(String)} calls
+	 * the function {@link Tup2strR#getNewInstance(String, String)} with the correct components.
+	 */
+	@Test
+	void getNewInstance_ValueTest()
+	{
+		Tup2strR t = new TestTup("a", "a");
+		
+		t.getNewInstance("b");
+		
+		assertEquals(true, ValueRelay.get("getNewInstanceC", false));
+		assertEquals("b", ValueRelay.get("getNewInstanceC_X", ""));
+		assertEquals("b", ValueRelay.get("getNewInstanceC_Y", ""));
+		
+		// Can't test for the result here, as the relaying and adopting of the values are implementation specific.
 	}
 	
 	/**
@@ -59,6 +106,15 @@ class Tup2strRTest
 		public String getY()
 		{
 			return this.y;
+		}
+		
+		@Override
+		public TestTup getNewInstance(String x, String y)
+		{
+			ValueRelay.relayCall("getNewInstanceC");
+			ValueRelay.relay("getNewInstanceC_X", x);
+			ValueRelay.relay("getNewInstanceC_Y", y);
+			return new TestTup(x, y);
 		}
 	}
 }

--- a/barghos-core/src/test/java/org/barghos/core/test/api/tuple3/Tup3bRTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/api/tuple3/Tup3bRTest.java
@@ -2,6 +2,7 @@ package org.barghos.core.test.api.tuple3;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import org.barghos.core.api.testing.ValueRelay;
@@ -15,31 +16,24 @@ import org.barghos.core.api.tuple3.Tup3bR;
 class Tup3bRTest
 {
 	/**
+	 * This method is called after each test in this class.
+	 */
+	@AfterEach
+	void cleanup()
+	{
+		ValueRelay.clear();
+	}
+	
+	/**
 	 * This test ensures, that the function {@link Tup3bR#isValid()} returns
 	 * the corrct values for different situations.
 	 */
 	@Test
 	void isValidTest()
 	{
-		Tup3bR t = new Tup3bR() {
-			public byte getX()
-			{
-				ValueRelay.relayCall("getX");
-				return (byte)0;
-			}
-
-			public byte getY()
-			{
-				ValueRelay.relayCall("getY");
-				return (byte)0;
-			}
-			
-			public byte getZ()
-			{
-				ValueRelay.relayCall("getZ");
-				return (byte)0;
-			}
-		};
+		final byte zero = (byte)0;
+		
+		Tup3bR t = new TestTup(zero, zero, zero);
 		
 		assertEquals(true, t.isValid());
 		assertEquals(false, ValueRelay.get("getX", false));
@@ -54,25 +48,9 @@ class Tup3bRTest
 	@Test
 	void isFiniteTest()
 	{
-		Tup3bR t = new Tup3bR() {
-			public byte getX()
-			{
-				ValueRelay.relayCall("getX");
-				return (byte)0;
-			}
-
-			public byte getY()
-			{
-				ValueRelay.relayCall("getY");
-				return (byte)0;
-			}
-			
-			public byte getZ()
-			{
-				ValueRelay.relayCall("getZ");
-				return (byte)0;
-			}
-		};
+		final byte zero = (byte)0;
+		
+		Tup3bR t = new TestTup(zero, zero, zero);
 		
 		assertEquals(true, t.isFinite());
 		assertEquals(false, ValueRelay.get("getX", false));
@@ -139,6 +117,54 @@ class Tup3bRTest
 	}
 	
 	/**
+	 * This test ensures, that the default implementation of the function {@link Tup3bR#getNewInstance(Tup3bR)} calls
+	 * the function {@link Tup3bR#getNewInstance(byte, byte, byte)} with the correct components.
+	 */
+	@Test
+	void getNewInstance_TupleTest()
+	{
+		final byte zero = (byte)0;
+		final byte one = (byte)1;
+		final byte two = (byte)2;
+		final byte three = (byte)3;
+		final byte four = (byte)4;
+		
+		Tup3bR t = new TestTup(one, one, one);
+		
+		t.getNewInstance(new TestTup(two, three, four));
+		
+		assertEquals(true, ValueRelay.get("getNewInstanceC", false));
+		assertEquals(two, ValueRelay.get("getNewInstanceC_X", zero));
+		assertEquals(three, ValueRelay.get("getNewInstanceC_Y", zero));
+		assertEquals(four, ValueRelay.get("getNewInstanceC_Z", zero));
+		
+		// Can't test for the result here, as the relaying and adopting of the values are implementation specific.
+	}
+	
+	/**
+	 * This test ensures, that the default implementation of the function {@link Tup3bR#getNewInstance(byte)} calls
+	 * the function {@link Tup3bR#getNewInstance(byte, byte, byte)} with the correct components.
+	 */
+	@Test
+	void getNewInstance_ValueTest()
+	{
+		final byte zero = (byte)0;
+		final byte one = (byte)1;
+		final byte two = (byte)2;
+		
+		Tup3bR t = new TestTup(one, one, one);
+		
+		t.getNewInstance(two);
+		
+		assertEquals(true, ValueRelay.get("getNewInstanceC", false));
+		assertEquals(two, ValueRelay.get("getNewInstanceC_X", zero));
+		assertEquals(two, ValueRelay.get("getNewInstanceC_Y", zero));
+		assertEquals(two, ValueRelay.get("getNewInstanceC_Z", zero));
+		
+		// Can't test for the result here, as the relaying and adopting of the values are implementation specific.
+	}
+	
+	/**
 	 * This class is a test implementation of the interface {@link Tup3bR}.
 	 * 
 	 * @author picatrix1899
@@ -159,19 +185,32 @@ class Tup3bRTest
 		@Override
 		public byte getX()
 		{
+			ValueRelay.relayCall("getX");
 			return this.x;
 		}
 		
 		@Override
 		public byte getY()
 		{
+			ValueRelay.relayCall("getY");
 			return this.y;
 		}
 		
 		@Override
 		public byte getZ()
 		{
+			ValueRelay.relayCall("getZ");
 			return this.z;
+		}
+		
+		@Override
+		public TestTup getNewInstance(byte x, byte y, byte z)
+		{
+			ValueRelay.relayCall("getNewInstanceC");
+			ValueRelay.relay("getNewInstanceC_X", x);
+			ValueRelay.relay("getNewInstanceC_Y", y);
+			ValueRelay.relay("getNewInstanceC_Z", z);
+			return new TestTup(x, y, z);
 		}
 	}
 }

--- a/barghos-core/src/test/java/org/barghos/core/test/api/tuple3/Tup3bigdRTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/api/tuple3/Tup3bigdRTest.java
@@ -2,6 +2,7 @@ package org.barghos.core.test.api.tuple3;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
@@ -16,6 +17,15 @@ import org.barghos.core.api.tuple3.Tup3bigdR;
  */
 class Tup3bigdRTest
 {
+	/**
+	 * This method is called after each test in this class.
+	 */
+	@AfterEach
+	void cleanup()
+	{
+		ValueRelay.clear();
+	}
+	
 	/**
 	 * This test ensures, that the function {@link Tup3bigdR#isValid()} returns
 	 * the corrct values for different situations.
@@ -48,25 +58,9 @@ class Tup3bigdRTest
 	@Test
 	void isFiniteTest()
 	{
-		Tup3bigdR t = new Tup3bigdR() {
-			public BigDecimal getX()
-			{
-				ValueRelay.relayCall("getX");
-				return null;
-			}
-
-			public BigDecimal getY()
-			{
-				ValueRelay.relayCall("getY");
-				return null;
-			}
-			
-			public BigDecimal getZ()
-			{
-				ValueRelay.relayCall("getZ");
-				return null;
-			}
-		};
+		BigDecimal zero = BigDecimal.ZERO;
+		
+		Tup3bigdR t = new TestTup(zero, zero, zero);
 		
 		assertEquals(true, t.isFinite());
 		assertEquals(false, ValueRelay.get("getX", false));
@@ -133,6 +127,54 @@ class Tup3bigdRTest
 	}
 	
 	/**
+	 * This test ensures, that the default implementation of the function {@link Tup3bigdR#getNewInstance(Tup3bigdR)} calls
+	 * the function {@link Tup3bigdR#getNewInstance(BigDecimal, BigDecimal, BigDecimal)} with the correct components.
+	 */
+	@Test
+	void getNewInstance_TupleTest()
+	{
+		final BigDecimal zero = BigDecimal.ZERO;
+		final BigDecimal one = BigDecimal.ONE;
+		final BigDecimal two = BigDecimal.valueOf(2.0);
+		final BigDecimal three = BigDecimal.valueOf(3.0);
+		final BigDecimal four = BigDecimal.valueOf(4.0);
+		
+		Tup3bigdR t = new TestTup(one, one, one);
+		
+		t.getNewInstance(new TestTup(two, three, four));
+		
+		assertEquals(true, ValueRelay.get("getNewInstanceC", false));
+		assertEquals(two, ValueRelay.get("getNewInstanceC_X", zero));
+		assertEquals(three, ValueRelay.get("getNewInstanceC_Y", zero));
+		assertEquals(four, ValueRelay.get("getNewInstanceC_Z", zero));
+		
+		// Can't test for the result here, as the relaying and adopting of the values are implementation specific.
+	}
+	
+	/**
+	 * This test ensures, that the default implementation of the function {@link Tup3bigdR#getNewInstance(BigDecimal)} calls
+	 * the function {@link Tup3bigdR#getNewInstance(BigDecimal, BigDecimal, BigDecimal)} with the correct components.
+	 */
+	@Test
+	void getNewInstance_ValueTest()
+	{
+		final BigDecimal zero = BigDecimal.ZERO;
+		final BigDecimal one = BigDecimal.ONE;
+		final BigDecimal two = BigDecimal.valueOf(2.0);
+
+		Tup3bigdR t = new TestTup(one, one, one);
+		
+		t.getNewInstance(two);
+		
+		assertEquals(true, ValueRelay.get("getNewInstanceC", false));
+		assertEquals(two, ValueRelay.get("getNewInstanceC_X", zero));
+		assertEquals(two, ValueRelay.get("getNewInstanceC_Y", zero));
+		assertEquals(two, ValueRelay.get("getNewInstanceC_Z", zero));
+		
+		// Can't test for the result here, as the relaying and adopting of the values are implementation specific.
+	}
+	
+	/**
 	 * This class is a test implementation of the interface {@link Tup2bigdR}.
 	 * 
 	 * @author picatrix1899
@@ -153,19 +195,32 @@ class Tup3bigdRTest
 		@Override
 		public BigDecimal getX()
 		{
+			ValueRelay.relayCall("getX");
 			return this.x;
 		}
 		
 		@Override
 		public BigDecimal getY()
 		{
+			ValueRelay.relayCall("getY");
 			return this.y;
 		}
 		
 		@Override
 		public BigDecimal getZ()
 		{
+			ValueRelay.relayCall("getZ");
 			return this.z;
+		}
+		
+		@Override
+		public TestTup getNewInstance(BigDecimal x, BigDecimal y, BigDecimal z)
+		{
+			ValueRelay.relayCall("getNewInstanceC");
+			ValueRelay.relay("getNewInstanceC_X", x);
+			ValueRelay.relay("getNewInstanceC_Y", y);
+			ValueRelay.relay("getNewInstanceC_Z", z);
+			return new TestTup(x, y, z);
 		}
 	}
 }

--- a/barghos-core/src/test/java/org/barghos/core/test/api/tuple3/Tup3bigiRTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/api/tuple3/Tup3bigiRTest.java
@@ -2,9 +2,9 @@ package org.barghos.core.test.api.tuple3;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
-import java.math.BigDecimal;
 import java.math.BigInteger;
 
 import org.barghos.core.api.testing.ValueRelay;
@@ -17,6 +17,15 @@ import org.barghos.core.api.tuple3.Tup3bigiR;
  */
 class Tup3bigiRTest
 {
+	/**
+	 * This method is called after each test in this class.
+	 */
+	@AfterEach
+	void cleanup()
+	{
+		ValueRelay.clear();
+	}
+	
 	/**
 	 * This test ensures, that the function {@link Tup3bigiR#isValid()} returns
 	 * the corrct values for different situations.
@@ -49,25 +58,9 @@ class Tup3bigiRTest
 	@Test
 	void isFiniteTest()
 	{
-		Tup3bigiR t = new Tup3bigiR() {
-			public BigInteger getX()
-			{
-				ValueRelay.relayCall("getX");
-				return null;
-			}
-
-			public BigInteger getY()
-			{
-				ValueRelay.relayCall("getY");
-				return null;
-			}
-			
-			public BigInteger getZ()
-			{
-				ValueRelay.relayCall("getZ");
-				return null;
-			}
-		};
+		final BigInteger zero = BigInteger.ZERO;
+		
+		Tup3bigiR t = new TestTup(zero, zero, zero);
 		
 		assertEquals(true, t.isFinite());
 		assertEquals(false, ValueRelay.get("getX", false));
@@ -102,7 +95,7 @@ class Tup3bigiRTest
 	}
 	
 	/**
-	 * This test ensures, that the function {@link Tup3bigiR#isZero(BigDecimal)} returns the correct
+	 * This test ensures, that the function {@link Tup3bigiR#isZero(BigInteger)} returns the correct
 	 * value based on the situation.
 	 */
 	@Test
@@ -134,6 +127,54 @@ class Tup3bigiRTest
 	}
 	
 	/**
+	 * This test ensures, that the default implementation of the function {@link Tup3bigiR#getNewInstance(Tup3bigiR)} calls
+	 * the function {@link Tup3bigiR#getNewInstance(BigInteger, BigInteger, BigInteger)} with the correct components.
+	 */
+	@Test
+	void getNewInstance_TupleTest()
+	{
+		final BigInteger zero = BigInteger.ZERO;
+		final BigInteger one = BigInteger.ONE;
+		final BigInteger two = BigInteger.valueOf(2);
+		final BigInteger three = BigInteger.valueOf(3);
+		final BigInteger four = BigInteger.valueOf(4);
+		
+		Tup3bigiR t = new TestTup(one, one, one);
+		
+		t.getNewInstance(new TestTup(two, three, four));
+		
+		assertEquals(true, ValueRelay.get("getNewInstanceC", false));
+		assertEquals(two, ValueRelay.get("getNewInstanceC_X", zero));
+		assertEquals(three, ValueRelay.get("getNewInstanceC_Y", zero));
+		assertEquals(four, ValueRelay.get("getNewInstanceC_Z", zero));
+		
+		// Can't test for the result here, as the relaying and adopting of the values are implementation specific.
+	}
+	
+	/**
+	 * This test ensures, that the default implementation of the function {@link Tup3bigiR#getNewInstance(BigInteger)} calls
+	 * the function {@link Tup3bigiR#getNewInstance(BigInteger, BigInteger, BigInteger)} with the correct components.
+	 */
+	@Test
+	void getNewInstance_ValueTest()
+	{
+		final BigInteger zero = BigInteger.ZERO;
+		final BigInteger one = BigInteger.ONE;
+		final BigInteger two = BigInteger.valueOf(2);
+
+		Tup3bigiR t = new TestTup(one, one, one);
+		
+		t.getNewInstance(two);
+		
+		assertEquals(true, ValueRelay.get("getNewInstanceC", false));
+		assertEquals(two, ValueRelay.get("getNewInstanceC_X", zero));
+		assertEquals(two, ValueRelay.get("getNewInstanceC_Y", zero));
+		assertEquals(two, ValueRelay.get("getNewInstanceC_Z", zero));
+		
+		// Can't test for the result here, as the relaying and adopting of the values are implementation specific.
+	}
+	
+	/**
 	 * This class is a test implementation of the interface {@link Tup3bigiR}.
 	 * 
 	 * @author picatrix1899
@@ -154,19 +195,32 @@ class Tup3bigiRTest
 		@Override
 		public BigInteger getX()
 		{
+			ValueRelay.relayCall("getX");
 			return this.x;
 		}
 		
 		@Override
 		public BigInteger getY()
 		{
+			ValueRelay.relayCall("getY");
 			return this.y;
 		}
 		
 		@Override
 		public BigInteger getZ()
 		{
+			ValueRelay.relayCall("getZ");
 			return this.z;
+		}
+		
+		@Override
+		public TestTup getNewInstance(BigInteger x, BigInteger y, BigInteger z)
+		{
+			ValueRelay.relayCall("getNewInstanceC");
+			ValueRelay.relay("getNewInstanceC_X", x);
+			ValueRelay.relay("getNewInstanceC_Y", y);
+			ValueRelay.relay("getNewInstanceC_Z", z);
+			return new TestTup(x, y, z);
 		}
 	}
 }

--- a/barghos-core/src/test/java/org/barghos/core/test/api/tuple3/Tup3boRTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/api/tuple3/Tup3boRTest.java
@@ -31,29 +31,99 @@ class Tup3boRTest
 	@Test
 	void isValidTest()
 	{
-		Tup3boR t = new Tup3boR() {
-			public boolean getX()
-			{
-				ValueRelay.relayCall("getX");
-				return false;
-			}
-
-			public boolean getY()
-			{
-				ValueRelay.relayCall("getY");
-				return false;
-			}
-			
-			public boolean getZ()
-			{
-				ValueRelay.relayCall("getZ");
-				return false;
-			}
-		};
+		Tup3boR t = new TestTup(false, false, false);
 		
 		assertEquals(true, t.isValid());
 		assertEquals(false, ValueRelay.get("getX", false));
 		assertEquals(false, ValueRelay.get("getY", false));
 		assertEquals(false, ValueRelay.get("getZ", false));
+	}
+	
+	/**
+	 * This test ensures, that the default implementation of the function {@link Tup3boR#getNewInstance(Tup3boR)} calls
+	 * the function {@link Tup3boR#getNewInstance(boolean, boolean, boolean)} with the correct components.
+	 */
+	@Test
+	void getNewInstance_TupleTest()
+	{
+		Tup3boR t = new TestTup(false, false, false);
+		
+		t.getNewInstance(new TestTup(true, true, true));
+		
+		assertEquals(true, ValueRelay.get("getNewInstanceC", false));
+		assertEquals(true, ValueRelay.get("getNewInstanceC_X", false));
+		assertEquals(true, ValueRelay.get("getNewInstanceC_Y", false));
+		assertEquals(true, ValueRelay.get("getNewInstanceC_Z", false));
+		
+		// Can't test for the result here, as the relaying and adopting of the values are implementation specific.
+	}
+	
+	/**
+	 * This test ensures, that the default implementation of the function {@link Tup3boR#getNewInstance(boolean)} calls
+	 * the function {@link Tup3boR#getNewInstance(boolean, boolean, boolean)} with the correct components.
+	 */
+	@Test
+	void getNewInstance_ValueTest()
+	{
+		Tup3boR t = new TestTup(false, false, false);
+		
+		t.getNewInstance(true);
+		
+		assertEquals(true, ValueRelay.get("getNewInstanceC", false));
+		assertEquals(true, ValueRelay.get("getNewInstanceC_X", false));
+		assertEquals(true, ValueRelay.get("getNewInstanceC_Y", false));
+		assertEquals(true, ValueRelay.get("getNewInstanceC_Z", false));
+		
+		// Can't test for the result here, as the relaying and adopting of the values are implementation specific.
+	}
+	
+	/**
+	 * This class is a test implementation of the interface {@link Tup3boR}.
+	 * 
+	 * @author picatrix1899
+	 */
+	private static class TestTup implements Tup3boR
+	{
+		private final boolean x;
+		private final boolean y;
+		private final boolean z;
+		
+		public TestTup(boolean x, boolean y, boolean z)
+		{
+			this.x = x;
+			this.y = y;
+			this.z = z;
+		}
+		
+		@Override
+		public boolean getX()
+		{
+			ValueRelay.relayCall("getX");
+			return this.x;
+		}
+		
+		@Override
+		public boolean getY()
+		{
+			ValueRelay.relayCall("getY");
+			return this.y;
+		}
+		
+		@Override
+		public boolean getZ()
+		{
+			ValueRelay.relayCall("getZ");
+			return this.z;
+		}
+		
+		@Override
+		public TestTup getNewInstance(boolean x, boolean y, boolean z)
+		{
+			ValueRelay.relayCall("getNewInstanceC");
+			ValueRelay.relay("getNewInstanceC_X", x);
+			ValueRelay.relay("getNewInstanceC_Y", y);
+			ValueRelay.relay("getNewInstanceC_Z", z);
+			return new TestTup(x, y, z);
+		}
 	}
 }

--- a/barghos-core/src/test/java/org/barghos/core/test/api/tuple3/Tup3cRTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/api/tuple3/Tup3cRTest.java
@@ -31,25 +31,7 @@ class Tup3cRTest
 	@Test
 	void isValidTest()
 	{
-		Tup3cR t = new Tup3cR() {
-			public char getX()
-			{
-				ValueRelay.relayCall("getX");
-				return 'a';
-			}
-
-			public char getY()
-			{
-				ValueRelay.relayCall("getY");
-				return 'a';
-			}
-			
-			public char getZ()
-			{
-				ValueRelay.relayCall("getZ");
-				return 'a';
-			}
-		};
+		Tup3cR t = new TestTup('a', 'a', 'a');
 		
 		assertEquals(true, t.isValid());
 		assertEquals(false, ValueRelay.get("getX", false));
@@ -64,29 +46,99 @@ class Tup3cRTest
 	@Test
 	void isFiniteTest()
 	{
-		Tup3cR t = new Tup3cR() {
-			public char getX()
-			{
-				ValueRelay.relayCall("getX");
-				return 'a';
-			}
-
-			public char getY()
-			{
-				ValueRelay.relayCall("getY");
-				return 'a';
-			}
-			
-			public char getZ()
-			{
-				ValueRelay.relayCall("getZ");
-				return 'a';
-			}
-		};
+		Tup3cR t = new TestTup('a', 'a', 'a');
 		
 		assertEquals(true, t.isFinite());
 		assertEquals(false, ValueRelay.get("getX", false));
 		assertEquals(false, ValueRelay.get("getY", false));
 		assertEquals(false, ValueRelay.get("getZ", false));
+	}
+	
+	/**
+	 * This test ensures, that the default implementation of the function {@link Tup3cR#getNewInstance(Tup3cR)} calls
+	 * the function {@link Tup3cR#getNewInstance(char, char, char)} with the correct components.
+	 */
+	@Test
+	void getNewInstance_TupleTest()
+	{
+		Tup3cR t = new TestTup('b', 'b', 'b');
+		
+		t.getNewInstance(new TestTup('c', 'd', 'e'));
+		
+		assertEquals(true, ValueRelay.get("getNewInstanceC", false));
+		assertEquals('c', ValueRelay.get("getNewInstanceC_X", 'a'));
+		assertEquals('d', ValueRelay.get("getNewInstanceC_Y", 'a'));
+		assertEquals('e', ValueRelay.get("getNewInstanceC_Z", 'a'));
+		
+		// Can't test for the result here, as the relaying and adopting of the values are implementation specific.
+	}
+	
+	/**
+	 * This test ensures, that the default implementation of the function {@link Tup3cR#getNewInstance(char)} calls
+	 * the function {@link Tup3cR#getNewInstance(char, char, char)} with the correct components.
+	 */
+	@Test
+	void getNewInstance_ValueTest()
+	{
+		Tup3cR t = new TestTup('a', 'a', 'a');
+		
+		t.getNewInstance('b');
+		
+		assertEquals(true, ValueRelay.get("getNewInstanceC", false));
+		assertEquals('b', ValueRelay.get("getNewInstanceC_X", 'a'));
+		assertEquals('b', ValueRelay.get("getNewInstanceC_Y", 'a'));
+		assertEquals('b', ValueRelay.get("getNewInstanceC_Z", 'a'));
+		
+		// Can't test for the result here, as the relaying and adopting of the values are implementation specific.
+	}
+	
+	/**
+	 * This class is a test implementation of the interface {@link Tup3bR}.
+	 * 
+	 * @author picatrix1899
+	 */
+	private static class TestTup implements Tup3cR
+	{
+		private final char x;
+		private final char y;
+		private final char z;
+		
+		public TestTup(char x, char y, char z)
+		{
+			this.x = x;
+			this.y = y;
+			this.z = z;
+		}
+		
+		@Override
+		public char getX()
+		{
+			ValueRelay.relayCall("getX");
+			return this.x;
+		}
+		
+		@Override
+		public char getY()
+		{
+			ValueRelay.relayCall("getY");
+			return this.y;
+		}
+		
+		@Override
+		public char getZ()
+		{
+			ValueRelay.relayCall("getZ");
+			return this.z;
+		}
+		
+		@Override
+		public TestTup getNewInstance(char x, char y, char z)
+		{
+			ValueRelay.relayCall("getNewInstanceC");
+			ValueRelay.relay("getNewInstanceC_X", x);
+			ValueRelay.relay("getNewInstanceC_Y", y);
+			ValueRelay.relay("getNewInstanceC_Z", z);
+			return new TestTup(x, y, z);
+		}
 	}
 }

--- a/barghos-core/src/test/java/org/barghos/core/test/api/tuple3/Tup3dRTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/api/tuple3/Tup3dRTest.java
@@ -2,6 +2,7 @@ package org.barghos.core.test.api.tuple3;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import org.barghos.core.api.testing.ValueRelay;
@@ -15,31 +16,22 @@ import org.barghos.core.api.tuple3.Tup3dR;
 class Tup3dRTest
 {
 	/**
+	 * This method is called after each test in this class.
+	 */
+	@AfterEach
+	void cleanup()
+	{
+		ValueRelay.clear();
+	}
+	
+	/**
 	 * This test ensures, that the function {@link Tup3dR#isValid()} returns
 	 * the corrct values for different situations.
 	 */
 	@Test
 	void isValidTest()
 	{
-		Tup3dR t = new Tup3dR() {
-			public double getX()
-			{
-				ValueRelay.relayCall("getX");
-				return 0.0;
-			}
-
-			public double getY()
-			{
-				ValueRelay.relayCall("getY");
-				return 0.0;
-			}
-			
-			public double getZ()
-			{
-				ValueRelay.relayCall("getZ");
-				return 0.0;
-			}
-		};
+		Tup3dR t = new TestTup(0.0, 0.0, 0.0);
 		
 		assertEquals(true, t.isValid());
 		assertEquals(false, ValueRelay.get("getX", false));
@@ -130,6 +122,44 @@ class Tup3dRTest
 	}
 	
 	/**
+	 * This test ensures, that the default implementation of the function {@link Tup3dR#getNewInstance(Tup3dR)} calls
+	 * the function {@link Tup3dR#getNewInstance(double, double, double)} with the correct components.
+	 */
+	@Test
+	void getNewInstance_TupleTest()
+	{
+		Tup3dR t = new TestTup(0.0, 0.0, 0.0);
+		
+		t.getNewInstance(new TestTup(1.0, 2.0, 3.0));
+		
+		assertEquals(true, ValueRelay.get("getNewInstanceC", false));
+		assertEquals(1.0, ValueRelay.get("getNewInstanceC_X", 0.0));
+		assertEquals(2.0, ValueRelay.get("getNewInstanceC_Y", 0.0));
+		assertEquals(3.0, ValueRelay.get("getNewInstanceC_Z", 0.0));
+		
+		// Can't test for the result here, as the relaying and adopting of the values are implementation specific.
+	}
+	
+	/**
+	 * This test ensures, that the default implementation of the function {@link Tup3dR#getNewInstance(double)} calls
+	 * the function {@link Tup3dR#getNewInstance(double, double, double)} with the correct components.
+	 */
+	@Test
+	void getNewInstance_ValueTest()
+	{
+		Tup3dR t = new TestTup(0.0, 0.0, 0.0);
+		
+		t.getNewInstance(1.0);
+		
+		assertEquals(true, ValueRelay.get("getNewInstanceC", false));
+		assertEquals(1.0, ValueRelay.get("getNewInstanceC_X", 0.0));
+		assertEquals(1.0, ValueRelay.get("getNewInstanceC_Y", 0.0));
+		assertEquals(1.0, ValueRelay.get("getNewInstanceC_Z", 0.0));
+		
+		// Can't test for the result here, as the relaying and adopting of the values are implementation specific.
+	}
+	
+	/**
 	 * This class is a test implementation of the interface {@link Tup3dR}.
 	 * 
 	 * @author picatrix1899
@@ -150,19 +180,32 @@ class Tup3dRTest
 		@Override
 		public double getX()
 		{
+			ValueRelay.relayCall("getX");
 			return this.x;
 		}
 		
 		@Override
 		public double getY()
 		{
+			ValueRelay.relayCall("getY");
 			return this.y;
 		}
 		
 		@Override
 		public double getZ()
 		{
+			ValueRelay.relayCall("getZ");
 			return this.z;
+		}
+		
+		@Override
+		public TestTup getNewInstance(double x, double y, double z)
+		{
+			ValueRelay.relayCall("getNewInstanceC");
+			ValueRelay.relay("getNewInstanceC_X", x);
+			ValueRelay.relay("getNewInstanceC_Y", y);
+			ValueRelay.relay("getNewInstanceC_Z", z);
+			return new TestTup(x, y, z);
 		}
 	}
 }

--- a/barghos-core/src/test/java/org/barghos/core/test/api/tuple3/Tup3fRTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/api/tuple3/Tup3fRTest.java
@@ -2,60 +2,45 @@ package org.barghos.core.test.api.tuple3;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import org.barghos.core.api.testing.ValueRelay;
-import org.barghos.core.api.tuple4.Tup4fR;
+import org.barghos.core.api.tuple3.Tup3fR;
 
 /**
- * This class provides component tests for the interface {@link Tup4fR}.
+ * This class provides component tests for the interface {@link Tup3fR}.
  * 
  * @author picatrix1899
  */
 class Tup3fRTest
 {
 	/**
-	 * This test ensures, that the function {@link Tup4fR#isValid()} returns
+	 * This method is called after each test in this class.
+	 */
+	@AfterEach
+	void cleanup()
+	{
+		ValueRelay.clear();
+	}
+	
+	/**
+	 * This test ensures, that the function {@link Tup3fR#isValid()} returns
 	 * the corrct values for different situations.
 	 */
 	@Test
 	void isValidTest()
 	{
-		Tup4fR t = new Tup4fR() {
-			public float getX()
-			{
-				ValueRelay.relayCall("getX");
-				return 0.0f;
-			}
-
-			public float getY()
-			{
-				ValueRelay.relayCall("getY");
-				return 0.0f;
-			}
-			
-			public float getZ()
-			{
-				ValueRelay.relayCall("getZ");
-				return 0.0f;
-			}
-			
-			public float getW()
-			{
-				ValueRelay.relayCall("getW");
-				return 0.0f;
-			}
-		};
+		Tup3fR t = new TestTup(0.0f, 0.0f, 0.0f);
 		
 		assertEquals(true, t.isValid());
 		assertEquals(false, ValueRelay.get("getX", false));
 		assertEquals(false, ValueRelay.get("getY", false));
 		assertEquals(false, ValueRelay.get("getZ", false));
-		assertEquals(false, ValueRelay.get("getW", false));
 	}
 	
 	/**
-	 * This test ensures, that the function {@link Tup4fR#isFinite()} returns
+	 * This test ensures, that the function {@link Tup3fR#isFinite()} returns
 	 * the corrct values for different situations.
 	 */
 	@Test
@@ -69,51 +54,45 @@ class Tup3fRTest
 			
 			boolean b = i == 0;
 			
-			Tup4fR t = new TestTup(v, v, v, v);
+			Tup3fR t = new TestTup(v, v, v);
 			assertEquals(b, t.isFinite());
 			
-			t = new TestTup(v, 0.0f, 0.0f, 0.0f);
+			t = new TestTup(v, 0.0f, 0.0f);
 			assertEquals(b, t.isFinite());
 			
-			t = new TestTup(0.0f, v, 0.0f, 0.0f);
+			t = new TestTup(0.0f, v, 0.0f);
 			assertEquals(b, t.isFinite());
 			
-			t = new TestTup(0.0f, 0.0f, v, 0.0f);
-			assertEquals(b, t.isFinite());
-			
-			t = new TestTup(0.0f, 0.0f, 0.0f, v);
+			t = new TestTup(0.0f, 0.0f, v);
 			assertEquals(b, t.isFinite());
 		}
 	}
 	
 	/**
-	 * This test ensures, that the function {@link Tup4fR#isZero()} returns the correct
+	 * This test ensures, that the function {@link Tup3fR#isZero()} returns the correct
 	 * value based on the situation.
 	 */
 	@Test
 	void isZeroExactTest()
 	{
-		Tup4fR t = new TestTup(0.0f, 0.0f, 0.0f, 0.0f);
+		Tup3fR t = new TestTup(0.0f, 0.0f, 0.0f);
 		assertEquals(true, t.isZero());
 		
-		t = new TestTup(1.0f, 0.0f, 0.0f, 0.0f);
+		t = new TestTup(1.0f, 0.0f, 0.0f);
 		assertEquals(false, t.isZero());
 		
-		t = new TestTup(0.0f, 1.0f, 0.0f, 0.0f);
+		t = new TestTup(0.0f, 1.0f, 0.0f);
 		assertEquals(false, t.isZero());
 		
-		t = new TestTup(0.0f, 0.0f, 1.0f, 0.0f);
+		t = new TestTup(0.0f, 0.0f, 1.0f);
 		assertEquals(false, t.isZero());
-		
-		t = new TestTup(0.0f, 0.0f, 0.0f, 1.0f);
-		assertEquals(false, t.isZero());
-		
-		t = new TestTup(1.0f, 1.0f, 1.0f, 1.0f);
+
+		t = new TestTup(1.0f, 1.0f, 1.0f);
 		assertEquals(false, t.isZero());
 	}
 	
 	/**
-	 * This test ensures, that the function {@link Tup4fR#isZero(byte)} returns the correct
+	 * This test ensures, that the function {@link Tup3fR#isZero(float)} returns the correct
 	 * value based on the situation.
 	 */
 	@Test
@@ -128,65 +107,105 @@ class Tup3fRTest
 			
 			boolean b = Math.abs(i) <= tolerance;
 			
-			Tup4fR t = new TestTup(v, v, v, v);
+			Tup3fR t = new TestTup(v, v, v);
 			assertEquals(b, t.isZero(tol));
 			
-			t = new TestTup(v, 0.0f, 0.0f, 0.0f);
+			t = new TestTup(v, 0.0f, 0.0f);
 			assertEquals(b, t.isZero(tol));
 			
-			t = new TestTup(0.0f, v, 0.0f, 0.0f);
+			t = new TestTup(0.0f, v, 0.0f);
 			assertEquals(b, t.isZero(tol));
 			
-			t = new TestTup(0.0f, 0.0f, v, 0.0f);
-			assertEquals(b, t.isZero(tol));
-			
-			t = new TestTup(0.0f, 0.0f, 0.0f, v);
+			t = new TestTup(0.0f, 0.0f, v);
 			assertEquals(b, t.isZero(tol));
 		}
 	}
 	
 	/**
-	 * This class is a test implementation of the interface {@link Tup4fR}.
+	 * This test ensures, that the default implementation of the function {@link Tup3fR#getNewInstance(Tup3fR)} calls
+	 * the function {@link Tup3fR#getNewInstance(float, float, float)} with the correct components.
+	 */
+	@Test
+	void getNewInstance_TupleTest()
+	{
+		Tup3fR t = new TestTup(0.0f, 0.0f, 0.0f);
+		
+		t.getNewInstance(new TestTup(1.0f, 2.0f, 3.0f));
+		
+		assertEquals(true, ValueRelay.get("getNewInstanceC", false));
+		assertEquals(1.0f, ValueRelay.get("getNewInstanceC_X", 0.0f));
+		assertEquals(2.0f, ValueRelay.get("getNewInstanceC_Y", 0.0f));
+		assertEquals(3.0f, ValueRelay.get("getNewInstanceC_Z", 0.0f));
+		
+		// Can't test for the result here, as the relaying and adopting of the values are implementation specific.
+	}
+	
+	/**
+	 * This test ensures, that the default implementation of the function {@link Tup3fR#getNewInstance(float)} calls
+	 * the function {@link Tup3fR#getNewInstance(float, float, float)} with the correct components.
+	 */
+	@Test
+	void getNewInstance_ValueTest()
+	{
+		Tup3fR t = new TestTup(0.0f, 0.0f, 0.0f);
+		
+		t.getNewInstance(1.0f);
+		
+		assertEquals(true, ValueRelay.get("getNewInstanceC", false));
+		assertEquals(1.0f, ValueRelay.get("getNewInstanceC_X", 0.0f));
+		assertEquals(1.0f, ValueRelay.get("getNewInstanceC_Y", 0.0f));
+		assertEquals(1.0f, ValueRelay.get("getNewInstanceC_Z", 0.0f));
+		
+		// Can't test for the result here, as the relaying and adopting of the values are implementation specific.
+	}
+	
+	/**
+	 * This class is a test implementation of the interface {@link Tup3fR}.
 	 * 
 	 * @author picatrix1899
 	 */
-	private static class TestTup implements Tup4fR
+	private static class TestTup implements Tup3fR
 	{
 		private final float x;
 		private final float y;
 		private final float z;
-		private final float w;
 		
-		public TestTup(float x, float y, float z, float w)
+		public TestTup(float x, float y, float z)
 		{
 			this.x = x;
 			this.y = y;
 			this.z = z;
-			this.w = w;
 		}
 		
 		@Override
 		public float getX()
 		{
+			ValueRelay.relayCall("getX");
 			return this.x;
 		}
 		
 		@Override
 		public float getY()
 		{
+			ValueRelay.relayCall("getY");
 			return this.y;
 		}
 		
 		@Override
 		public float getZ()
 		{
+			ValueRelay.relayCall("getZ");
 			return this.z;
 		}
 		
 		@Override
-		public float getW()
+		public TestTup getNewInstance(float x, float y, float z)
 		{
-			return this.w;
+			ValueRelay.relayCall("getNewInstanceC");
+			ValueRelay.relay("getNewInstanceC_X", x);
+			ValueRelay.relay("getNewInstanceC_Y", y);
+			ValueRelay.relay("getNewInstanceC_Z", z);
+			return new TestTup(x, y, z);
 		}
 	}
 }

--- a/barghos-core/src/test/java/org/barghos/core/test/api/tuple3/Tup3iRTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/api/tuple3/Tup3iRTest.java
@@ -2,6 +2,7 @@ package org.barghos.core.test.api.tuple3;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import org.barghos.core.api.testing.ValueRelay;
@@ -15,31 +16,22 @@ import org.barghos.core.api.tuple3.Tup3iR;
 class Tup3iRTest
 {
 	/**
+	 * This method is called after each test in this class.
+	 */
+	@AfterEach
+	void cleanup()
+	{
+		ValueRelay.clear();
+	}
+	
+	/**
 	 * This test ensures, that the function {@link Tup3iR#isValid()} returns
 	 * the corrct values for different situations.
 	 */
 	@Test
 	void isValidTest()
 	{
-		Tup3iR t = new Tup3iR() {
-			public int getX()
-			{
-				ValueRelay.relayCall("getX");
-				return 0;
-			}
-
-			public int getY()
-			{
-				ValueRelay.relayCall("getY");
-				return 0;
-			}
-			
-			public int getZ()
-			{
-				ValueRelay.relayCall("getZ");
-				return 0;
-			}
-		};
+		Tup3iR t = new TestTup(0, 0, 0);
 		
 		assertEquals(true, t.isValid());
 		assertEquals(false, ValueRelay.get("getX", false));
@@ -54,25 +46,7 @@ class Tup3iRTest
 	@Test
 	void isFiniteTest()
 	{
-		Tup3iR t = new Tup3iR() {
-			public int getX()
-			{
-				ValueRelay.relayCall("getX");
-				return 0;
-			}
-
-			public int getY()
-			{
-				ValueRelay.relayCall("getY");
-				return 0;
-			}
-			
-			public int getZ()
-			{
-				ValueRelay.relayCall("getZ");
-				return 0;
-			}
-		};
+		Tup3iR t = new TestTup(0, 0, 0);
 		
 		assertEquals(true, t.isFinite());
 		assertEquals(false, ValueRelay.get("getX", false));
@@ -131,6 +105,44 @@ class Tup3iRTest
 	}
 	
 	/**
+	 * This test ensures, that the default implementation of the function {@link Tup3iR#getNewInstance(Tup3iR)} calls
+	 * the function {@link Tup3iR#getNewInstance(int, int, int)} with the correct components.
+	 */
+	@Test
+	void getNewInstance_TupleTest()
+	{
+		Tup3iR t = new TestTup(0, 0, 0);
+		
+		t.getNewInstance(new TestTup(1, 2, 3));
+		
+		assertEquals(true, ValueRelay.get("getNewInstanceC", false));
+		assertEquals(1, ValueRelay.get("getNewInstanceC_X", 0));
+		assertEquals(2, ValueRelay.get("getNewInstanceC_Y", 0));
+		assertEquals(3, ValueRelay.get("getNewInstanceC_Z", 0));
+		
+		// Can't test for the result here, as the relaying and adopting of the values are implementation specific.
+	}
+	
+	/**
+	 * This test ensures, that the default implementation of the function {@link Tup3iR#getNewInstance(int)} calls
+	 * the function {@link Tup3iR#getNewInstance(int, int, int)} with the correct components.
+	 */
+	@Test
+	void getNewInstance_ValueTest()
+	{
+		Tup3iR t = new TestTup(0, 0, 0);
+		
+		t.getNewInstance(1);
+		
+		assertEquals(true, ValueRelay.get("getNewInstanceC", false));
+		assertEquals(1, ValueRelay.get("getNewInstanceC_X", 0));
+		assertEquals(1, ValueRelay.get("getNewInstanceC_Y", 0));
+		assertEquals(1, ValueRelay.get("getNewInstanceC_Z", 0));
+		
+		// Can't test for the result here, as the relaying and adopting of the values are implementation specific.
+	}
+	
+	/**
 	 * This class is a test implementation of the interface {@link Tup3iR}.
 	 * 
 	 * @author picatrix1899
@@ -151,19 +163,32 @@ class Tup3iRTest
 		@Override
 		public int getX()
 		{
+			ValueRelay.relayCall("getX");
 			return this.x;
 		}
 		
 		@Override
 		public int getY()
 		{
+			ValueRelay.relayCall("getY");
 			return this.y;
 		}
 		
 		@Override
 		public int getZ()
 		{
+			ValueRelay.relayCall("getZ");
 			return this.z;
+		}
+		
+		@Override
+		public TestTup getNewInstance(int x, int y, int z)
+		{
+			ValueRelay.relayCall("getNewInstanceC");
+			ValueRelay.relay("getNewInstanceC_X", x);
+			ValueRelay.relay("getNewInstanceC_Y", y);
+			ValueRelay.relay("getNewInstanceC_Z", z);
+			return new TestTup(x, y, z);
 		}
 	}
 }

--- a/barghos-core/src/test/java/org/barghos/core/test/api/tuple3/Tup3lRTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/api/tuple3/Tup3lRTest.java
@@ -2,6 +2,7 @@ package org.barghos.core.test.api.tuple3;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import org.barghos.core.api.testing.ValueRelay;
@@ -15,31 +16,22 @@ import org.barghos.core.api.tuple3.Tup3lR;
 class Tup3lRTest
 {
 	/**
+	 * This method is called after each test in this class.
+	 */
+	@AfterEach
+	void cleanup()
+	{
+		ValueRelay.clear();
+	}
+	
+	/**
 	 * This test ensures, that the function {@link Tup3lR#isValid()} returns
 	 * the corrct values for different situations.
 	 */
 	@Test
 	void isValidTest()
 	{
-		Tup3lR t = new Tup3lR() {
-			public long getX()
-			{
-				ValueRelay.relayCall("getX");
-				return 0l;
-			}
-
-			public long getY()
-			{
-				ValueRelay.relayCall("getY");
-				return 0l;
-			}
-			
-			public long getZ()
-			{
-				ValueRelay.relayCall("getZ");
-				return 0l;
-			}
-		};
+		Tup3lR t = new TestTup(0l, 0l, 0l);
 		
 		assertEquals(true, t.isValid());
 		assertEquals(false, ValueRelay.get("getX", false));
@@ -54,25 +46,7 @@ class Tup3lRTest
 	@Test
 	void isFiniteTest()
 	{
-		Tup3lR t = new Tup3lR() {
-			public long getX()
-			{
-				ValueRelay.relayCall("getX");
-				return 0l;
-			}
-
-			public long getY()
-			{
-				ValueRelay.relayCall("getY");
-				return 0l;
-			}
-			
-			public long getZ()
-			{
-				ValueRelay.relayCall("getZ");
-				return 0l;
-			}
-		};
+		Tup3lR t = new TestTup(0l, 0l, 0l);
 		
 		assertEquals(true, t.isFinite());
 		assertEquals(false, ValueRelay.get("getX", false));
@@ -134,6 +108,44 @@ class Tup3lRTest
 	}
 	
 	/**
+	 * This test ensures, that the default implementation of the function {@link Tup3lR#getNewInstance(Tup3lR)} calls
+	 * the function {@link Tup3lR#getNewInstance(long, long, long)} with the correct components.
+	 */
+	@Test
+	void getNewInstance_TupleTest()
+	{
+		Tup3lR t = new TestTup(0l, 0l, 0l);
+		
+		t.getNewInstance(new TestTup(1l, 2l, 3l));
+		
+		assertEquals(true, ValueRelay.get("getNewInstanceC", false));
+		assertEquals(1l, ValueRelay.get("getNewInstanceC_X", 0l));
+		assertEquals(2l, ValueRelay.get("getNewInstanceC_Y", 0l));
+		assertEquals(3l, ValueRelay.get("getNewInstanceC_Z", 0l));
+		
+		// Can't test for the result here, as the relaying and adopting of the values are implementation specific.
+	}
+	
+	/**
+	 * This test ensures, that the default implementation of the function {@link Tup3lR#getNewInstance(long)} calls
+	 * the function {@link Tup3lR#getNewInstance(long, long, long)} with the correct components.
+	 */
+	@Test
+	void getNewInstance_ValueTest()
+	{
+		Tup3lR t = new TestTup(0l, 0l, 0l);
+		
+		t.getNewInstance(1l);
+		
+		assertEquals(true, ValueRelay.get("getNewInstanceC", false));
+		assertEquals(1l, ValueRelay.get("getNewInstanceC_X", 0l));
+		assertEquals(1l, ValueRelay.get("getNewInstanceC_Y", 0l));
+		assertEquals(1l, ValueRelay.get("getNewInstanceC_Z", 0l));
+		
+		// Can't test for the result here, as the relaying and adopting of the values are implementation specific.
+	}
+	
+	/**
 	 * This class is a test implementation of the interface {@link Tup3lR}.
 	 * 
 	 * @author picatrix1899
@@ -154,19 +166,32 @@ class Tup3lRTest
 		@Override
 		public long getX()
 		{
+			ValueRelay.relayCall("getX");
 			return this.x;
 		}
 		
 		@Override
 		public long getY()
 		{
+			ValueRelay.relayCall("getY");
 			return this.y;
 		}
 		
 		@Override
 		public long getZ()
 		{
+			ValueRelay.relayCall("getZ");
 			return this.z;
+		}
+		
+		@Override
+		public TestTup getNewInstance(long x, long y, long z)
+		{
+			ValueRelay.relayCall("getNewInstanceC");
+			ValueRelay.relay("getNewInstanceC_X", x);
+			ValueRelay.relay("getNewInstanceC_Y", y);
+			ValueRelay.relay("getNewInstanceC_Z", z);
+			return new TestTup(x, y, z);
 		}
 	}
 }

--- a/barghos-core/src/test/java/org/barghos/core/test/api/tuple3/Tup3oRTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/api/tuple3/Tup3oRTest.java
@@ -2,8 +2,10 @@ package org.barghos.core.test.api.tuple3;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
+import org.barghos.core.api.testing.ValueRelay;
 import org.barghos.core.api.tuple3.Tup3oR;
 
 /**
@@ -13,6 +15,15 @@ import org.barghos.core.api.tuple3.Tup3oR;
  */
 class Tup3oRTest
 {
+	/**
+	 * This method is called after each test in this class.
+	 */
+	@AfterEach
+	void cleanup()
+	{
+		ValueRelay.clear();
+	}
+	
 	/**
 	 * This test ensures, that the function {@link Tup3oR#isValid()} returns
 	 * the corrct values for different situations.
@@ -34,6 +45,25 @@ class Tup3oRTest
 		
 		t = new TestTup<>(new Object(), new Object(), new Object());
 		assertEquals(true, t.isValid());
+	}
+	
+	/**
+	 * This test ensures, that the default implementation of the function {@link Tup3oR#getNewInstance(Tup3oR)} calls
+	 * the function {@link Tup3oR#getNewInstance(Object, Object, Object)} with the correct components.
+	 */
+	@Test
+	void getNewInstance_TupleTest()
+	{
+		Tup3oR<Long,Long,Long> t = new TestTup<>(1l, 1l, 1l);
+		
+		t.getNewInstance(new TestTup<>(2l, 3l, 4l));
+		
+		assertEquals(true, ValueRelay.get("getNewInstanceC", false));
+		assertEquals(2l, ValueRelay.get("getNewInstanceC_X", 0l));
+		assertEquals(3l, ValueRelay.get("getNewInstanceC_Y", 0l));
+		assertEquals(4l, ValueRelay.get("getNewInstanceC_Z", 0l));
+		
+		// Can't test for the result here, as the relaying and adopting of the values are implementation specific.
 	}
 	
 	/**
@@ -70,6 +100,16 @@ class Tup3oRTest
 		public Z getZ()
 		{
 			return this.z;
+		}
+		
+		@Override
+		public TestTup<X,Y,Z> getNewInstance(X x, Y y, Z z)
+		{
+			ValueRelay.relayCall("getNewInstanceC");
+			ValueRelay.relay("getNewInstanceC_X", x);
+			ValueRelay.relay("getNewInstanceC_Y", y);
+			ValueRelay.relay("getNewInstanceC_Z", z);
+			return new TestTup<>(x, y, z);
 		}
 	}
 }

--- a/barghos-core/src/test/java/org/barghos/core/test/api/tuple3/Tup3objRTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/api/tuple3/Tup3objRTest.java
@@ -2,8 +2,10 @@ package org.barghos.core.test.api.tuple3;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
+import org.barghos.core.api.testing.ValueRelay;
 import org.barghos.core.api.tuple3.Tup3objR;
 
 /**
@@ -13,6 +15,15 @@ import org.barghos.core.api.tuple3.Tup3objR;
  */
 class Tup3objRTest
 {
+	/**
+	 * This method is called after each test in this class.
+	 */
+	@AfterEach
+	void cleanup()
+	{
+		ValueRelay.clear();
+	}
+	
 	/**
 	 * This test ensures, that the function {@link Tup3objR#isValid()} returns
 	 * the corrct values for different situations.
@@ -34,6 +45,44 @@ class Tup3objRTest
 		
 		t = new TestTup(new Object(), new Object(), new Object());
 		assertEquals(true, t.isValid());
+	}
+	
+	/**
+	 * This test ensures, that the default implementation of the function {@link Tup3objR#getNewInstance(Tup3objR)} calls
+	 * the function {@link Tup3objR#getNewInstance(Object, Object, Object)} with the correct components.
+	 */
+	@Test
+	void getNewInstance_TupleTest()
+	{
+		Tup3objR t = new TestTup(1l, 1l, 1l);
+		
+		t.getNewInstance(new TestTup(2l, 3l, 4l));
+		
+		assertEquals(true, ValueRelay.get("getNewInstanceC", false));
+		assertEquals(2l, ValueRelay.get("getNewInstanceC_X", 0l));
+		assertEquals(3l, ValueRelay.get("getNewInstanceC_Y", 0l));
+		assertEquals(4l, ValueRelay.get("getNewInstanceC_Z", 0l));
+		
+		// Can't test for the result here, as the relaying and adopting of the values are implementation specific.
+	}
+	
+	/**
+	 * This test ensures, that the default implementation of the function {@link Tup3objR#getNewInstance(Object)} calls
+	 * the function {@link Tup3objR#getNewInstance(Object, Object, Object)} with the correct components.
+	 */
+	@Test
+	void getNewInstance_ValueTest()
+	{
+		Tup3objR t = new TestTup(1l, 1l, 1l);
+		
+		t.getNewInstance(2l);
+		
+		assertEquals(true, ValueRelay.get("getNewInstanceC", false));
+		assertEquals(2l, ValueRelay.get("getNewInstanceC_X", 0l));
+		assertEquals(2l, ValueRelay.get("getNewInstanceC_Y", 0l));
+		assertEquals(2l, ValueRelay.get("getNewInstanceC_Z", 0l));
+		
+		// Can't test for the result here, as the relaying and adopting of the values are implementation specific.
 	}
 	
 	/**
@@ -70,6 +119,16 @@ class Tup3objRTest
 		public Object getZ()
 		{
 			return this.z;
+		}
+		
+		@Override
+		public TestTup getNewInstance(Object x, Object y, Object z)
+		{
+			ValueRelay.relayCall("getNewInstanceC");
+			ValueRelay.relay("getNewInstanceC_X", x);
+			ValueRelay.relay("getNewInstanceC_Y", y);
+			ValueRelay.relay("getNewInstanceC_Z", z);
+			return new TestTup(x, y, z);
 		}
 	}
 }

--- a/barghos-core/src/test/java/org/barghos/core/test/api/tuple3/Tup3sRTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/api/tuple3/Tup3sRTest.java
@@ -2,6 +2,7 @@ package org.barghos.core.test.api.tuple3;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import org.barghos.core.api.testing.ValueRelay;
@@ -15,31 +16,24 @@ import org.barghos.core.api.tuple3.Tup3sR;
 class Tup3sRTest
 {
 	/**
+	 * This method is called after each test in this class.
+	 */
+	@AfterEach
+	void cleanup()
+	{
+		ValueRelay.clear();
+	}
+	
+	/**
 	 * This test ensures, that the function {@link Tup3sR#isValid()} returns
 	 * the corrct values for different situations.
 	 */
 	@Test
 	void isValidTest()
 	{
-		Tup3sR t = new Tup3sR() {
-			public short getX()
-			{
-				ValueRelay.relayCall("getX");
-				return (short)0;
-			}
-
-			public short getY()
-			{
-				ValueRelay.relayCall("getY");
-				return (short)0;
-			}
-			
-			public short getZ()
-			{
-				ValueRelay.relayCall("getZ");
-				return (short)0;
-			}
-		};
+		final short zero = (short)0;
+		
+		Tup3sR t = new TestTup(zero, zero, zero);
 		
 		assertEquals(true, t.isValid());
 		assertEquals(false, ValueRelay.get("getX", false));
@@ -54,25 +48,9 @@ class Tup3sRTest
 	@Test
 	void isFiniteTest()
 	{
-		Tup3sR t = new Tup3sR() {
-			public short getX()
-			{
-				ValueRelay.relayCall("getX");
-				return (short)0;
-			}
-
-			public short getY()
-			{
-				ValueRelay.relayCall("getY");
-				return (short)0;
-			}
-			
-			public short getZ()
-			{
-				ValueRelay.relayCall("getZ");
-				return (short)0;
-			}
-		};
+		final short zero = (short)0;
+		
+		Tup3sR t = new TestTup(zero, zero, zero);
 		
 		assertEquals(true, t.isFinite());
 		assertEquals(false, ValueRelay.get("getX", false));
@@ -139,6 +117,54 @@ class Tup3sRTest
 	}
 	
 	/**
+	 * This test ensures, that the default implementation of the function {@link Tup3sR#getNewInstance(Tup3sR)} calls
+	 * the function {@link Tup3sR#getNewInstance(short, short, short)} with the correct components.
+	 */
+	@Test
+	void getNewInstance_TupleTest()
+	{
+		final short zero = (short)0;
+		final short one = (short)1;
+		final short two = (short)2;
+		final short three = (short)3;
+		final short four = (short)4;
+		
+		Tup3sR t = new TestTup(one, one, one);
+		
+		t.getNewInstance(new TestTup(two, three, four));
+		
+		assertEquals(true, ValueRelay.get("getNewInstanceC", false));
+		assertEquals(two, ValueRelay.get("getNewInstanceC_X", zero));
+		assertEquals(three, ValueRelay.get("getNewInstanceC_Y", zero));
+		assertEquals(four, ValueRelay.get("getNewInstanceC_Z", zero));
+		
+		// Can't test for the result here, as the relaying and adopting of the values are implementation specific.
+	}
+	
+	/**
+	 * This test ensures, that the default implementation of the function {@link Tup3sR#getNewInstance(short)} calls
+	 * the function {@link Tup3sR#getNewInstance(short, short, short)} with the correct components.
+	 */
+	@Test
+	void getNewInstance_ValueTest()
+	{
+		final short zero = (short)0;
+		final short one = (short)1;
+		final short two = (short)2;
+		
+		Tup3sR t = new TestTup(one, one, one);
+		
+		t.getNewInstance(two);
+		
+		assertEquals(true, ValueRelay.get("getNewInstanceC", false));
+		assertEquals(two, ValueRelay.get("getNewInstanceC_X", zero));
+		assertEquals(two, ValueRelay.get("getNewInstanceC_Y", zero));
+		assertEquals(two, ValueRelay.get("getNewInstanceC_Z", zero));
+		
+		// Can't test for the result here, as the relaying and adopting of the values are implementation specific.
+	}
+	
+	/**
 	 * This class is a test implementation of the interface {@link Tup3sR}.
 	 * 
 	 * @author picatrix1899
@@ -159,19 +185,32 @@ class Tup3sRTest
 		@Override
 		public short getX()
 		{
+			ValueRelay.relayCall("getX");
 			return this.x;
 		}
 		
 		@Override
 		public short getY()
 		{
+			ValueRelay.relayCall("getY");
 			return this.y;
 		}
 		
 		@Override
 		public short getZ()
 		{
+			ValueRelay.relayCall("getZ");
 			return this.z;
+		}
+		
+		@Override
+		public TestTup getNewInstance(short x, short y, short z)
+		{
+			ValueRelay.relayCall("getNewInstanceC");
+			ValueRelay.relay("getNewInstanceC_X", x);
+			ValueRelay.relay("getNewInstanceC_Y", y);
+			ValueRelay.relay("getNewInstanceC_Z", z);
+			return new TestTup(x, y, z);
 		}
 	}
 }

--- a/barghos-core/src/test/java/org/barghos/core/test/api/tuple3/Tup3strRTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/api/tuple3/Tup3strRTest.java
@@ -2,8 +2,10 @@ package org.barghos.core.test.api.tuple3;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
+import org.barghos.core.api.testing.ValueRelay;
 import org.barghos.core.api.tuple3.Tup3strR;
 
 /**
@@ -13,6 +15,15 @@ import org.barghos.core.api.tuple3.Tup3strR;
  */
 class Tup3strRTest
 {
+	/**
+	 * This method is called after each test in this class.
+	 */
+	@AfterEach
+	void cleanup()
+	{
+		ValueRelay.clear();
+	}
+	
 	/**
 	 * This test ensures, that the function {@link Tup3strR#isValid()} returns
 	 * the corrct values for different situations.
@@ -34,6 +45,44 @@ class Tup3strRTest
 		
 		t = new TestTup("", "", "");
 		assertEquals(true, t.isValid());
+	}
+	
+	/**
+	 * This test ensures, that the default implementation of the function {@link Tup3strR#getNewInstance(Tup3strR)} calls
+	 * the function {@link Tup3sRtr#getNewInstance(String, String, String)} with the correct components.
+	 */
+	@Test
+	void getNewInstance_TupleTest()
+	{
+		Tup3strR t = new TestTup("a", "a", "a");
+		
+		t.getNewInstance(new TestTup("b", "c", "d"));
+		
+		assertEquals(true, ValueRelay.get("getNewInstanceC", false));
+		assertEquals("b", ValueRelay.get("getNewInstanceC_X", ""));
+		assertEquals("c", ValueRelay.get("getNewInstanceC_Y", ""));
+		assertEquals("d", ValueRelay.get("getNewInstanceC_Z", ""));
+		
+		// Can't test for the result here, as the relaying and adopting of the values are implementation specific.
+	}
+	
+	/**
+	 * This test ensures, that the default implementation of the function {@link Tup3strR#getNewInstance(String)} calls
+	 * the function {@link Tup3strR#getNewInstance(String, String, String)} with the correct components.
+	 */
+	@Test
+	void getNewInstance_ValueTest()
+	{
+		Tup3strR t = new TestTup("a", "a", "a");
+		
+		t.getNewInstance("b");
+		
+		assertEquals(true, ValueRelay.get("getNewInstanceC", false));
+		assertEquals("b", ValueRelay.get("getNewInstanceC_X", ""));
+		assertEquals("b", ValueRelay.get("getNewInstanceC_Y", ""));
+		assertEquals("b", ValueRelay.get("getNewInstanceC_Z", ""));
+		
+		// Can't test for the result here, as the relaying and adopting of the values are implementation specific.
 	}
 	
 	/**
@@ -70,6 +119,16 @@ class Tup3strRTest
 		public String getZ()
 		{
 			return this.z;
+		}
+		
+		@Override
+		public TestTup getNewInstance(String x, String y, String z)
+		{
+			ValueRelay.relayCall("getNewInstanceC");
+			ValueRelay.relay("getNewInstanceC_X", x);
+			ValueRelay.relay("getNewInstanceC_Y", y);
+			ValueRelay.relay("getNewInstanceC_Z", z);
+			return new TestTup(x, y, z);
 		}
 	}
 }

--- a/barghos-core/src/test/java/org/barghos/core/test/api/tuple4/Tup4bRTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/api/tuple4/Tup4bRTest.java
@@ -2,6 +2,7 @@ package org.barghos.core.test.api.tuple4;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import org.barghos.core.api.testing.ValueRelay;
@@ -15,37 +16,24 @@ import org.barghos.core.api.tuple4.Tup4bR;
 class Tup4bRTest
 {
 	/**
+	 * This method is called after each test in this class.
+	 */
+	@AfterEach
+	void cleanup()
+	{
+		ValueRelay.clear();
+	}
+	
+	/**
 	 * This test ensures, that the function {@link Tup4bR#isValid()} returns
 	 * the corrct values for different situations.
 	 */
 	@Test
 	void isValidTest()
 	{
-		Tup4bR t = new Tup4bR() {
-			public byte getX()
-			{
-				ValueRelay.relayCall("getX");
-				return (byte)0;
-			}
-
-			public byte getY()
-			{
-				ValueRelay.relayCall("getY");
-				return (byte)0;
-			}
-			
-			public byte getZ()
-			{
-				ValueRelay.relayCall("getZ");
-				return (byte)0;
-			}
-			
-			public byte getW()
-			{
-				ValueRelay.relayCall("getW");
-				return (byte)0;
-			}
-		};
+		final byte zero = (byte)0;
+		
+		Tup4bR t = new TestTup(zero, zero, zero, zero);
 		
 		assertEquals(true, t.isValid());
 		assertEquals(false, ValueRelay.get("getX", false));
@@ -61,31 +49,9 @@ class Tup4bRTest
 	@Test
 	void isFiniteTest()
 	{
-		Tup4bR t = new Tup4bR() {
-			public byte getX()
-			{
-				ValueRelay.relayCall("getX");
-				return (byte)0;
-			}
-
-			public byte getY()
-			{
-				ValueRelay.relayCall("getY");
-				return (byte)0;
-			}
-			
-			public byte getZ()
-			{
-				ValueRelay.relayCall("getZ");
-				return (byte)0;
-			}
-			
-			public byte getW()
-			{
-				ValueRelay.relayCall("getW");
-				return (byte)0;
-			}
-		};
+		final byte zero = (byte)0;
+		
+		Tup4bR t = new TestTup(zero, zero, zero, zero);
 		
 		assertEquals(true, t.isFinite());
 		assertEquals(false, ValueRelay.get("getX", false));
@@ -159,6 +125,57 @@ class Tup4bRTest
 	}
 	
 	/**
+	 * This test ensures, that the default implementation of the function {@link Tup4bR#getNewInstance(Tup4bR)} calls
+	 * the function {@link Tup4bR#getNewInstance(byte, byte, byte, byte)} with the correct components.
+	 */
+	@Test
+	void getNewInstance_TupleTest()
+	{
+		final byte zero = (byte)0;
+		final byte one = (byte)1;
+		final byte two = (byte)2;
+		final byte three = (byte)3;
+		final byte four = (byte)4;
+		final byte five = (byte)5;
+		
+		Tup4bR t = new TestTup(one, one, one, one);
+		
+		t.getNewInstance(new TestTup(two, three, four, five));
+		
+		assertEquals(true, ValueRelay.get("getNewInstanceC", false));
+		assertEquals(two, ValueRelay.get("getNewInstanceC_X", zero));
+		assertEquals(three, ValueRelay.get("getNewInstanceC_Y", zero));
+		assertEquals(four, ValueRelay.get("getNewInstanceC_Z", zero));
+		assertEquals(five, ValueRelay.get("getNewInstanceC_W", zero));
+		
+		// Can't test for the result here, as the relaying and adopting of the values are implementation specific.
+	}
+	
+	/**
+	 * This test ensures, that the default implementation of the function {@link Tup4bR#getNewInstance(byte)} calls
+	 * the function {@link Tup4bR#getNewInstance(byte, byte, byte, byte)} with the correct components.
+	 */
+	@Test
+	void getNewInstance_ValueTest()
+	{
+		final byte zero = (byte)0;
+		final byte one = (byte)1;
+		final byte two = (byte)2;
+		
+		Tup4bR t = new TestTup(one, one, one, one);
+		
+		t.getNewInstance(two);
+		
+		assertEquals(true, ValueRelay.get("getNewInstanceC", false));
+		assertEquals(two, ValueRelay.get("getNewInstanceC_X", zero));
+		assertEquals(two, ValueRelay.get("getNewInstanceC_Y", zero));
+		assertEquals(two, ValueRelay.get("getNewInstanceC_Z", zero));
+		assertEquals(two, ValueRelay.get("getNewInstanceC_W", zero));
+		
+		// Can't test for the result here, as the relaying and adopting of the values are implementation specific.
+	}
+	
+	/**
 	 * This class is a test implementation of the interface {@link Tup4bR}.
 	 * 
 	 * @author picatrix1899
@@ -181,25 +198,40 @@ class Tup4bRTest
 		@Override
 		public byte getX()
 		{
+			ValueRelay.relayCall("getX");
 			return this.x;
 		}
 		
 		@Override
 		public byte getY()
 		{
+			ValueRelay.relayCall("getY");
 			return this.y;
 		}
 		
 		@Override
 		public byte getZ()
 		{
+			ValueRelay.relayCall("getZ");
 			return this.z;
 		}
 		
 		@Override
 		public byte getW()
 		{
+			ValueRelay.relayCall("getW");
 			return this.w;
+		}
+		
+		@Override
+		public TestTup getNewInstance(byte x, byte y, byte z, byte w)
+		{
+			ValueRelay.relayCall("getNewInstanceC");
+			ValueRelay.relay("getNewInstanceC_X", x);
+			ValueRelay.relay("getNewInstanceC_Y", y);
+			ValueRelay.relay("getNewInstanceC_Z", z);
+			ValueRelay.relay("getNewInstanceC_W", w);
+			return new TestTup(x, y, z, w);
 		}
 	}
 }

--- a/barghos-core/src/test/java/org/barghos/core/test/api/tuple4/Tup4bigdRTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/api/tuple4/Tup4bigdRTest.java
@@ -2,6 +2,7 @@ package org.barghos.core.test.api.tuple4;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
@@ -16,6 +17,15 @@ import org.barghos.core.api.tuple4.Tup4bigdR;
  */
 class Tup4bigdRTest
 {
+	/**
+	 * This method is called after each test in this class.
+	 */
+	@AfterEach
+	void cleanup()
+	{
+		ValueRelay.clear();
+	}
+	
 	/**
 	 * This test ensures, that the function {@link Tup4bigdR#isValid()} returns
 	 * the corrct values for different situations.
@@ -51,31 +61,9 @@ class Tup4bigdRTest
 	@Test
 	void isFiniteTest()
 	{
-		Tup4bigdR t = new Tup4bigdR() {
-			public BigDecimal getX()
-			{
-				ValueRelay.relayCall("getX");
-				return null;
-			}
-
-			public BigDecimal getY()
-			{
-				ValueRelay.relayCall("getY");
-				return null;
-			}
-			
-			public BigDecimal getZ()
-			{
-				ValueRelay.relayCall("getZ");
-				return null;
-			}
-			
-			public BigDecimal getW()
-			{
-				ValueRelay.relayCall("getW");
-				return null;
-			}
-		};
+		final BigDecimal zero = BigDecimal.ZERO;
+		
+		Tup4bigdR t = new TestTup(zero, zero, zero, zero);
 		
 		assertEquals(true, t.isFinite());
 		assertEquals(false, ValueRelay.get("getX", false));
@@ -149,6 +137,57 @@ class Tup4bigdRTest
 	}
 	
 	/**
+	 * This test ensures, that the default implementation of the function {@link Tup4bigdR#getNewInstance(Tup4bigdR)} calls
+	 * the function {@link Tup4bigdR#getNewInstance(BigDecimal, BigDecimal, BigDecimal, BigDecimal)} with the correct components.
+	 */
+	@Test
+	void getNewInstance_TupleTest()
+	{
+		final BigDecimal zero = BigDecimal.ZERO;
+		final BigDecimal one = BigDecimal.ONE;
+		final BigDecimal two = BigDecimal.valueOf(2.0);
+		final BigDecimal three = BigDecimal.valueOf(3.0);
+		final BigDecimal four = BigDecimal.valueOf(4.0);
+		final BigDecimal five = BigDecimal.valueOf(5.0);
+		
+		Tup4bigdR t = new TestTup(one, one, one, one);
+		
+		t.getNewInstance(new TestTup(two, three, four, five));
+		
+		assertEquals(true, ValueRelay.get("getNewInstanceC", false));
+		assertEquals(two, ValueRelay.get("getNewInstanceC_X", zero));
+		assertEquals(three, ValueRelay.get("getNewInstanceC_Y", zero));
+		assertEquals(four, ValueRelay.get("getNewInstanceC_Z", zero));
+		assertEquals(five, ValueRelay.get("getNewInstanceC_W", zero));
+		
+		// Can't test for the result here, as the relaying and adopting of the values are implementation specific.
+	}
+	
+	/**
+	 * This test ensures, that the default implementation of the function {@link Tup4bigdR#getNewInstance(BigDecimal)} calls
+	 * the function {@link Tup4bigdR#getNewInstance(BigDecimal, BigDecimal, BigDecimal, BigDecimal)} with the correct components.
+	 */
+	@Test
+	void getNewInstance_ValueTest()
+	{
+		final BigDecimal zero = BigDecimal.ZERO;
+		final BigDecimal one = BigDecimal.ONE;
+		final BigDecimal two = BigDecimal.valueOf(2.0);
+
+		Tup4bigdR t = new TestTup(one, one, one, one);
+		
+		t.getNewInstance(two);
+		
+		assertEquals(true, ValueRelay.get("getNewInstanceC", false));
+		assertEquals(two, ValueRelay.get("getNewInstanceC_X", zero));
+		assertEquals(two, ValueRelay.get("getNewInstanceC_Y", zero));
+		assertEquals(two, ValueRelay.get("getNewInstanceC_Z", zero));
+		assertEquals(two, ValueRelay.get("getNewInstanceC_W", zero));
+		
+		// Can't test for the result here, as the relaying and adopting of the values are implementation specific.
+	}
+	
+	/**
 	 * This class is a test implementation of the interface {@link Tup4bigdR}.
 	 * 
 	 * @author picatrix1899
@@ -171,25 +210,40 @@ class Tup4bigdRTest
 		@Override
 		public BigDecimal getX()
 		{
+			ValueRelay.relayCall("getX");
 			return this.x;
 		}
 		
 		@Override
 		public BigDecimal getY()
 		{
+			ValueRelay.relayCall("getY");
 			return this.y;
 		}
 		
 		@Override
 		public BigDecimal getZ()
 		{
+			ValueRelay.relayCall("getZ");
 			return this.z;
 		}
 		
 		@Override
 		public BigDecimal getW()
 		{
+			ValueRelay.relayCall("getW");
 			return this.w;
+		}
+		
+		@Override
+		public TestTup getNewInstance(BigDecimal x, BigDecimal y, BigDecimal z, BigDecimal w)
+		{
+			ValueRelay.relayCall("getNewInstanceC");
+			ValueRelay.relay("getNewInstanceC_X", x);
+			ValueRelay.relay("getNewInstanceC_Y", y);
+			ValueRelay.relay("getNewInstanceC_Z", z);
+			ValueRelay.relay("getNewInstanceC_W", w);
+			return new TestTup(x, y, z, w);
 		}
 	}
 }

--- a/barghos-core/src/test/java/org/barghos/core/test/api/tuple4/Tup4bigiRTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/api/tuple4/Tup4bigiRTest.java
@@ -2,9 +2,9 @@ package org.barghos.core.test.api.tuple4;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
-import java.math.BigDecimal;
 import java.math.BigInteger;
 
 import org.barghos.core.api.testing.ValueRelay;
@@ -17,6 +17,15 @@ import org.barghos.core.api.tuple4.Tup4bigiR;
  */
 class Tup4bigiRTest
 {
+	/**
+	 * This method is called after each test in this class.
+	 */
+	@AfterEach
+	void cleanup()
+	{
+		ValueRelay.clear();
+	}
+	
 	/**
 	 * This test ensures, that the function {@link Tup4bigiR#isValid()} returns
 	 * the corrct values for different situations.
@@ -52,31 +61,9 @@ class Tup4bigiRTest
 	@Test
 	void isFiniteTest()
 	{
-		Tup4bigiR t = new Tup4bigiR() {
-			public BigInteger getX()
-			{
-				ValueRelay.relayCall("getX");
-				return null;
-			}
-
-			public BigInteger getY()
-			{
-				ValueRelay.relayCall("getY");
-				return null;
-			}
-			
-			public BigInteger getZ()
-			{
-				ValueRelay.relayCall("getZ");
-				return null;
-			}
-			
-			public BigInteger getW()
-			{
-				ValueRelay.relayCall("getW");
-				return null;
-			}
-		};
+		final BigInteger zero = BigInteger.ZERO;
+		
+		Tup4bigiR t = new TestTup(zero, zero, zero, zero);
 		
 		assertEquals(true, t.isFinite());
 		assertEquals(false, ValueRelay.get("getX", false));
@@ -115,7 +102,7 @@ class Tup4bigiRTest
 	}
 	
 	/**
-	 * This test ensures, that the function {@link Tup4bigiR#isZero(BigDecimal)} returns the correct
+	 * This test ensures, that the function {@link Tup4bigiR#isZero(BigInteger)} returns the correct
 	 * value based on the situation.
 	 */
 	@Test
@@ -150,6 +137,57 @@ class Tup4bigiRTest
 	}
 	
 	/**
+	 * This test ensures, that the default implementation of the function {@link Tup4bigiR#getNewInstance(Tup4bigiR)} calls
+	 * the function {@link Tup4bigiR#getNewInstance(BigInteger, BigInteger, BigInteger, BigInteger)} with the correct components.
+	 */
+	@Test
+	void getNewInstance_TupleTest()
+	{
+		final BigInteger zero = BigInteger.ZERO;
+		final BigInteger one = BigInteger.ONE;
+		final BigInteger two = BigInteger.valueOf(2);
+		final BigInteger three = BigInteger.valueOf(3);
+		final BigInteger four = BigInteger.valueOf(4);
+		final BigInteger five = BigInteger.valueOf(5);
+		
+		Tup4bigiR t = new TestTup(one, one, one, one);
+		
+		t.getNewInstance(new TestTup(two, three, four, five));
+		
+		assertEquals(true, ValueRelay.get("getNewInstanceC", false));
+		assertEquals(two, ValueRelay.get("getNewInstanceC_X", zero));
+		assertEquals(three, ValueRelay.get("getNewInstanceC_Y", zero));
+		assertEquals(four, ValueRelay.get("getNewInstanceC_Z", zero));
+		assertEquals(five, ValueRelay.get("getNewInstanceC_W", zero));
+		
+		// Can't test for the result here, as the relaying and adopting of the values are implementation specific.
+	}
+	
+	/**
+	 * This test ensures, that the default implementation of the function {@link Tup4bigiR#getNewInstance(BigInteger)} calls
+	 * the function {@link Tup4bigiR#getNewInstance(BigInteger, BigInteger, BigInteger, BigInteger)} with the correct components.
+	 */
+	@Test
+	void getNewInstance_ValueTest()
+	{
+		final BigInteger zero = BigInteger.ZERO;
+		final BigInteger one = BigInteger.ONE;
+		final BigInteger two = BigInteger.valueOf(2);
+
+		Tup4bigiR t = new TestTup(one, one, one, one);
+		
+		t.getNewInstance(two);
+		
+		assertEquals(true, ValueRelay.get("getNewInstanceC", false));
+		assertEquals(two, ValueRelay.get("getNewInstanceC_X", zero));
+		assertEquals(two, ValueRelay.get("getNewInstanceC_Y", zero));
+		assertEquals(two, ValueRelay.get("getNewInstanceC_Z", zero));
+		assertEquals(two, ValueRelay.get("getNewInstanceC_W", zero));
+		
+		// Can't test for the result here, as the relaying and adopting of the values are implementation specific.
+	}
+	
+	/**
 	 * This class is a test implementation of the interface {@link Tup4bigiR}.
 	 * 
 	 * @author picatrix1899
@@ -172,25 +210,40 @@ class Tup4bigiRTest
 		@Override
 		public BigInteger getX()
 		{
+			ValueRelay.relayCall("getX");
 			return this.x;
 		}
 		
 		@Override
 		public BigInteger getY()
 		{
+			ValueRelay.relayCall("getY");
 			return this.y;
 		}
 		
 		@Override
 		public BigInteger getZ()
 		{
+			ValueRelay.relayCall("getZ");
 			return this.z;
 		}
 		
 		@Override
 		public BigInteger getW()
 		{
+			ValueRelay.relayCall("getW");
 			return this.w;
+		}
+		
+		@Override
+		public TestTup getNewInstance(BigInteger x, BigInteger y, BigInteger z, BigInteger w)
+		{
+			ValueRelay.relayCall("getNewInstanceC");
+			ValueRelay.relay("getNewInstanceC_X", x);
+			ValueRelay.relay("getNewInstanceC_Y", y);
+			ValueRelay.relay("getNewInstanceC_Z", z);
+			ValueRelay.relay("getNewInstanceC_W", w);
+			return new TestTup(x, y, z, w);
 		}
 	}
 }

--- a/barghos-core/src/test/java/org/barghos/core/test/api/tuple4/Tup4boRTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/api/tuple4/Tup4boRTest.java
@@ -31,36 +31,112 @@ class Tup4boRTest
 	@Test
 	void isValidTest()
 	{
-		Tup4boR t = new Tup4boR() {
-			public boolean getX()
-			{
-				ValueRelay.relayCall("getX");
-				return false;
-			}
-
-			public boolean getY()
-			{
-				ValueRelay.relayCall("getY");
-				return false;
-			}
-			
-			public boolean getZ()
-			{
-				ValueRelay.relayCall("getZ");
-				return false;
-			}
-			
-			public boolean getW()
-			{
-				ValueRelay.relayCall("getW");
-				return false;
-			}
-		};
+		Tup4boR t = new TestTup(false, false, false, false);
 		
 		assertEquals(true, t.isValid());
 		assertEquals(false, ValueRelay.get("getX", false));
 		assertEquals(false, ValueRelay.get("getY", false));
 		assertEquals(false, ValueRelay.get("getZ", false));
 		assertEquals(false, ValueRelay.get("getW", false));
+	}
+	
+	/**
+	 * This test ensures, that the default implementation of the function {@link Tup4boR#getNewInstance(Tup4boR)} calls
+	 * the function {@link Tup4boR#getNewInstance(boolean, boolean, boolean, boolean)} with the correct components.
+	 */
+	@Test
+	void getNewInstance_TupleTest()
+	{
+		Tup4boR t = new TestTup(false, false, false, false);
+		
+		t.getNewInstance(new TestTup(true, true, true, true));
+		
+		assertEquals(true, ValueRelay.get("getNewInstanceC", false));
+		assertEquals(true, ValueRelay.get("getNewInstanceC_X", false));
+		assertEquals(true, ValueRelay.get("getNewInstanceC_Y", false));
+		assertEquals(true, ValueRelay.get("getNewInstanceC_Z", false));
+		assertEquals(true, ValueRelay.get("getNewInstanceC_W", false));
+		
+		// Can't test for the result here, as the relaying and adopting of the values are implementation specific.
+	}
+	
+	/**
+	 * This test ensures, that the default implementation of the function {@link Tup4boR#getNewInstance(boolean)} calls
+	 * the function {@link Tup4boR#getNewInstance(boolean, boolean, boolean, boolean)} with the correct components.
+	 */
+	@Test
+	void getNewInstance_ValueTest()
+	{
+		Tup4boR t = new TestTup(false, false, false, false);
+		
+		t.getNewInstance(true);
+		
+		assertEquals(true, ValueRelay.get("getNewInstanceC", false));
+		assertEquals(true, ValueRelay.get("getNewInstanceC_X", false));
+		assertEquals(true, ValueRelay.get("getNewInstanceC_Y", false));
+		assertEquals(true, ValueRelay.get("getNewInstanceC_Z", false));
+		assertEquals(true, ValueRelay.get("getNewInstanceC_W", false));
+		
+		// Can't test for the result here, as the relaying and adopting of the values are implementation specific.
+	}
+	
+	/**
+	 * This class is a test implementation of the interface {@link Tup4boR}.
+	 * 
+	 * @author picatrix1899
+	 */
+	private static class TestTup implements Tup4boR
+	{
+		private final boolean x;
+		private final boolean y;
+		private final boolean z;
+		private final boolean w;
+		
+		public TestTup(boolean x, boolean y, boolean z, boolean w)
+		{
+			this.x = x;
+			this.y = y;
+			this.z = z;
+			this.w = w;
+		}
+		
+		@Override
+		public boolean getX()
+		{
+			ValueRelay.relayCall("getX");
+			return this.x;
+		}
+		
+		@Override
+		public boolean getY()
+		{
+			ValueRelay.relayCall("getY");
+			return this.y;
+		}
+		
+		@Override
+		public boolean getZ()
+		{
+			ValueRelay.relayCall("getZ");
+			return this.z;
+		}
+		
+		@Override
+		public boolean getW()
+		{
+			ValueRelay.relayCall("getW");
+			return this.w;
+		}
+		
+		@Override
+		public TestTup getNewInstance(boolean x, boolean y, boolean z, boolean w)
+		{
+			ValueRelay.relayCall("getNewInstanceC");
+			ValueRelay.relay("getNewInstanceC_X", x);
+			ValueRelay.relay("getNewInstanceC_Y", y);
+			ValueRelay.relay("getNewInstanceC_Z", z);
+			ValueRelay.relay("getNewInstanceC_W", w);
+			return new TestTup(x, y, z, w);
+		}
 	}
 }

--- a/barghos-core/src/test/java/org/barghos/core/test/api/tuple4/Tup4cRTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/api/tuple4/Tup4cRTest.java
@@ -31,31 +31,7 @@ class Tup4cRTest
 	@Test
 	void isValidTest()
 	{
-		Tup4cR t = new Tup4cR() {
-			public char getX()
-			{
-				ValueRelay.relayCall("getX");
-				return 'a';
-			}
-
-			public char getY()
-			{
-				ValueRelay.relayCall("getY");
-				return 'a';
-			}
-			
-			public char getZ()
-			{
-				ValueRelay.relayCall("getZ");
-				return 'a';
-			}
-			
-			public char getW()
-			{
-				ValueRelay.relayCall("getW");
-				return 'a';
-			}
-		};
+		Tup4cR t = new TestTup('a', 'a', 'a', 'a');
 		
 		assertEquals(true, t.isValid());
 		assertEquals(false, ValueRelay.get("getX", false));
@@ -71,36 +47,112 @@ class Tup4cRTest
 	@Test
 	void isFiniteTest()
 	{
-		Tup4cR t = new Tup4cR() {
-			public char getX()
-			{
-				ValueRelay.relayCall("getX");
-				return 'a';
-			}
-
-			public char getY()
-			{
-				ValueRelay.relayCall("getY");
-				return 'a';
-			}
-			
-			public char getZ()
-			{
-				ValueRelay.relayCall("getZ");
-				return 'a';
-			}
-			
-			public char getW()
-			{
-				ValueRelay.relayCall("getW");
-				return 'a';
-			}
-		};
+		Tup4cR t = new TestTup('a', 'a', 'a', 'a');
 		
 		assertEquals(true, t.isFinite());
 		assertEquals(false, ValueRelay.get("getX", false));
 		assertEquals(false, ValueRelay.get("getY", false));
 		assertEquals(false, ValueRelay.get("getZ", false));
 		assertEquals(false, ValueRelay.get("getW", false));
+	}
+	
+	/**
+	 * This test ensures, that the default implementation of the function {@link Tup4cR#getNewInstance(Tup4cR)} calls
+	 * the function {@link Tup4cR#getNewInstance(char, char, char, char)} with the correct components.
+	 */
+	@Test
+	void getNewInstance_TupleTest()
+	{
+		Tup4cR t = new TestTup('b', 'b', 'b', 'b');
+		
+		t.getNewInstance(new TestTup('c', 'd', 'e', 'f'));
+		
+		assertEquals(true, ValueRelay.get("getNewInstanceC", false));
+		assertEquals('c', ValueRelay.get("getNewInstanceC_X", 'a'));
+		assertEquals('d', ValueRelay.get("getNewInstanceC_Y", 'a'));
+		assertEquals('e', ValueRelay.get("getNewInstanceC_Z", 'a'));
+		assertEquals('f', ValueRelay.get("getNewInstanceC_W", 'a'));
+		
+		// Can't test for the result here, as the relaying and adopting of the values are implementation specific.
+	}
+	
+	/**
+	 * This test ensures, that the default implementation of the function {@link Tup4cR#getNewInstance(char)} calls
+	 * the function {@link Tup4cR#getNewInstance(char, char, char, char)} with the correct components.
+	 */
+	@Test
+	void getNewInstance_ValueTest()
+	{
+		Tup4cR t = new TestTup('b', 'b', 'b', 'b');
+		
+		t.getNewInstance('c');
+		
+		assertEquals(true, ValueRelay.get("getNewInstanceC", false));
+		assertEquals('c', ValueRelay.get("getNewInstanceC_X", 'a'));
+		assertEquals('c', ValueRelay.get("getNewInstanceC_Y", 'a'));
+		assertEquals('c', ValueRelay.get("getNewInstanceC_Z", 'a'));
+		assertEquals('c', ValueRelay.get("getNewInstanceC_W", 'a'));
+		
+		// Can't test for the result here, as the relaying and adopting of the values are implementation specific.
+	}
+	
+	/**
+	 * This class is a test implementation of the interface {@link Tup4cR}.
+	 * 
+	 * @author picatrix1899
+	 */
+	private static class TestTup implements Tup4cR
+	{
+		private final char x;
+		private final char y;
+		private final char z;
+		private final char w;
+		
+		public TestTup(char x, char y, char z, char w)
+		{
+			this.x = x;
+			this.y = y;
+			this.z = z;
+			this.w = w;
+		}
+		
+		@Override
+		public char getX()
+		{
+			ValueRelay.relayCall("getX");
+			return this.x;
+		}
+		
+		@Override
+		public char getY()
+		{
+			ValueRelay.relayCall("getY");
+			return this.y;
+		}
+		
+		@Override
+		public char getZ()
+		{
+			ValueRelay.relayCall("getZ");
+			return this.z;
+		}
+		
+		@Override
+		public char getW()
+		{
+			ValueRelay.relayCall("getW");
+			return this.w;
+		}
+		
+		@Override
+		public TestTup getNewInstance(char x, char y, char z, char w)
+		{
+			ValueRelay.relayCall("getNewInstanceC");
+			ValueRelay.relay("getNewInstanceC_X", x);
+			ValueRelay.relay("getNewInstanceC_Y", y);
+			ValueRelay.relay("getNewInstanceC_Z", z);
+			ValueRelay.relay("getNewInstanceC_W", w);
+			return new TestTup(x, y, z, w);
+		}
 	}
 }

--- a/barghos-core/src/test/java/org/barghos/core/test/api/tuple4/Tup4dRTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/api/tuple4/Tup4dRTest.java
@@ -2,6 +2,7 @@ package org.barghos.core.test.api.tuple4;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import org.barghos.core.api.testing.ValueRelay;
@@ -15,37 +16,22 @@ import org.barghos.core.api.tuple4.Tup4dR;
 class Tup4dRTest
 {
 	/**
+	 * This method is called after each test in this class.
+	 */
+	@AfterEach
+	void cleanup()
+	{
+		ValueRelay.clear();
+	}
+	
+	/**
 	 * This test ensures, that the function {@link Tup4dR#isValid()} returns
 	 * the corrct values for different situations.
 	 */
 	@Test
 	void isValidTest()
 	{
-		Tup4dR t = new Tup4dR() {
-			public double getX()
-			{
-				ValueRelay.relayCall("getX");
-				return 0.0;
-			}
-
-			public double getY()
-			{
-				ValueRelay.relayCall("getY");
-				return 0.0;
-			}
-			
-			public double getZ()
-			{
-				ValueRelay.relayCall("getZ");
-				return 0.0;
-			}
-			
-			public double getW()
-			{
-				ValueRelay.relayCall("getW");
-				return 0.0;
-			}
-		};
+		Tup4dR t = new TestTup(0.0, 0.0, 0.0, 0.0);
 		
 		assertEquals(true, t.isValid());
 		assertEquals(false, ValueRelay.get("getX", false));
@@ -146,6 +132,46 @@ class Tup4dRTest
 	}
 	
 	/**
+	 * This test ensures, that the default implementation of the function {@link Tup4dR#getNewInstance(Tup4dR)} calls
+	 * the function {@link Tup4dR#getNewInstance(double, double, double, double)} with the correct components.
+	 */
+	@Test
+	void getNewInstance_TupleTest()
+	{
+		Tup4dR t = new TestTup(1.0, 1.0, 1.0, 1.0);
+		
+		t.getNewInstance(new TestTup(2.0, 3.0, 4.0, 5.0));
+		
+		assertEquals(true, ValueRelay.get("getNewInstanceC", false));
+		assertEquals(2.0, ValueRelay.get("getNewInstanceC_X", 0.0));
+		assertEquals(3.0, ValueRelay.get("getNewInstanceC_Y", 0.0));
+		assertEquals(4.0, ValueRelay.get("getNewInstanceC_Z", 0.0));
+		assertEquals(5.0, ValueRelay.get("getNewInstanceC_W", 0.0));
+		
+		// Can't test for the result here, as the relaying and adopting of the values are implementation specific.
+	}
+	
+	/**
+	 * This test ensures, that the default implementation of the function {@link Tup4dR#getNewInstance(double)} calls
+	 * the function {@link Tup4dR#getNewInstance(double, double, double, double)} with the correct components.
+	 */
+	@Test
+	void getNewInstance_ValueTest()
+	{
+		Tup4dR t = new TestTup(1.0, 1.0, 1.0, 1.0);
+		
+		t.getNewInstance(2.0);
+		
+		assertEquals(true, ValueRelay.get("getNewInstanceC", false));
+		assertEquals(2.0, ValueRelay.get("getNewInstanceC_X", 0.0));
+		assertEquals(2.0, ValueRelay.get("getNewInstanceC_Y", 0.0));
+		assertEquals(2.0, ValueRelay.get("getNewInstanceC_Z", 0.0));
+		assertEquals(2.0, ValueRelay.get("getNewInstanceC_W", 0.0));
+		
+		// Can't test for the result here, as the relaying and adopting of the values are implementation specific.
+	}
+	
+	/**
 	 * This class is a test implementation of the interface {@link Tup4dR}.
 	 * 
 	 * @author picatrix1899
@@ -168,25 +194,40 @@ class Tup4dRTest
 		@Override
 		public double getX()
 		{
+			ValueRelay.relayCall("getX");
 			return this.x;
 		}
 		
 		@Override
 		public double getY()
 		{
+			ValueRelay.relayCall("getY");
 			return this.y;
 		}
 		
 		@Override
 		public double getZ()
 		{
+			ValueRelay.relayCall("getZ");
 			return this.z;
 		}
 		
 		@Override
 		public double getW()
 		{
+			ValueRelay.relayCall("getW");
 			return this.w;
+		}
+		
+		@Override
+		public TestTup getNewInstance(double x, double y, double z, double w)
+		{
+			ValueRelay.relayCall("getNewInstanceC");
+			ValueRelay.relay("getNewInstanceC_X", x);
+			ValueRelay.relay("getNewInstanceC_Y", y);
+			ValueRelay.relay("getNewInstanceC_Z", z);
+			ValueRelay.relay("getNewInstanceC_W", w);
+			return new TestTup(x, y, z, w);
 		}
 	}
 }

--- a/barghos-core/src/test/java/org/barghos/core/test/api/tuple4/Tup4fRTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/api/tuple4/Tup4fRTest.java
@@ -2,6 +2,7 @@ package org.barghos.core.test.api.tuple4;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import org.barghos.core.api.testing.ValueRelay;
@@ -15,37 +16,22 @@ import org.barghos.core.api.tuple4.Tup4fR;
 class Tup4fRTest
 {
 	/**
+	 * This method is called after each test in this class.
+	 */
+	@AfterEach
+	void cleanup()
+	{
+		ValueRelay.clear();
+	}
+	
+	/**
 	 * This test ensures, that the function {@link Tup4fR#isValid()} returns
 	 * the corrct values for different situations.
 	 */
 	@Test
 	void isValidTest()
 	{
-		Tup4fR t = new Tup4fR() {
-			public float getX()
-			{
-				ValueRelay.relayCall("getX");
-				return 0.0f;
-			}
-
-			public float getY()
-			{
-				ValueRelay.relayCall("getY");
-				return 0.0f;
-			}
-			
-			public float getZ()
-			{
-				ValueRelay.relayCall("getZ");
-				return 0.0f;
-			}
-			
-			public float getW()
-			{
-				ValueRelay.relayCall("getW");
-				return 0.0f;
-			}
-		};
+		Tup4fR t = new TestTup(0.0f, 0.0f, 0.0f, 0.0f);
 		
 		assertEquals(true, t.isValid());
 		assertEquals(false, ValueRelay.get("getX", false));
@@ -146,6 +132,46 @@ class Tup4fRTest
 	}
 	
 	/**
+	 * This test ensures, that the default implementation of the function {@link Tup4fR#getNewInstance(Tup4fR)} calls
+	 * the function {@link Tup4fR#getNewInstance(float, float, float, float)} with the correct components.
+	 */
+	@Test
+	void getNewInstance_TupleTest()
+	{
+		Tup4fR t = new TestTup(1.0f, 1.0f, 1.0f, 1.0f);
+		
+		t.getNewInstance(new TestTup(2.0f, 3.0f, 4.0f, 5.0f));
+		
+		assertEquals(true, ValueRelay.get("getNewInstanceC", false));
+		assertEquals(2.0f, ValueRelay.get("getNewInstanceC_X", 0.0f));
+		assertEquals(3.0f, ValueRelay.get("getNewInstanceC_Y", 0.0f));
+		assertEquals(4.0f, ValueRelay.get("getNewInstanceC_Z", 0.0f));
+		assertEquals(5.0f, ValueRelay.get("getNewInstanceC_W", 0.0f));
+		
+		// Can't test for the result here, as the relaying and adopting of the values are implementation specific.
+	}
+	
+	/**
+	 * This test ensures, that the default implementation of the function {@link Tup4fR#getNewInstance(float)} calls
+	 * the function {@link Tup4fR#getNewInstance(float, float, float, float)} with the correct components.
+	 */
+	@Test
+	void getNewInstance_ValueTest()
+	{
+		Tup4fR t = new TestTup(1.0f, 1.0f, 1.0f, 1.0f);
+		
+		t.getNewInstance(2.0f);
+		
+		assertEquals(true, ValueRelay.get("getNewInstanceC", false));
+		assertEquals(2.0f, ValueRelay.get("getNewInstanceC_X", 0.0f));
+		assertEquals(2.0f, ValueRelay.get("getNewInstanceC_Y", 0.0f));
+		assertEquals(2.0f, ValueRelay.get("getNewInstanceC_Z", 0.0f));
+		assertEquals(2.0f, ValueRelay.get("getNewInstanceC_W", 0.0f));
+		
+		// Can't test for the result here, as the relaying and adopting of the values are implementation specific.
+	}
+	
+	/**
 	 * This class is a test implementation of the interface {@link Tup4fR}.
 	 * 
 	 * @author picatrix1899
@@ -168,25 +194,40 @@ class Tup4fRTest
 		@Override
 		public float getX()
 		{
+			ValueRelay.relayCall("getX");
 			return this.x;
 		}
 		
 		@Override
 		public float getY()
 		{
+			ValueRelay.relayCall("getY");
 			return this.y;
 		}
 		
 		@Override
 		public float getZ()
 		{
+			ValueRelay.relayCall("getZ");
 			return this.z;
 		}
 		
 		@Override
 		public float getW()
 		{
+			ValueRelay.relayCall("getW");
 			return this.w;
+		}
+		
+		@Override
+		public TestTup getNewInstance(float x, float y, float z, float w)
+		{
+			ValueRelay.relayCall("getNewInstanceC");
+			ValueRelay.relay("getNewInstanceC_X", x);
+			ValueRelay.relay("getNewInstanceC_Y", y);
+			ValueRelay.relay("getNewInstanceC_Z", z);
+			ValueRelay.relay("getNewInstanceC_W", w);
+			return new TestTup(x, y, z, w);
 		}
 	}
 }

--- a/barghos-core/src/test/java/org/barghos/core/test/api/tuple4/Tup4lRTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/api/tuple4/Tup4lRTest.java
@@ -2,6 +2,7 @@ package org.barghos.core.test.api.tuple4;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import org.barghos.core.api.testing.ValueRelay;
@@ -15,37 +16,22 @@ import org.barghos.core.api.tuple4.Tup4lR;
 class Tup4lRTest
 {
 	/**
+	 * This method is called after each test in this class.
+	 */
+	@AfterEach
+	void cleanup()
+	{
+		ValueRelay.clear();
+	}
+	
+	/**
 	 * This test ensures, that the function {@link Tup4lR#isValid()} returns
 	 * the corrct values for different situations.
 	 */
 	@Test
 	void isValidTest()
 	{
-		Tup4lR t = new Tup4lR() {
-			public long getX()
-			{
-				ValueRelay.relayCall("getX");
-				return 0l;
-			}
-
-			public long getY()
-			{
-				ValueRelay.relayCall("getY");
-				return 0l;
-			}
-			
-			public long getZ()
-			{
-				ValueRelay.relayCall("getZ");
-				return 0l;
-			}
-			
-			public long getW()
-			{
-				ValueRelay.relayCall("getW");
-				return 0l;
-			}
-		};
+		Tup4lR t = new TestTup(0l, 0l, 0l, 0l);
 		
 		assertEquals(true, t.isValid());
 		assertEquals(false, ValueRelay.get("getX", false));
@@ -61,31 +47,7 @@ class Tup4lRTest
 	@Test
 	void isFiniteTest()
 	{
-		Tup4lR t = new Tup4lR() {
-			public long getX()
-			{
-				ValueRelay.relayCall("getX");
-				return 0l;
-			}
-
-			public long getY()
-			{
-				ValueRelay.relayCall("getY");
-				return 0l;
-			}
-			
-			public long getZ()
-			{
-				ValueRelay.relayCall("getZ");
-				return 0l;
-			}
-			
-			public long getW()
-			{
-				ValueRelay.relayCall("getW");
-				return 0l;
-			}
-		};
+		Tup4lR t = new TestTup(0l, 0l, 0l, 0l);
 		
 		assertEquals(true, t.isFinite());
 		assertEquals(false, ValueRelay.get("getX", false));
@@ -154,6 +116,46 @@ class Tup4lRTest
 	}
 	
 	/**
+	 * This test ensures, that the default implementation of the function {@link Tup4lR#getNewInstance(Tup4lR)} calls
+	 * the function {@link Tup4lR#getNewInstance(long, long, long, long)} with the correct components.
+	 */
+	@Test
+	void getNewInstance_TupleTest()
+	{
+		Tup4lR t = new TestTup(1l, 1l, 1l, 1l);
+		
+		t.getNewInstance(new TestTup(2l, 3l, 4l, 5l));
+		
+		assertEquals(true, ValueRelay.get("getNewInstanceC", false));
+		assertEquals(2l, ValueRelay.get("getNewInstanceC_X", 0l));
+		assertEquals(3l, ValueRelay.get("getNewInstanceC_Y", 0l));
+		assertEquals(4l, ValueRelay.get("getNewInstanceC_Z", 0l));
+		assertEquals(5l, ValueRelay.get("getNewInstanceC_W", 0l));
+		
+		// Can't test for the result here, as the relaying and adopting of the values are implementation specific.
+	}
+	
+	/**
+	 * This test ensures, that the default implementation of the function {@link Tup4lR#getNewInstance(long)} calls
+	 * the function {@link Tup4lR#getNewInstance(long, long, long, long)} with the correct components.
+	 */
+	@Test
+	void getNewInstance_ValueTest()
+	{
+		Tup4lR t = new TestTup(1l, 1l, 1l, 1l);
+		
+		t.getNewInstance(2l);
+		
+		assertEquals(true, ValueRelay.get("getNewInstanceC", false));
+		assertEquals(2l, ValueRelay.get("getNewInstanceC_X", 0l));
+		assertEquals(2l, ValueRelay.get("getNewInstanceC_Y", 0l));
+		assertEquals(2l, ValueRelay.get("getNewInstanceC_Z", 0l));
+		assertEquals(2l, ValueRelay.get("getNewInstanceC_W", 0l));
+		
+		// Can't test for the result here, as the relaying and adopting of the values are implementation specific.
+	}
+	
+	/**
 	 * This class is a test implementation of the interface {@link Tup4lR}.
 	 * 
 	 * @author picatrix1899
@@ -176,25 +178,40 @@ class Tup4lRTest
 		@Override
 		public long getX()
 		{
+			ValueRelay.relayCall("getX");
 			return this.x;
 		}
 		
 		@Override
 		public long getY()
 		{
+			ValueRelay.relayCall("getY");
 			return this.y;
 		}
 		
 		@Override
 		public long getZ()
 		{
+			ValueRelay.relayCall("getZ");
 			return this.z;
 		}
 		
 		@Override
 		public long getW()
 		{
+			ValueRelay.relayCall("getW");
 			return this.w;
+		}
+		
+		@Override
+		public TestTup getNewInstance(long x, long y, long z, long w)
+		{
+			ValueRelay.relayCall("getNewInstanceC");
+			ValueRelay.relay("getNewInstanceC_X", x);
+			ValueRelay.relay("getNewInstanceC_Y", y);
+			ValueRelay.relay("getNewInstanceC_Z", z);
+			ValueRelay.relay("getNewInstanceC_W", w);
+			return new TestTup(x, y, z, w);
 		}
 	}
 }

--- a/barghos-core/src/test/java/org/barghos/core/test/api/tuple4/Tup4oRTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/api/tuple4/Tup4oRTest.java
@@ -2,8 +2,10 @@ package org.barghos.core.test.api.tuple4;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
+import org.barghos.core.api.testing.ValueRelay;
 import org.barghos.core.api.tuple4.Tup4oR;
 
 /**
@@ -13,6 +15,15 @@ import org.barghos.core.api.tuple4.Tup4oR;
  */
 class Tup4oRTest
 {
+	/**
+	 * This method is called after each test in this class.
+	 */
+	@AfterEach
+	void cleanup()
+	{
+		ValueRelay.clear();
+	}
+	
 	/**
 	 * This test ensures, that the function {@link Tup4oR#isValid()} returns
 	 * the corrct values for different situations.
@@ -37,6 +48,26 @@ class Tup4oRTest
 		
 		t = new TestTup<>(new Object(), new Object(), new Object(), new Object());
 		assertEquals(true, t.isValid());
+	}
+	
+	/**
+	 * This test ensures, that the default implementation of the function {@link Tup4oR#getNewInstance(Tup4oR)} calls
+	 * the function {@link Tup4oR#getNewInstance(Object, Object, Object, Object)} with the correct components.
+	 */
+	@Test
+	void getNewInstance_TupleTest()
+	{
+		Tup4oR<Long,Long,Long,Long> t = new TestTup<>(1l, 1l, 1l, 1l);
+		
+		t.getNewInstance(new TestTup<>(2l, 3l, 4l, 5l));
+		
+		assertEquals(true, ValueRelay.get("getNewInstanceC", false));
+		assertEquals(2l, ValueRelay.get("getNewInstanceC_X", 0l));
+		assertEquals(3l, ValueRelay.get("getNewInstanceC_Y", 0l));
+		assertEquals(4l, ValueRelay.get("getNewInstanceC_Z", 0l));
+		assertEquals(5l, ValueRelay.get("getNewInstanceC_W", 0l));
+		
+		// Can't test for the result here, as the relaying and adopting of the values are implementation specific.
 	}
 	
 	/**
@@ -81,6 +112,17 @@ class Tup4oRTest
 		public W getW()
 		{
 			return this.w;
+		}
+		
+		@Override
+		public TestTup<X,Y,Z,W> getNewInstance(X x, Y y, Z z, W w)
+		{
+			ValueRelay.relayCall("getNewInstanceC");
+			ValueRelay.relay("getNewInstanceC_X", x);
+			ValueRelay.relay("getNewInstanceC_Y", y);
+			ValueRelay.relay("getNewInstanceC_Z", z);
+			ValueRelay.relay("getNewInstanceC_W", w);
+			return new TestTup<>(x, y, z, w);
 		}
 	}
 }

--- a/barghos-core/src/test/java/org/barghos/core/test/api/tuple4/Tup4objRTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/api/tuple4/Tup4objRTest.java
@@ -2,8 +2,10 @@ package org.barghos.core.test.api.tuple4;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
+import org.barghos.core.api.testing.ValueRelay;
 import org.barghos.core.api.tuple4.Tup4objR;
 
 /**
@@ -13,6 +15,15 @@ import org.barghos.core.api.tuple4.Tup4objR;
  */
 class Tup4objRTest
 {
+	/**
+	 * This method is called after each test in this class.
+	 */
+	@AfterEach
+	void cleanup()
+	{
+		ValueRelay.clear();
+	}
+	
 	/**
 	 * This test ensures, that the function {@link Tup4objR#isValid()} returns
 	 * the corrct values for different situations.
@@ -37,6 +48,46 @@ class Tup4objRTest
 		
 		t = new TestTup(new Object(), new Object(), new Object(), new Object());
 		assertEquals(true, t.isValid());
+	}
+	
+	/**
+	 * This test ensures, that the default implementation of the function {@link Tup4objR#getNewInstance(Tup4objR)} calls
+	 * the function {@link Tup4objR#getNewInstance(Object, Object, Object, Object)} with the correct components.
+	 */
+	@Test
+	void getNewInstance_TupleTest()
+	{
+		Tup4objR t = new TestTup(1l, 1l, 1l, 1l);
+		
+		t.getNewInstance(new TestTup(2l, 3l, 4l, 5l));
+		
+		assertEquals(true, ValueRelay.get("getNewInstanceC", false));
+		assertEquals(2l, ValueRelay.get("getNewInstanceC_X", 0l));
+		assertEquals(3l, ValueRelay.get("getNewInstanceC_Y", 0l));
+		assertEquals(4l, ValueRelay.get("getNewInstanceC_Z", 0l));
+		assertEquals(5l, ValueRelay.get("getNewInstanceC_W", 0l));
+		
+		// Can't test for the result here, as the relaying and adopting of the values are implementation specific.
+	}
+	
+	/**
+	 * This test ensures, that the default implementation of the function {@link Tup4objR#getNewInstance(Object)} calls
+	 * the function {@link Tup4objR#getNewInstance(Object, Object, Object, Object)} with the correct components.
+	 */
+	@Test
+	void getNewInstance_ValueTest()
+	{
+		Tup4objR t = new TestTup(1l, 1l, 1l, 1l);
+		
+		t.getNewInstance(2l);
+		
+		assertEquals(true, ValueRelay.get("getNewInstanceC", false));
+		assertEquals(2l, ValueRelay.get("getNewInstanceC_X", 0l));
+		assertEquals(2l, ValueRelay.get("getNewInstanceC_Y", 0l));
+		assertEquals(2l, ValueRelay.get("getNewInstanceC_Z", 0l));
+		assertEquals(2l, ValueRelay.get("getNewInstanceC_W", 0l));
+		
+		// Can't test for the result here, as the relaying and adopting of the values are implementation specific.
 	}
 	
 	/**
@@ -81,6 +132,17 @@ class Tup4objRTest
 		public Object getW()
 		{
 			return this.w;
+		}
+		
+		@Override
+		public TestTup getNewInstance(Object x, Object y, Object z, Object w)
+		{
+			ValueRelay.relayCall("getNewInstanceC");
+			ValueRelay.relay("getNewInstanceC_X", x);
+			ValueRelay.relay("getNewInstanceC_Y", y);
+			ValueRelay.relay("getNewInstanceC_Z", z);
+			ValueRelay.relay("getNewInstanceC_W", w);
+			return new TestTup(x, y, z, w);
 		}
 	}
 }

--- a/barghos-core/src/test/java/org/barghos/core/test/api/tuple4/Tup4sRTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/api/tuple4/Tup4sRTest.java
@@ -2,6 +2,7 @@ package org.barghos.core.test.api.tuple4;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import org.barghos.core.api.testing.ValueRelay;
@@ -15,37 +16,24 @@ import org.barghos.core.api.tuple4.Tup4sR;
 class Tup4sRTest
 {
 	/**
+	 * This method is called after each test in this class.
+	 */
+	@AfterEach
+	void cleanup()
+	{
+		ValueRelay.clear();
+	}
+	
+	/**
 	 * This test ensures, that the function {@link Tup4sR#isValid()} returns
 	 * the corrct values for different situations.
 	 */
 	@Test
 	void isValidTest()
 	{
-		Tup4sR t = new Tup4sR() {
-			public short getX()
-			{
-				ValueRelay.relayCall("getX");
-				return (short)0;
-			}
-
-			public short getY()
-			{
-				ValueRelay.relayCall("getY");
-				return (short)0;
-			}
-			
-			public short getZ()
-			{
-				ValueRelay.relayCall("getZ");
-				return (short)0;
-			}
-			
-			public short getW()
-			{
-				ValueRelay.relayCall("getW");
-				return (short)0;
-			}
-		};
+		final short zero = (short)0;
+		
+		Tup4sR t = new TestTup(zero, zero, zero, zero);
 		
 		assertEquals(true, t.isValid());
 		assertEquals(false, ValueRelay.get("getX", false));
@@ -61,31 +49,9 @@ class Tup4sRTest
 	@Test
 	void isFiniteTest()
 	{
-		Tup4sR t = new Tup4sR() {
-			public short getX()
-			{
-				ValueRelay.relayCall("getX");
-				return (short)0;
-			}
-
-			public short getY()
-			{
-				ValueRelay.relayCall("getY");
-				return (short)0;
-			}
-			
-			public short getZ()
-			{
-				ValueRelay.relayCall("getZ");
-				return (short)0;
-			}
-			
-			public short getW()
-			{
-				ValueRelay.relayCall("getW");
-				return (short)0;
-			}
-		};
+		final short zero = (short)0;
+		
+		Tup4sR t = new TestTup(zero, zero, zero, zero);
 		
 		assertEquals(true, t.isFinite());
 		assertEquals(false, ValueRelay.get("getX", false));
@@ -159,6 +125,57 @@ class Tup4sRTest
 	}
 	
 	/**
+	 * This test ensures, that the default implementation of the function {@link Tup4sR#getNewInstance(Tup4sR)} calls
+	 * the function {@link Tup4sR#getNewInstance(short, short, short, short)} with the correct components.
+	 */
+	@Test
+	void getNewInstance_TupleTest()
+	{
+		final short zero = (short)0;
+		final short one = (short)1;
+		final short two = (short)2;
+		final short three = (short)3;
+		final short four = (short)4;
+		final short five = (short)5;
+		
+		Tup4sR t = new TestTup(one, one, one, one);
+		
+		t.getNewInstance(new TestTup(two, three, four, five));
+		
+		assertEquals(true, ValueRelay.get("getNewInstanceC", false));
+		assertEquals(two, ValueRelay.get("getNewInstanceC_X", zero));
+		assertEquals(three, ValueRelay.get("getNewInstanceC_Y", zero));
+		assertEquals(four, ValueRelay.get("getNewInstanceC_Z", zero));
+		assertEquals(five, ValueRelay.get("getNewInstanceC_W", zero));
+		
+		// Can't test for the result here, as the relaying and adopting of the values are implementation specific.
+	}
+	
+	/**
+	 * This test ensures, that the default implementation of the function {@link Tup4sR#getNewInstance(short)} calls
+	 * the function {@link Tup4sR#getNewInstance(short, short, short, short)} with the correct components.
+	 */
+	@Test
+	void getNewInstance_ValueTest()
+	{
+		final short zero = (short)0;
+		final short one = (short)1;
+		final short two = (short)2;
+		
+		Tup4sR t = new TestTup(one, one, one, one);
+		
+		t.getNewInstance(two);
+		
+		assertEquals(true, ValueRelay.get("getNewInstanceC", false));
+		assertEquals(two, ValueRelay.get("getNewInstanceC_X", zero));
+		assertEquals(two, ValueRelay.get("getNewInstanceC_Y", zero));
+		assertEquals(two, ValueRelay.get("getNewInstanceC_Z", zero));
+		assertEquals(two, ValueRelay.get("getNewInstanceC_W", zero));
+		
+		// Can't test for the result here, as the relaying and adopting of the values are implementation specific.
+	}
+	
+	/**
 	 * This class is a test implementation of the interface {@link Tup4sR}.
 	 * 
 	 * @author picatrix1899
@@ -181,25 +198,40 @@ class Tup4sRTest
 		@Override
 		public short getX()
 		{
+			ValueRelay.relayCall("getX");
 			return this.x;
 		}
 		
 		@Override
 		public short getY()
 		{
+			ValueRelay.relayCall("getY");
 			return this.y;
 		}
 		
 		@Override
 		public short getZ()
 		{
+			ValueRelay.relayCall("getZ");
 			return this.z;
 		}
 		
 		@Override
 		public short getW()
 		{
+			ValueRelay.relayCall("getW");
 			return this.w;
+		}
+		
+		@Override
+		public TestTup getNewInstance(short x, short y, short z, short w)
+		{
+			ValueRelay.relayCall("getNewInstanceC");
+			ValueRelay.relay("getNewInstanceC_X", x);
+			ValueRelay.relay("getNewInstanceC_Y", y);
+			ValueRelay.relay("getNewInstanceC_Z", z);
+			ValueRelay.relay("getNewInstanceC_W", w);
+			return new TestTup(x, y, z, w);
 		}
 	}
 }

--- a/barghos-core/src/test/java/org/barghos/core/test/api/tuple4/Tup4strRTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/api/tuple4/Tup4strRTest.java
@@ -2,8 +2,10 @@ package org.barghos.core.test.api.tuple4;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
+import org.barghos.core.api.testing.ValueRelay;
 import org.barghos.core.api.tuple4.Tup4strR;
 
 /**
@@ -13,6 +15,15 @@ import org.barghos.core.api.tuple4.Tup4strR;
  */
 class Tup4strRTest
 {
+	/**
+	 * This method is called after each test in this class.
+	 */
+	@AfterEach
+	void cleanup()
+	{
+		ValueRelay.clear();
+	}
+	
 	/**
 	 * This test ensures, that the function {@link Tup4strR#isValid()} returns
 	 * the corrct values for different situations.
@@ -37,6 +48,46 @@ class Tup4strRTest
 		
 		t = new TestTup("", "", "", "");
 		assertEquals(true, t.isValid());
+	}
+	
+	/**
+	 * This test ensures, that the default implementation of the function {@link Tup4strR#getNewInstance(Tup4strR)} calls
+	 * the function {@link Tup4strR#getNewInstance(String, String, String, String)} with the correct components.
+	 */
+	@Test
+	void getNewInstance_TupleTest()
+	{
+		Tup4strR t = new TestTup("a", "a", "a", "a");
+		
+		t.getNewInstance(new TestTup("b", "c", "d", "e"));
+		
+		assertEquals(true, ValueRelay.get("getNewInstanceC", false));
+		assertEquals("b", ValueRelay.get("getNewInstanceC_X", ""));
+		assertEquals("c", ValueRelay.get("getNewInstanceC_Y", ""));
+		assertEquals("d", ValueRelay.get("getNewInstanceC_Z", ""));
+		assertEquals("e", ValueRelay.get("getNewInstanceC_W", ""));
+		
+		// Can't test for the result here, as the relaying and adopting of the values are implementation specific.
+	}
+	
+	/**
+	 * This test ensures, that the default implementation of the function {@link Tup4strR#getNewInstance(String)} calls
+	 * the function {@link Tup4strR#getNewInstance(String, String, String, String)} with the correct components.
+	 */
+	@Test
+	void getNewInstance_ValueTest()
+	{
+		Tup4strR t = new TestTup("a", "a", "a", "a");
+		
+		t.getNewInstance("b");
+		
+		assertEquals(true, ValueRelay.get("getNewInstanceC", false));
+		assertEquals("b", ValueRelay.get("getNewInstanceC_X", ""));
+		assertEquals("b", ValueRelay.get("getNewInstanceC_Y", ""));
+		assertEquals("b", ValueRelay.get("getNewInstanceC_Z", ""));
+		assertEquals("b", ValueRelay.get("getNewInstanceC_W", ""));
+		
+		// Can't test for the result here, as the relaying and adopting of the values are implementation specific.
 	}
 	
 	/**
@@ -81,6 +132,17 @@ class Tup4strRTest
 		public String getW()
 		{
 			return this.w;
+		}
+		
+		@Override
+		public TestTup getNewInstance(String x, String y, String z, String w)
+		{
+			ValueRelay.relayCall("getNewInstanceC");
+			ValueRelay.relay("getNewInstanceC_X", x);
+			ValueRelay.relay("getNewInstanceC_Y", y);
+			ValueRelay.relay("getNewInstanceC_Z", z);
+			ValueRelay.relay("getNewInstanceC_W", w);
+			return new TestTup(x, y, z, w);
 		}
 	}
 }

--- a/barghos-core/src/test/java/org/barghos/core/test/tuple2/PTup2bTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/tuple2/PTup2bTest.java
@@ -140,4 +140,20 @@ class PTup2bTest
 		assertTrue(t.equals(new Tup2b((byte)1, (byte)2)));
 		assertTrue(t.equals(PTup2b.gen((byte)1, (byte)2)));	
 	}
+	
+	/**
+	 * This test ensures, that the function {@link PTup2b#getNewInstance(byte, byte)}
+	 * returns a new instance of {@link PTup2b} with the given values.
+	 */
+	@Test
+	void getNewInstanceTest()
+	{
+		PTup2b t = PTup2b.gen((byte)1, (byte)1);
+
+		PTup2b result = t.getNewInstance((byte)2, (byte)3);
+		
+		assertNotSame(t, result);
+		assertEquals((byte)2, result.getX());
+		assertEquals((byte)3, result.getY());
+	}
 }

--- a/barghos-core/src/test/java/org/barghos/core/test/tuple2/PTup2bigdTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/tuple2/PTup2bigdTest.java
@@ -142,4 +142,20 @@ class PTup2bigdTest
 		assertTrue(t.equals(new Tup2bigd(BigDecimal.valueOf(1.1), BigDecimal.valueOf(2.2))));
 		assertTrue(t.equals(PTup2bigd.gen(BigDecimal.valueOf(1.1), BigDecimal.valueOf(2.2))));	
 	}
+	
+	/**
+	 * This test ensures, that the function {@link PTup2bigd#getNewInstance(BigDecimal, BigDecimal)}
+	 * returns a new instance of {@link PTup2bigd} with the given values.
+	 */
+	@Test
+	void getNewInstanceTest()
+	{
+		PTup2bigd t = PTup2bigd.gen(BigDecimal.valueOf(1.0), BigDecimal.valueOf(2.0));
+
+		PTup2bigd result = t.getNewInstance(BigDecimal.valueOf(3.0), BigDecimal.valueOf(4.0));
+		
+		assertNotSame(t, result);
+		assertEquals(BigDecimal.valueOf(3.0), result.getX());
+		assertEquals(BigDecimal.valueOf(4.0), result.getY());
+	}
 }

--- a/barghos-core/src/test/java/org/barghos/core/test/tuple2/PTup2bigiTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/tuple2/PTup2bigiTest.java
@@ -142,4 +142,20 @@ class PTup2bigiTest
 		assertTrue(t.equals(new Tup2bigi(BigInteger.valueOf(1), BigInteger.valueOf(2))));
 		assertTrue(t.equals(PTup2bigi.gen(BigInteger.valueOf(1), BigInteger.valueOf(2))));	
 	}
+	
+	/**
+	 * This test ensures, that the function {@link PTup2bigi#getNewInstance(BigInteger, BigInteger)}
+	 * returns a new instance of {@link PTup2bigi} with the given values.
+	 */
+	@Test
+	void getNewInstanceTest()
+	{
+		PTup2bigi t = PTup2bigi.gen(BigInteger.valueOf(1), BigInteger.valueOf(2));
+
+		PTup2bigi result = t.getNewInstance(BigInteger.valueOf(3), BigInteger.valueOf(4));
+		
+		assertNotSame(t, result);
+		assertEquals(BigInteger.valueOf(3), result.getX());
+		assertEquals(BigInteger.valueOf(4), result.getY());
+	}
 }

--- a/barghos-core/src/test/java/org/barghos/core/test/tuple2/PTup2boTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/tuple2/PTup2boTest.java
@@ -49,7 +49,6 @@ package org.barghos.core.test.tuple2;
 import static org.junit.jupiter.api.Assertions.*;
 
 import org.junit.jupiter.api.Test;
-
 import org.barghos.core.tuple2.PTup2bo;
 import org.barghos.core.tuple2.Tup2bo;
 
@@ -139,5 +138,21 @@ class PTup2boTest
 		
 		assertTrue(t.equals(new Tup2bo(false, true)));
 		assertTrue(t.equals(PTup2bo.gen(false, true)));	
+	}
+	
+	/**
+	 * This test ensures, that the function {@link PTup2bo#getNewInstance(boolean, boolean)}
+	 * returns a new instance of {@link PTup2bo} with the given values.
+	 */
+	@Test
+	void getNewInstanceTest()
+	{
+		PTup2bo t = PTup2bo.gen(false, true);
+
+		PTup2bo result = t.getNewInstance(true, false);
+		
+		assertNotSame(t, result);
+		assertEquals(true, result.getX());
+		assertEquals(false, result.getY());
 	}
 }

--- a/barghos-core/src/test/java/org/barghos/core/test/tuple2/PTup2cTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/tuple2/PTup2cTest.java
@@ -140,4 +140,20 @@ class PTup2cTest
 		assertTrue(t.equals(new Tup2c('a', 'b')));
 		assertTrue(t.equals(PTup2c.gen('a', 'b')));	
 	}
+	
+	/**
+	 * This test ensures, that the function {@link PTup2c#getNewInstance(char, char)}
+	 * returns a new instance of {@link PTup2c} with the given values.
+	 */
+	@Test
+	void getNewInstanceTest()
+	{
+		PTup2c t = PTup2c.gen('a', 'a');
+
+		PTup2c result = t.getNewInstance('b', 'c');
+		
+		assertNotSame(t, result);
+		assertEquals('b', result.getX());
+		assertEquals('c', result.getY());
+	}
 }

--- a/barghos-core/src/test/java/org/barghos/core/test/tuple2/PTup2dTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/tuple2/PTup2dTest.java
@@ -140,4 +140,20 @@ class PTup2dTest
 		assertTrue(t.equals(new Tup2d(1.1, 2.2)));
 		assertTrue(t.equals(PTup2d.gen(1.1, 2.2)));	
 	}
+	
+	/**
+	 * This test ensures, that the function {@link PTup2d#getNewInstance(double, double)}
+	 * returns a new instance of {@link PTup2d} with the given values.
+	 */
+	@Test
+	void getNewInstanceTest()
+	{
+		PTup2d t = PTup2d.gen(1.0, 1.0);
+
+		PTup2d result = t.getNewInstance(2.0, 3.0);
+		
+		assertNotSame(t, result);
+		assertEquals(2.0, result.getX());
+		assertEquals(3.0, result.getY());
+	}
 }

--- a/barghos-core/src/test/java/org/barghos/core/test/tuple2/PTup2fTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/tuple2/PTup2fTest.java
@@ -140,4 +140,20 @@ class PTup2fTest
 		assertTrue(t.equals(new Tup2f(1.1f, 2.2f)));
 		assertTrue(t.equals(PTup2f.gen(1.1f, 2.2f)));	
 	}
+	
+	/**
+	 * This test ensures, that the function {@link PTup2f#getNewInstance(float, float)}
+	 * returns a new instance of {@link PTup2f} with the given values.
+	 */
+	@Test
+	void getNewInstanceTest()
+	{
+		PTup2f t = PTup2f.gen(1.0f, 1.0f);
+
+		PTup2f result = t.getNewInstance(2.0f, 3.0f);
+		
+		assertNotSame(t, result);
+		assertEquals(2.0f, result.getX());
+		assertEquals(3.0f, result.getY());
+	}
 }

--- a/barghos-core/src/test/java/org/barghos/core/test/tuple2/PTup2iTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/tuple2/PTup2iTest.java
@@ -140,4 +140,20 @@ class PTup2iTest
 		assertTrue(t.equals(new Tup2i(1, 2)));
 		assertTrue(t.equals(PTup2i.gen(1, 2)));	
 	}
+	
+	/**
+	 * This test ensures, that the function {@link PTup2i#getNewInstance(int, int)}
+	 * returns a new instance of {@link PTup2i} with the given values.
+	 */
+	@Test
+	void getNewInstanceTest()
+	{
+		PTup2i t = PTup2i.gen(1, 1);
+
+		PTup2i result = t.getNewInstance(2, 3);
+		
+		assertNotSame(t, result);
+		assertEquals(2, result.getX());
+		assertEquals(3, result.getY());
+	}
 }

--- a/barghos-core/src/test/java/org/barghos/core/test/tuple2/PTup2lTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/tuple2/PTup2lTest.java
@@ -140,4 +140,20 @@ class PTup2lTest
 		assertTrue(t.equals(new Tup2l(1l, 2l)));
 		assertTrue(t.equals(PTup2l.gen(1l, 2l)));	
 	}
+	
+	/**
+	 * This test ensures, that the function {@link PTup2l#getNewInstance(long, long)}
+	 * returns a new instance of {@link PTup2l} with the given values.
+	 */
+	@Test
+	void getNewInstanceTest()
+	{
+		PTup2l t = PTup2l.gen(1l, 1l);
+
+		PTup2l result = t.getNewInstance(2l, 3l);
+		
+		assertNotSame(t, result);
+		assertEquals(2l, result.getX());
+		assertEquals(3l, result.getY());
+	}
 }

--- a/barghos-core/src/test/java/org/barghos/core/test/tuple2/PTup2oTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/tuple2/PTup2oTest.java
@@ -125,4 +125,20 @@ class PTup2oTest
 		assertTrue(t.equals(new Tup2o<>(1, "arg2")));
 		assertTrue(t.equals(PTup2o.gen(1, "arg2")));	
 	}
+	
+	/**
+	 * This test ensures, that the function {@link PTup2o#getNewInstance(Object, Object)}
+	 * returns a new instance of {@link PTup2o} with the given values.
+	 */
+	@Test
+	void getNewInstanceTest()
+	{
+		PTup2o<Long,Long> t = PTup2o.gen(1l, 1l);
+
+		PTup2o<Long,Long> result = t.getNewInstance(2l, 3l);
+		
+		assertNotSame(t, result);
+		assertEquals(2l, (long)result.getX());
+		assertEquals(3l, (long)result.getY());
+	}
 }

--- a/barghos-core/src/test/java/org/barghos/core/test/tuple2/PTup2objTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/tuple2/PTup2objTest.java
@@ -140,4 +140,20 @@ class PTup2objTest
 		assertTrue(t.equals(new Tup2obj(1, "arg2")));
 		assertTrue(t.equals(PTup2obj.gen(1, "arg2")));	
 	}
+	
+	/**
+	 * This test ensures, that the function {@link PTup2obj#getNewInstance(Object, Object)}
+	 * returns a new instance of {@link PTup2obj} with the given values.
+	 */
+	@Test
+	void getNewInstanceTest()
+	{
+		PTup2obj t = PTup2obj.gen(1l, "a");
+
+		PTup2obj result = t.getNewInstance(2.0f, 'b');
+		
+		assertNotSame(t, result);
+		assertEquals(2.0f, result.getX());
+		assertEquals('b', result.getY());
+	}
 }

--- a/barghos-core/src/test/java/org/barghos/core/test/tuple2/PTup2sTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/tuple2/PTup2sTest.java
@@ -140,4 +140,20 @@ class PTup2sTest
 		assertTrue(t.equals(new Tup2s((short)1, (short)2)));
 		assertTrue(t.equals(PTup2s.gen((short)1, (short)2)));	
 	}
+	
+	/**
+	 * This test ensures, that the function {@link PTup2s#getNewInstance(short, short)}
+	 * returns a new instance of {@link PTup2s} with the given values.
+	 */
+	@Test
+	void getNewInstanceTest()
+	{
+		PTup2s t = PTup2s.gen((short)1, (short)1);
+
+		PTup2s result = t.getNewInstance((short)2, (short)3);
+		
+		assertNotSame(t, result);
+		assertEquals((short)2, result.getX());
+		assertEquals((short)3, result.getY());
+	}
 }

--- a/barghos-core/src/test/java/org/barghos/core/test/tuple2/PTup2strTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/tuple2/PTup2strTest.java
@@ -140,4 +140,20 @@ class PTup2strTest
 		assertTrue(t.equals(new Tup2str("arg1", "arg2")));
 		assertTrue(t.equals(PTup2str.gen("arg1", "arg2")));	
 	}
+	
+	/**
+	 * This test ensures, that the function {@link PTup2str#getNewInstance(String, String)}
+	 * returns a new instance of {@link PTup2str} with the given values.
+	 */
+	@Test
+	void getNewInstanceTest()
+	{
+		PTup2str t = PTup2str.gen("a", "a");
+
+		PTup2str result = t.getNewInstance("b", "c");
+		
+		assertNotSame(t, result);
+		assertEquals("b", result.getX());
+		assertEquals("c", result.getY());
+	}
 }

--- a/barghos-core/src/test/java/org/barghos/core/test/tuple2/Tup2bTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/tuple2/Tup2bTest.java
@@ -257,4 +257,20 @@ class Tup2bTest
 		assertTrue(t.equals(new Tup2b((byte)1, (byte)2)));
 		assertTrue(t.equals(PTup2b.gen((byte)1, (byte)2)));
 	}
+	
+	/**
+	 * This test ensures, that the function {@link Tup2b#getNewInstance(byte, byte)}
+	 * returns a new instance of {@link Tup2b} with the given values.
+	 */
+	@Test
+	void getNewInstanceTest()
+	{
+		Tup2b t = new Tup2b((byte)1, (byte)1);
+
+		Tup2b result = t.getNewInstance((byte)2, (byte)3);
+		
+		assertNotSame(t, result);
+		assertEquals((byte)2, result.getX());
+		assertEquals((byte)3, result.getY());
+	}
 }

--- a/barghos-core/src/test/java/org/barghos/core/test/tuple2/Tup2bigdTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/tuple2/Tup2bigdTest.java
@@ -259,4 +259,20 @@ class Tup2bigdTest
 		assertTrue(t.equals(new Tup2bigd(BigDecimal.valueOf(1.1), BigDecimal.valueOf(2.2))));
 		assertTrue(t.equals(PTup2bigd.gen(BigDecimal.valueOf(1.1), BigDecimal.valueOf(2.2))));
 	}
+	
+	/**
+	 * This test ensures, that the function {@link Tup2bigd#getNewInstance(BigDecimal, BigDecimal)}
+	 * returns a new instance of {@link Tup2bigd} with the given values.
+	 */
+	@Test
+	void getNewInstanceTest()
+	{
+		Tup2bigd t = new Tup2bigd(BigDecimal.valueOf(1.0), BigDecimal.valueOf(2.0));
+
+		Tup2bigd result = t.getNewInstance(BigDecimal.valueOf(3.0), BigDecimal.valueOf(4.0));
+		
+		assertNotSame(t, result);
+		assertEquals(BigDecimal.valueOf(3.0), result.getX());
+		assertEquals(BigDecimal.valueOf(4.0), result.getY());
+	}
 }

--- a/barghos-core/src/test/java/org/barghos/core/test/tuple2/Tup2bigiTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/tuple2/Tup2bigiTest.java
@@ -259,4 +259,20 @@ class Tup2bigiTest
 		assertTrue(t.equals(new Tup2bigi(BigInteger.valueOf(1), BigInteger.valueOf(2))));
 		assertTrue(t.equals(PTup2bigi.gen(BigInteger.valueOf(1), BigInteger.valueOf(2))));
 	}
+	
+	/**
+	 * This test ensures, that the function {@link Tup2bigi#getNewInstance(BigInteger, BigInteger)}
+	 * returns a new instance of {@link Tup2bigi} with the given values.
+	 */
+	@Test
+	void getNewInstanceTest()
+	{
+		Tup2bigi t = new Tup2bigi(BigInteger.valueOf(1), BigInteger.valueOf(2));
+
+		Tup2bigi result = t.getNewInstance(BigInteger.valueOf(3), BigInteger.valueOf(4));
+		
+		assertNotSame(t, result);
+		assertEquals(BigInteger.valueOf(3), result.getX());
+		assertEquals(BigInteger.valueOf(4), result.getY());
+	}
 }

--- a/barghos-core/src/test/java/org/barghos/core/test/tuple2/Tup2boTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/tuple2/Tup2boTest.java
@@ -257,4 +257,20 @@ class Tup2boTest
 		assertTrue(t.equals(new Tup2bo(false, true)));
 		assertTrue(t.equals(PTup2bo.gen(false, true)));
 	}
+	
+	/**
+	 * This test ensures, that the function {@link Tup2bo#getNewInstance(boolean, boolean)}
+	 * returns a new instance of {@link Tup2bo} with the given values.
+	 */
+	@Test
+	void getNewInstanceTest()
+	{
+		Tup2bo t = new Tup2bo(false, true);
+
+		Tup2bo result = t.getNewInstance(true, false);
+		
+		assertNotSame(t, result);
+		assertEquals(true, result.getX());
+		assertEquals(false, result.getY());
+	}
 }

--- a/barghos-core/src/test/java/org/barghos/core/test/tuple2/Tup2cTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/tuple2/Tup2cTest.java
@@ -257,4 +257,20 @@ class Tup2cTest
 		assertTrue(t.equals(new Tup2c('a', 'b')));
 		assertTrue(t.equals(PTup2c.gen('a', 'b')));
 	}
+	
+	/**
+	 * This test ensures, that the function {@link Tup2c#getNewInstance(char, char)}
+	 * returns a new instance of {@link Tup2c} with the given values.
+	 */
+	@Test
+	void getNewInstanceTest()
+	{
+		Tup2c t = new Tup2c('a', 'a');
+
+		Tup2c result = t.getNewInstance('b', 'c');
+		
+		assertNotSame(t, result);
+		assertEquals('b', result.getX());
+		assertEquals('c', result.getY());
+	}
 }

--- a/barghos-core/src/test/java/org/barghos/core/test/tuple2/Tup2dTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/tuple2/Tup2dTest.java
@@ -257,4 +257,20 @@ class Tup2dTest
 		assertTrue(t.equals(new Tup2d(1.2, 3.4)));
 		assertTrue(t.equals(PTup2d.gen(1.2, 3.4)));
 	}
+	
+	/**
+	 * This test ensures, that the function {@link Tup2d#getNewInstance(double, double)}
+	 * returns a new instance of {@link Tup2d} with the given values.
+	 */
+	@Test
+	void getNewInstanceTest()
+	{
+		Tup2d t = new Tup2d(1.0, 1.0);
+
+		Tup2d result = t.getNewInstance(2.0, 3.0);
+		
+		assertNotSame(t, result);
+		assertEquals(2.0, result.getX());
+		assertEquals(3.0, result.getY());
+	}
 }

--- a/barghos-core/src/test/java/org/barghos/core/test/tuple2/Tup2fTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/tuple2/Tup2fTest.java
@@ -257,4 +257,20 @@ class Tup2fTest
 		assertTrue(t.equals(new Tup2f(1.2f, 3.4f)));
 		assertTrue(t.equals(PTup2f.gen(1.2f, 3.4f)));
 	}
+	
+	/**
+	 * This test ensures, that the function {@link Tup2f#getNewInstance(float, float)}
+	 * returns a new instance of {@link Tup2f} with the given values.
+	 */
+	@Test
+	void getNewInstanceTest()
+	{
+		Tup2f t = new Tup2f(1.0f, 1.0f);
+
+		Tup2f result = t.getNewInstance(2.0f, 3.0f);
+		
+		assertNotSame(t, result);
+		assertEquals(2.0f, result.getX());
+		assertEquals(3.0f, result.getY());
+	}
 }

--- a/barghos-core/src/test/java/org/barghos/core/test/tuple2/Tup2iTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/tuple2/Tup2iTest.java
@@ -257,4 +257,20 @@ class Tup2iTest
 		assertTrue(t.equals(new Tup2i(1, 2)));
 		assertTrue(t.equals(PTup2i.gen(1, 2)));
 	}
+	
+	/**
+	 * This test ensures, that the function {@link Tup2i#getNewInstance(int, int)}
+	 * returns a new instance of {@link Tup2i} with the given values.
+	 */
+	@Test
+	void getNewInstanceTest()
+	{
+		Tup2i t = new Tup2i(1, 1);
+
+		Tup2i result = t.getNewInstance(2, 3);
+		
+		assertNotSame(t, result);
+		assertEquals(2, result.getX());
+		assertEquals(3, result.getY());
+	}
 }

--- a/barghos-core/src/test/java/org/barghos/core/test/tuple2/Tup2lTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/tuple2/Tup2lTest.java
@@ -257,4 +257,20 @@ class Tup2lTest
 		assertTrue(t.equals(new Tup2l(1l, 2l)));
 		assertTrue(t.equals(PTup2l.gen(1l, 2l)));
 	}
+	
+	/**
+	 * This test ensures, that the function {@link Tup2l#getNewInstance(long, long)}
+	 * returns a new instance of {@link Tup2l} with the given values.
+	 */
+	@Test
+	void getNewInstanceTest()
+	{
+		Tup2l t = new Tup2l(1l, 1l);
+
+		Tup2l result = t.getNewInstance(2l, 3l);
+		
+		assertNotSame(t, result);
+		assertEquals(2l, result.getX());
+		assertEquals(3l, result.getY());
+	}
 }

--- a/barghos-core/src/test/java/org/barghos/core/test/tuple2/Tup2oTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/tuple2/Tup2oTest.java
@@ -226,4 +226,20 @@ class Tup2oTest
 		assertTrue(t.equals(new Tup2o<>(1, "arg2")));
 		assertTrue(t.equals(PTup2o.gen(1, "arg2")));
 	}
+	
+	/**
+	 * This test ensures, that the function {@link Tup2o#getNewInstance(Object, Object)}
+	 * returns a new instance of {@link Tup2o} with the given values.
+	 */
+	@Test
+	void getNewInstanceTest()
+	{
+		Tup2o<Long,Long> t = new Tup2o<>(1l, 1l);
+
+		Tup2o<Long,Long> result = t.getNewInstance(2l, 3l);
+		
+		assertNotSame(t, result);
+		assertEquals(2l, (long)result.getX());
+		assertEquals(3l, (long)result.getY());
+	}
 }

--- a/barghos-core/src/test/java/org/barghos/core/test/tuple2/Tup2objTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/tuple2/Tup2objTest.java
@@ -257,4 +257,20 @@ class Tup2objTest
 		assertTrue(t.equals(new Tup2obj(1, "arg2")));
 		assertTrue(t.equals(PTup2obj.gen(1, "arg2")));
 	}
+	
+	/**
+	 * This test ensures, that the function {@link Tup2obj#getNewInstance(Object, Object)}
+	 * returns a new instance of {@link Tup2obj} with the given values.
+	 */
+	@Test
+	void getNewInstanceTest()
+	{
+		Tup2obj t = new Tup2obj(1l, "a");
+
+		Tup2obj result = t.getNewInstance(2.0f, 'b');
+		
+		assertNotSame(t, result);
+		assertEquals(2.0f, result.getX());
+		assertEquals('b', result.getY());
+	}
 }

--- a/barghos-core/src/test/java/org/barghos/core/test/tuple2/Tup2sTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/tuple2/Tup2sTest.java
@@ -257,4 +257,20 @@ class Tup2sTest
 		assertTrue(t.equals(new Tup2s((short)1, (short)2)));
 		assertTrue(t.equals(PTup2s.gen((short)1, (short)2)));
 	}
+	
+	/**
+	 * This test ensures, that the function {@link Tup2s#getNewInstance(short, short)}
+	 * returns a new instance of {@link Tup2s} with the given values.
+	 */
+	@Test
+	void getNewInstanceTest()
+	{
+		Tup2s t = new Tup2s((short)1, (short)1);
+
+		Tup2s result = t.getNewInstance((short)2, (short)3);
+		
+		assertNotSame(t, result);
+		assertEquals((short)2, result.getX());
+		assertEquals((short)3, result.getY());
+	}
 }

--- a/barghos-core/src/test/java/org/barghos/core/test/tuple2/Tup2strTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/tuple2/Tup2strTest.java
@@ -257,4 +257,20 @@ class Tup2strTest
 		assertTrue(t.equals(new Tup2str("arg1", "arg2")));
 		assertTrue(t.equals(PTup2str.gen("arg1", "arg2")));
 	}
+	
+	/**
+	 * This test ensures, that the function {@link Tup2str#getNewInstance(String, String)}
+	 * returns a new instance of {@link Tup2str} with the given values.
+	 */
+	@Test
+	void getNewInstanceTest()
+	{
+		Tup2str t = new Tup2str("a", "a");
+
+		Tup2str result = t.getNewInstance("b", "c");
+		
+		assertNotSame(t, result);
+		assertEquals("b", result.getX());
+		assertEquals("c", result.getY());
+	}
 }

--- a/barghos-core/src/test/java/org/barghos/core/test/tuple3/PTup3bTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/tuple3/PTup3bTest.java
@@ -142,4 +142,21 @@ class PTup3bTest
 		assertTrue(t.equals(new Tup3b((byte)1, (byte)2, (byte)3)));
 		assertTrue(t.equals(PTup3b.gen((byte)1, (byte)2, (byte)3)));	
 	}
+	
+	/**
+	 * This test ensures, that the function {@link PTup3b#getNewInstance(byte, byte, byte)}
+	 * returns a new instance of {@link PTup3b} with the given values.
+	 */
+	@Test
+	void getNewInstanceTest()
+	{
+		PTup3b t = PTup3b.gen((byte)1, (byte)1, (byte)1);
+
+		PTup3b result = t.getNewInstance((byte)2, (byte)3, (byte)4);
+		
+		assertNotSame(t, result);
+		assertEquals((byte)2, result.getX());
+		assertEquals((byte)3, result.getY());
+		assertEquals((byte)4, result.getZ());
+	}
 }

--- a/barghos-core/src/test/java/org/barghos/core/test/tuple3/PTup3bigdTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/tuple3/PTup3bigdTest.java
@@ -144,4 +144,21 @@ class PTup3bigdTest
 		assertTrue(t.equals(new Tup3bigd(BigDecimal.valueOf(1.1), BigDecimal.valueOf(2.2), BigDecimal.valueOf(3.3))));
 		assertTrue(t.equals(PTup3bigd.gen(BigDecimal.valueOf(1.1), BigDecimal.valueOf(2.2), BigDecimal.valueOf(3.3))));	
 	}
+	
+	/**
+	 * This test ensures, that the function {@link PTup3bigd#getNewInstance(BigDecimal, BigDecimal, BigDecimal)}
+	 * returns a new instance of {@link PTup3bigd} with the given values.
+	 */
+	@Test
+	void getNewInstanceTest()
+	{
+		PTup3bigd t = PTup3bigd.gen(BigDecimal.valueOf(1.0), BigDecimal.valueOf(1.0), BigDecimal.valueOf(1.0));
+
+		PTup3bigd result = t.getNewInstance(BigDecimal.valueOf(2.0), BigDecimal.valueOf(3.0), BigDecimal.valueOf(4.0));
+		
+		assertNotSame(t, result);
+		assertEquals(BigDecimal.valueOf(2.0), result.getX());
+		assertEquals(BigDecimal.valueOf(3.0), result.getY());
+		assertEquals(BigDecimal.valueOf(4.0), result.getZ());
+	}
 }

--- a/barghos-core/src/test/java/org/barghos/core/test/tuple3/PTup3bigiTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/tuple3/PTup3bigiTest.java
@@ -144,4 +144,21 @@ class PTup3bigiTest
 		assertTrue(t.equals(new Tup3bigi(BigInteger.valueOf(1), BigInteger.valueOf(2), BigInteger.valueOf(3))));
 		assertTrue(t.equals(PTup3bigi.gen(BigInteger.valueOf(1), BigInteger.valueOf(2), BigInteger.valueOf(3))));	
 	}
+	
+	/**
+	 * This test ensures, that the function {@link PTup3bigi#getNewInstance(BigInteger, BigInteger, BigInteger)}
+	 * returns a new instance of {@link PTup3bigi} with the given values.
+	 */
+	@Test
+	void getNewInstanceTest()
+	{
+		PTup3bigi t = PTup3bigi.gen(BigInteger.valueOf(1), BigInteger.valueOf(1), BigInteger.valueOf(1));
+
+		PTup3bigi result = t.getNewInstance(BigInteger.valueOf(2), BigInteger.valueOf(3), BigInteger.valueOf(4));
+		
+		assertNotSame(t, result);
+		assertEquals(BigInteger.valueOf(2), result.getX());
+		assertEquals(BigInteger.valueOf(3), result.getY());
+		assertEquals(BigInteger.valueOf(4), result.getZ());
+	}
 }

--- a/barghos-core/src/test/java/org/barghos/core/test/tuple3/PTup3boTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/tuple3/PTup3boTest.java
@@ -142,4 +142,21 @@ class PTup3boTest
 		assertTrue(t.equals(new Tup3bo(false, true, false)));
 		assertTrue(t.equals(PTup3bo.gen(false, true, false)));	
 	}
+	
+	/**
+	 * This test ensures, that the function {@link PTup3bo#getNewInstance(boolean, boolean, boolean)}
+	 * returns a new instance of {@link PTup3bo} with the given values.
+	 */
+	@Test
+	void getNewInstanceTest()
+	{
+		PTup3bo t = PTup3bo.gen(false, true, false);
+
+		PTup3bo result = t.getNewInstance(true, false, true);
+		
+		assertNotSame(t, result);
+		assertEquals(true, result.getX());
+		assertEquals(false, result.getY());
+		assertEquals(true, result.getZ());
+	}
 }

--- a/barghos-core/src/test/java/org/barghos/core/test/tuple3/PTup3cTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/tuple3/PTup3cTest.java
@@ -142,4 +142,21 @@ class PTup3cTest
 		assertTrue(t.equals(new Tup3c('a', 'b', 'c')));
 		assertTrue(t.equals(PTup3c.gen('a', 'b', 'c')));	
 	}
+	
+	/**
+	 * This test ensures, that the function {@link PTup3c#getNewInstance(char, char, char)}
+	 * returns a new instance of {@link PTup3c} with the given values.
+	 */
+	@Test
+	void getNewInstanceTest()
+	{
+		PTup3c t = PTup3c.gen('a', 'a', 'a');
+
+		PTup3c result = t.getNewInstance('b', 'c', 'd');
+		
+		assertNotSame(t, result);
+		assertEquals('b', result.getX());
+		assertEquals('c', result.getY());
+		assertEquals('d', result.getZ());
+	}
 }

--- a/barghos-core/src/test/java/org/barghos/core/test/tuple3/PTup3dTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/tuple3/PTup3dTest.java
@@ -142,4 +142,21 @@ class PTup3dTest
 		assertTrue(t.equals(new Tup3d(1.1, 2.2, 3.3)));
 		assertTrue(t.equals(PTup3d.gen(1.1, 2.2, 3.3)));	
 	}
+	
+	/**
+	 * This test ensures, that the function {@link PTup3d#getNewInstance(double, double, double)}
+	 * returns a new instance of {@link PTup3d} with the given values.
+	 */
+	@Test
+	void getNewInstanceTest()
+	{
+		PTup3d t = PTup3d.gen(1.0, 1.0, 1.0);
+
+		PTup3d result = t.getNewInstance(2.0, 3.0, 4.0);
+		
+		assertNotSame(t, result);
+		assertEquals(2.0, result.getX());
+		assertEquals(3.0, result.getY());
+		assertEquals(4.0, result.getZ());
+	}
 }

--- a/barghos-core/src/test/java/org/barghos/core/test/tuple3/PTup3fTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/tuple3/PTup3fTest.java
@@ -142,4 +142,21 @@ class PTup3fTest
 		assertTrue(t.equals(new Tup3f(1.1f, 2.2f, 3.3f)));
 		assertTrue(t.equals(PTup3f.gen(1.1f, 2.2f, 3.3f)));	
 	}
+	
+	/**
+	 * This test ensures, that the function {@link PTup3f#getNewInstance(float, float, float)}
+	 * returns a new instance of {@link PTup3f} with the given values.
+	 */
+	@Test
+	void getNewInstanceTest()
+	{
+		PTup3f t = PTup3f.gen(1.0f, 1.0f, 1.0f);
+
+		PTup3f result = t.getNewInstance(2.0f, 3.0f, 4.0f);
+		
+		assertNotSame(t, result);
+		assertEquals(2.0f, result.getX());
+		assertEquals(3.0f, result.getY());
+		assertEquals(4.0f, result.getZ());
+	}
 }

--- a/barghos-core/src/test/java/org/barghos/core/test/tuple3/PTup3iTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/tuple3/PTup3iTest.java
@@ -142,4 +142,21 @@ class PTup3iTest
 		assertTrue(t.equals(new Tup3i(1, 2, 3)));
 		assertTrue(t.equals(PTup3i.gen(1, 2, 3)));	
 	}
+	
+	/**
+	 * This test ensures, that the function {@link PTup3i#getNewInstance(int, int, int)}
+	 * returns a new instance of {@link PTup3i} with the given values.
+	 */
+	@Test
+	void getNewInstanceTest()
+	{
+		PTup3i t = PTup3i.gen(1, 1, 1);
+
+		PTup3i result = t.getNewInstance(2, 3, 4);
+		
+		assertNotSame(t, result);
+		assertEquals(2, result.getX());
+		assertEquals(3, result.getY());
+		assertEquals(4, result.getZ());
+	}
 }

--- a/barghos-core/src/test/java/org/barghos/core/test/tuple3/PTup3lTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/tuple3/PTup3lTest.java
@@ -142,4 +142,21 @@ class PTup3lTest
 		assertTrue(t.equals(new Tup3l(1l, 2l, 3l)));
 		assertTrue(t.equals(PTup3l.gen(1l, 2l, 3l)));	
 	}
+	
+	/**
+	 * This test ensures, that the function {@link PTup3l#getNewInstance(long, long, long)}
+	 * returns a new instance of {@link PTup3l} with the given values.
+	 */
+	@Test
+	void getNewInstanceTest()
+	{
+		PTup3l t = PTup3l.gen(1l, 1l, 1l);
+		
+		PTup3l result = t.getNewInstance(2l, 3l, 4l);
+		
+		assertNotSame(t, result);
+		assertEquals(2l, result.getX());
+		assertEquals(3l, result.getY());
+		assertEquals(4l, result.getZ());
+	}
 }

--- a/barghos-core/src/test/java/org/barghos/core/test/tuple3/PTup3oTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/tuple3/PTup3oTest.java
@@ -126,4 +126,21 @@ class PTup3oTest
 		assertTrue(t.equals(new Tup3o<>(1, "arg2", 3.3)));
 		assertTrue(t.equals(PTup3o.gen(1, "arg2", 3.3)));	
 	}
+	
+	/**
+	 * This test ensures, that the function {@link PTup3o#getNewInstance(Object, Object, Object)}
+	 * returns a new instance of {@link PTup3o} with the given values.
+	 */
+	@Test
+	void getNewInstanceTest()
+	{
+		PTup3o<Long,Long,Long> t = PTup3o.gen(1l, 1l, 1l);
+		
+		PTup3o<Long,Long,Long> result = t.getNewInstance(2l, 3l, 4l);
+		
+		assertNotSame(t, result);
+		assertEquals(2l, (long)result.getX());
+		assertEquals(3l, (long)result.getY());
+		assertEquals(4l, (long)result.getZ());
+	}
 }

--- a/barghos-core/src/test/java/org/barghos/core/test/tuple3/PTup3objTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/tuple3/PTup3objTest.java
@@ -142,4 +142,21 @@ class PTup3objTest
 		assertTrue(t.equals(new Tup3obj(1, "arg2", 3.3)));
 		assertTrue(t.equals(PTup3obj.gen(1, "arg2", 3.3)));	
 	}
+	
+	/**
+	 * This test ensures, that the function {@link PTup3obj#getNewInstance(Object, Object, Object)}
+	 * returns a new instance of {@link PTup3obj} with the given values.
+	 */
+	@Test
+	void getNewInstanceTest()
+	{
+		PTup3obj t = PTup3obj.gen(1l, 1l, 1l);
+		
+		PTup3obj result = t.getNewInstance(2l, 3l, 4l);
+		
+		assertNotSame(t, result);
+		assertEquals(2l, result.getX());
+		assertEquals(3l, result.getY());
+		assertEquals(4l, result.getZ());
+	}
 }

--- a/barghos-core/src/test/java/org/barghos/core/test/tuple3/PTup3sTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/tuple3/PTup3sTest.java
@@ -142,4 +142,21 @@ class PTup3sTest
 		assertTrue(t.equals(new Tup3s((short)1, (short)2, (short)3)));
 		assertTrue(t.equals(PTup3s.gen((short)1, (short)2, (short)3)));	
 	}
+	
+	/**
+	 * This test ensures, that the function {@link PTup3s#getNewInstance(short, short, short)}
+	 * returns a new instance of {@link PTup3s} with the given values.
+	 */
+	@Test
+	void getNewInstanceTest()
+	{
+		PTup3s t = PTup3s.gen((short)1, (short)1, (short)1);
+		
+		PTup3s result = t.getNewInstance((short)2, (short)3, (short)4);
+		
+		assertNotSame(t, result);
+		assertEquals((short)2, result.getX());
+		assertEquals((short)3, result.getY());
+		assertEquals((short)4, result.getZ());
+	}
 }

--- a/barghos-core/src/test/java/org/barghos/core/test/tuple3/PTup3strTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/tuple3/PTup3strTest.java
@@ -142,4 +142,21 @@ class PTup3strTest
 		assertTrue(t.equals(new Tup3str("arg1", "arg2", "arg3")));
 		assertTrue(t.equals(PTup3str.gen("arg1", "arg2", "arg3")));	
 	}
+	
+	/**
+	 * This test ensures, that the function {@link PTup3str#getNewInstance(String, String, String)}
+	 * returns a new instance of {@link PTup3str} with the given values.
+	 */
+	@Test
+	void getNewInstanceTest()
+	{
+		PTup3str t = PTup3str.gen("a", "a", "a");
+
+		PTup3str result = t.getNewInstance("b", "c", "d");
+		
+		assertNotSame(t, result);
+		assertEquals("b", result.getX());
+		assertEquals("c", result.getY());
+		assertEquals("d", result.getZ());
+	}
 }

--- a/barghos-core/src/test/java/org/barghos/core/test/tuple3/Tup3bTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/tuple3/Tup3bTest.java
@@ -297,4 +297,21 @@ class Tup3bTest
 		assertTrue(t.equals(new Tup3b((byte)1, (byte)2, (byte)3)));
 		assertTrue(t.equals(PTup3b.gen((byte)1, (byte)2, (byte)3)));
 	}
+	
+	/**
+	 * This test ensures, that the function {@link Tup3b#getNewInstance(byte, byte, byte)}
+	 * returns a new instance of {@link Tup3b} with the given values.
+	 */
+	@Test
+	void getNewInstanceTest()
+	{
+		Tup3b t = new Tup3b((byte)1, (byte)1, (byte)1);
+
+		Tup3b result = t.getNewInstance((byte)2, (byte)3, (byte)4);
+		
+		assertNotSame(t, result);
+		assertEquals((byte)2, result.getX());
+		assertEquals((byte)3, result.getY());
+		assertEquals((byte)4, result.getZ());
+	}
 }

--- a/barghos-core/src/test/java/org/barghos/core/test/tuple3/Tup3bigdTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/tuple3/Tup3bigdTest.java
@@ -299,4 +299,21 @@ class Tup3bigdTest
 		assertTrue(t.equals(new Tup3bigd(BigDecimal.valueOf(1.1), BigDecimal.valueOf(2.2), BigDecimal.valueOf(3.3))));
 		assertTrue(t.equals(PTup3bigd.gen(BigDecimal.valueOf(1.1), BigDecimal.valueOf(2.2), BigDecimal.valueOf(3.3))));
 	}
+	
+	/**
+	 * This test ensures, that the function {@link Tup3bigd#getNewInstance(BigDecimal, BigDecimal, BigDecimal)}
+	 * returns a new instance of {@link Tup3bigd} with the given values.
+	 */
+	@Test
+	void getNewInstanceTest()
+	{
+		Tup3bigd t = new Tup3bigd(BigDecimal.valueOf(1.0), BigDecimal.valueOf(1.0), BigDecimal.valueOf(1.0));
+
+		Tup3bigd result = t.getNewInstance(BigDecimal.valueOf(2.0), BigDecimal.valueOf(3.0), BigDecimal.valueOf(4.0));
+		
+		assertNotSame(t, result);
+		assertEquals(BigDecimal.valueOf(2.0), result.getX());
+		assertEquals(BigDecimal.valueOf(3.0), result.getY());
+		assertEquals(BigDecimal.valueOf(4.0), result.getZ());
+	}
 }

--- a/barghos-core/src/test/java/org/barghos/core/test/tuple3/Tup3bigiTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/tuple3/Tup3bigiTest.java
@@ -299,4 +299,21 @@ class Tup3bigiTest
 		assertTrue(t.equals(new Tup3bigi(BigInteger.valueOf(1), BigInteger.valueOf(2), BigInteger.valueOf(3))));
 		assertTrue(t.equals(PTup3bigi.gen(BigInteger.valueOf(1), BigInteger.valueOf(2), BigInteger.valueOf(3))));
 	}
+	
+	/**
+	 * This test ensures, that the function {@link Tup3bigi#getNewInstance(BigInteger, BigInteger, BigInteger)}
+	 * returns a new instance of {@link Tup3bigi} with the given values.
+	 */
+	@Test
+	void getNewInstanceTest()
+	{
+		Tup3bigi t = new Tup3bigi(BigInteger.valueOf(1), BigInteger.valueOf(1), BigInteger.valueOf(1));
+
+		Tup3bigi result = t.getNewInstance(BigInteger.valueOf(2), BigInteger.valueOf(3), BigInteger.valueOf(4));
+		
+		assertNotSame(t, result);
+		assertEquals(BigInteger.valueOf(2), result.getX());
+		assertEquals(BigInteger.valueOf(3), result.getY());
+		assertEquals(BigInteger.valueOf(4), result.getZ());
+	}
 }

--- a/barghos-core/src/test/java/org/barghos/core/test/tuple3/Tup3boTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/tuple3/Tup3boTest.java
@@ -297,4 +297,21 @@ class Tup3boTest
 		assertTrue(t.equals(new Tup3bo(false, true, true)));
 		assertTrue(t.equals(PTup3bo.gen(false, true, true)));
 	}
+	
+	/**
+	 * This test ensures, that the function {@link Tup3bo#getNewInstance(boolean, boolean, boolean)}
+	 * returns a new instance of {@link Tup3bo} with the given values.
+	 */
+	@Test
+	void getNewInstanceTest()
+	{
+		Tup3bo t = new Tup3bo(false, true, false);
+
+		Tup3bo result = t.getNewInstance(true, false, true);
+		
+		assertNotSame(t, result);
+		assertEquals(true, result.getX());
+		assertEquals(false, result.getY());
+		assertEquals(true, result.getZ());
+	}
 }

--- a/barghos-core/src/test/java/org/barghos/core/test/tuple3/Tup3cTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/tuple3/Tup3cTest.java
@@ -297,4 +297,21 @@ class Tup3cTest
 		assertTrue(t.equals(new Tup3c('a', 'b', 'c')));
 		assertTrue(t.equals(PTup3c.gen('a', 'b', 'c')));
 	}
+	
+	/**
+	 * This test ensures, that the function {@link Tup3c#getNewInstance(char, char, char)}
+	 * returns a new instance of {@link Tup3c} with the given values.
+	 */
+	@Test
+	void getNewInstanceTest()
+	{
+		Tup3c t = new Tup3c('a', 'a', 'a');
+
+		Tup3c result = t.getNewInstance('b', 'c', 'd');
+		
+		assertNotSame(t, result);
+		assertEquals('b', result.getX());
+		assertEquals('c', result.getY());
+		assertEquals('d', result.getZ());
+	}
 }

--- a/barghos-core/src/test/java/org/barghos/core/test/tuple3/Tup3dTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/tuple3/Tup3dTest.java
@@ -297,4 +297,21 @@ class Tup3dTest
 		assertTrue(t.equals(new Tup3d(1.2, 3.4, 5.6)));
 		assertTrue(t.equals(PTup3d.gen(1.2, 3.4, 5.6)));
 	}
+	
+	/**
+	 * This test ensures, that the function {@link Tup3d#getNewInstance(double, double, double)}
+	 * returns a new instance of {@link Tup3d} with the given values.
+	 */
+	@Test
+	void getNewInstanceTest()
+	{
+		Tup3d t = new Tup3d(1.0, 1.0, 1.0);
+
+		Tup3d result = t.getNewInstance(2.0, 3.0, 4.0);
+		
+		assertNotSame(t, result);
+		assertEquals(2.0, result.getX());
+		assertEquals(3.0, result.getY());
+		assertEquals(4.0, result.getZ());
+	}
 }

--- a/barghos-core/src/test/java/org/barghos/core/test/tuple3/Tup3fTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/tuple3/Tup3fTest.java
@@ -297,4 +297,21 @@ class Tup3fTest
 		assertTrue(t.equals(new Tup3f(1.2f, 3.4f, 5.6f)));
 		assertTrue(t.equals(PTup3f.gen(1.2f, 3.4f, 5.6f)));
 	}
+	
+	/**
+	 * This test ensures, that the function {@link Tup3f#getNewInstance(float, float, float)}
+	 * returns a new instance of {@link Tup3f} with the given values.
+	 */
+	@Test
+	void getNewInstanceTest()
+	{
+		Tup3f t = new Tup3f(1.0f, 1.0f, 1.0f);
+
+		Tup3f result = t.getNewInstance(2.0f, 3.0f, 4.0f);
+		
+		assertNotSame(t, result);
+		assertEquals(2.0f, result.getX());
+		assertEquals(3.0f, result.getY());
+		assertEquals(4.0f, result.getZ());
+	}
 }

--- a/barghos-core/src/test/java/org/barghos/core/test/tuple3/Tup3iTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/tuple3/Tup3iTest.java
@@ -296,4 +296,21 @@ class Tup3iTest
 		assertTrue(t.equals(new Tup3i(1, 2, 3)));
 		assertTrue(t.equals(PTup3i.gen(1, 2, 3)));
 	}
+	
+	/**
+	 * This test ensures, that the function {@link Tup3i#getNewInstance(int, int, int)}
+	 * returns a new instance of {@link Tup3i} with the given values.
+	 */
+	@Test
+	void getNewInstanceTest()
+	{
+		Tup3i t = new Tup3i(1, 1, 1);
+
+		Tup3i result = t.getNewInstance(2, 3, 4);
+		
+		assertNotSame(t, result);
+		assertEquals(2, result.getX());
+		assertEquals(3, result.getY());
+		assertEquals(4, result.getZ());
+	}
 }

--- a/barghos-core/src/test/java/org/barghos/core/test/tuple3/Tup3lTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/tuple3/Tup3lTest.java
@@ -297,4 +297,21 @@ class Tup3lTest
 		assertTrue(t.equals(new Tup3l(1l, 2l, 3l)));
 		assertTrue(t.equals(PTup3l.gen(1l, 2l, 3l)));
 	}
+	
+	/**
+	 * This test ensures, that the function {@link Tup3l#getNewInstance(long, long, long)}
+	 * returns a new instance of {@link Tup3l} with the given values.
+	 */
+	@Test
+	void getNewInstanceTest()
+	{
+		Tup3l t = new Tup3l(1l, 1l, 1l);
+		
+		Tup3l result = t.getNewInstance(2l, 3l, 4l);
+		
+		assertNotSame(t, result);
+		assertEquals(2l, result.getX());
+		assertEquals(3l, result.getY());
+		assertEquals(4l, result.getZ());
+	}
 }

--- a/barghos-core/src/test/java/org/barghos/core/test/tuple3/Tup3oTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/tuple3/Tup3oTest.java
@@ -264,4 +264,21 @@ class Tup3oTest
 		assertTrue(t.equals(new Tup3o<>(1, "arg2", 3.3)));
 		assertTrue(t.equals(PTup3o.gen(1, "arg2", 3.3)));
 	}
+	
+	/**
+	 * This test ensures, that the function {@link Tup3o#getNewInstance(Object, Object, Object)}
+	 * returns a new instance of {@link Tup3o} with the given values.
+	 */
+	@Test
+	void getNewInstanceTest()
+	{
+		Tup3o<Long,Long,Long> t = new Tup3o<>(1l, 1l, 1l);
+		
+		Tup3o<Long,Long,Long> result = t.getNewInstance(2l, 3l, 4l);
+		
+		assertNotSame(t, result);
+		assertEquals(2l, (long)result.getX());
+		assertEquals(3l, (long)result.getY());
+		assertEquals(4l, (long)result.getZ());
+	}
 }

--- a/barghos-core/src/test/java/org/barghos/core/test/tuple3/Tup3objTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/tuple3/Tup3objTest.java
@@ -297,4 +297,21 @@ class Tup3objTest
 		assertTrue(t.equals(new Tup3obj(1, "arg2", 3.3)));
 		assertTrue(t.equals(PTup3obj.gen(1, "arg2", 3.3)));
 	}
+	
+	/**
+	 * This test ensures, that the function {@link Tup3obj#getNewInstance(Object, Object, Object)}
+	 * returns a new instance of {@link Tup3obj} with the given values.
+	 */
+	@Test
+	void getNewInstanceTest()
+	{
+		Tup3obj t = new Tup3obj(1l, 1l, 1l);
+		
+		Tup3obj result = t.getNewInstance(2l, 3l, 4l);
+		
+		assertNotSame(t, result);
+		assertEquals(2l, result.getX());
+		assertEquals(3l, result.getY());
+		assertEquals(4l, result.getZ());
+	}
 }

--- a/barghos-core/src/test/java/org/barghos/core/test/tuple3/Tup3sTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/tuple3/Tup3sTest.java
@@ -297,4 +297,21 @@ class Tup3sTest
 		assertTrue(t.equals(new Tup3s((short)1, (short)2, (short)3)));
 		assertTrue(t.equals(PTup3s.gen((short)1, (short)2, (short)3)));
 	}
+	
+	/**
+	 * This test ensures, that the function {@link Tup3s#getNewInstance(short, short, short)}
+	 * returns a new instance of {@link Tup3s} with the given values.
+	 */
+	@Test
+	void getNewInstanceTest()
+	{
+		Tup3s t = new Tup3s((short)1, (short)1, (short)1);
+		
+		Tup3s result = t.getNewInstance((short)2, (short)3, (short)4);
+		
+		assertNotSame(t, result);
+		assertEquals((short)2, result.getX());
+		assertEquals((short)3, result.getY());
+		assertEquals((short)4, result.getZ());
+	}
 }

--- a/barghos-core/src/test/java/org/barghos/core/test/tuple3/Tup3strTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/tuple3/Tup3strTest.java
@@ -297,4 +297,21 @@ class Tup3strTest
 		assertTrue(t.equals(new Tup3str("arg1", "arg2", "arg3")));
 		assertTrue(t.equals(PTup3str.gen("arg1", "arg2", "arg3")));
 	}
+	
+	/**
+	 * This test ensures, that the function {@link Tup3str#getNewInstance(String, String, String)}
+	 * returns a new instance of {@link Tup3str} with the given values.
+	 */
+	@Test
+	void getNewInstanceTest()
+	{
+		Tup3str t = new Tup3str("a", "a", "a");
+
+		Tup3str result = t.getNewInstance("b", "c", "d");
+		
+		assertNotSame(t, result);
+		assertEquals("b", result.getX());
+		assertEquals("c", result.getY());
+		assertEquals("d", result.getZ());
+	}
 }

--- a/barghos-core/src/test/java/org/barghos/core/test/tuple4/PTup4bTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/tuple4/PTup4bTest.java
@@ -146,4 +146,22 @@ class PTup4bTest
 		assertTrue(t.equals(new Tup4b((byte)1, (byte)2, (byte)3, (byte)4)));
 		assertTrue(t.equals(PTup4b.gen((byte)1, (byte)2, (byte)3, (byte)4)));	
 	}
+	
+	/**
+	 * This test ensures, that the function {@link PTup4b#getNewInstance(byte, byte, byte, byte)}
+	 * returns a new instance of {@link PTup4b} with the given values.
+	 */
+	@Test
+	void getNewInstanceTest()
+	{
+		PTup4b t = PTup4b.gen((byte)1, (byte)1, (byte)1, (byte)1);
+
+		PTup4b result = t.getNewInstance((byte)2, (byte)3, (byte)4, (byte)5);
+		
+		assertNotSame(t, result);
+		assertEquals((byte)2, result.getX());
+		assertEquals((byte)3, result.getY());
+		assertEquals((byte)4, result.getZ());
+		assertEquals((byte)5, result.getW());
+	}
 }

--- a/barghos-core/src/test/java/org/barghos/core/test/tuple4/PTup4bigdTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/tuple4/PTup4bigdTest.java
@@ -148,4 +148,22 @@ class PTup4bigdTest
 		assertTrue(t.equals(new Tup4bigd(BigDecimal.valueOf(1.1), BigDecimal.valueOf(2.2), BigDecimal.valueOf(3.3), BigDecimal.valueOf(4.4))));
 		assertTrue(t.equals(PTup4bigd.gen(BigDecimal.valueOf(1.1), BigDecimal.valueOf(2.2), BigDecimal.valueOf(3.3), BigDecimal.valueOf(4.4))));	
 	}
+	
+	/**
+	 * This test ensures, that the function {@link PTup4bigd#getNewInstance(BigDecimal, BigDecimal, BigDecimal, BigDecimal)}
+	 * returns a new instance of {@link PTup4bigd} with the given values.
+	 */
+	@Test
+	void getNewInstanceTest()
+	{
+		PTup4bigd t = PTup4bigd.gen(BigDecimal.valueOf(1.0), BigDecimal.valueOf(1.0), BigDecimal.valueOf(1.0), BigDecimal.valueOf(1.0));
+
+		PTup4bigd result = t.getNewInstance(BigDecimal.valueOf(2.0), BigDecimal.valueOf(3.0), BigDecimal.valueOf(4.0), BigDecimal.valueOf(5.0));
+		
+		assertNotSame(t, result);
+		assertEquals(BigDecimal.valueOf(2.0), result.getX());
+		assertEquals(BigDecimal.valueOf(3.0), result.getY());
+		assertEquals(BigDecimal.valueOf(4.0), result.getZ());
+		assertEquals(BigDecimal.valueOf(5.0), result.getW());
+	}
 }

--- a/barghos-core/src/test/java/org/barghos/core/test/tuple4/PTup4bigiTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/tuple4/PTup4bigiTest.java
@@ -148,4 +148,22 @@ class PTup4bigiTest
 		assertTrue(t.equals(new Tup4bigi(BigInteger.valueOf(1), BigInteger.valueOf(2), BigInteger.valueOf(3), BigInteger.valueOf(4))));
 		assertTrue(t.equals(PTup4bigi.gen(BigInteger.valueOf(1), BigInteger.valueOf(2), BigInteger.valueOf(3), BigInteger.valueOf(4))));	
 	}
+	
+	/**
+	 * This test ensures, that the function {@link PTup4bigi#getNewInstance(BigInteger, BigInteger, BigInteger, BigInteger)}
+	 * returns a new instance of {@link PTup4bigi} with the given values.
+	 */
+	@Test
+	void getNewInstanceTest()
+	{
+		PTup4bigi t = PTup4bigi.gen(BigInteger.valueOf(1), BigInteger.valueOf(1), BigInteger.valueOf(1), BigInteger.valueOf(1));
+
+		PTup4bigi result = t.getNewInstance(BigInteger.valueOf(2), BigInteger.valueOf(3), BigInteger.valueOf(4), BigInteger.valueOf(5));
+		
+		assertNotSame(t, result);
+		assertEquals(BigInteger.valueOf(2), result.getX());
+		assertEquals(BigInteger.valueOf(3), result.getY());
+		assertEquals(BigInteger.valueOf(4), result.getZ());
+		assertEquals(BigInteger.valueOf(5), result.getW());
+	}
 }

--- a/barghos-core/src/test/java/org/barghos/core/test/tuple4/PTup4boTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/tuple4/PTup4boTest.java
@@ -146,4 +146,22 @@ class PTup4boTest
 		assertTrue(t.equals(new Tup4bo(false, true, false, true)));
 		assertTrue(t.equals(PTup4bo.gen(false, true, false, true)));	
 	}
+	
+	/**
+	 * This test ensures, that the function {@link PTup4bo#getNewInstance(boolean, boolean, boolean, boolean)}
+	 * returns a new instance of {@link PTup4bo} with the given values.
+	 */
+	@Test
+	void getNewInstanceTest()
+	{
+		PTup4bo t = PTup4bo.gen(false, true, false, true);
+
+		PTup4bo result = t.getNewInstance(true, false, true, false);
+		
+		assertNotSame(t, result);
+		assertEquals(true, result.getX());
+		assertEquals(false, result.getY());
+		assertEquals(true, result.getZ());
+		assertEquals(false, result.getW());
+	}
 }

--- a/barghos-core/src/test/java/org/barghos/core/test/tuple4/PTup4cTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/tuple4/PTup4cTest.java
@@ -146,4 +146,22 @@ class PTup4cTest
 		assertTrue(t.equals(new Tup4c('a', 'b', 'c', 'd')));
 		assertTrue(t.equals(PTup4c.gen('a', 'b', 'c', 'd')));	
 	}
+	
+	/**
+	 * This test ensures, that the function {@link PTup4c#getNewInstance(char, char, char, char)}
+	 * returns a new instance of {@link PTup4c} with the given values.
+	 */
+	@Test
+	void getNewInstanceTest()
+	{
+		PTup4c t = PTup4c.gen('a', 'a', 'a', 'a');
+
+		PTup4c result = t.getNewInstance('b', 'c', 'd', 'e');
+		
+		assertNotSame(t, result);
+		assertEquals('b', result.getX());
+		assertEquals('c', result.getY());
+		assertEquals('d', result.getZ());
+		assertEquals('e', result.getW());
+	}
 }

--- a/barghos-core/src/test/java/org/barghos/core/test/tuple4/PTup4dTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/tuple4/PTup4dTest.java
@@ -146,4 +146,22 @@ class PTup4dTest
 		assertTrue(t.equals(new Tup4d(1.1, 2.2, 3.3, 4.4)));
 		assertTrue(t.equals(PTup4d.gen(1.1, 2.2, 3.3, 4.4)));	
 	}
+	
+	/**
+	 * This test ensures, that the function {@link PTup4d#getNewInstance(double, double, double, double)}
+	 * returns a new instance of {@link PTup4d} with the given values.
+	 */
+	@Test
+	void getNewInstanceTest()
+	{
+		PTup4d t = PTup4d.gen(1.0, 1.0, 1.0, 1.0);
+
+		PTup4d result = t.getNewInstance(2.0, 3.0, 4.0, 5.0);
+		
+		assertNotSame(t, result);
+		assertEquals(2.0, result.getX());
+		assertEquals(3.0, result.getY());
+		assertEquals(4.0, result.getZ());
+		assertEquals(5.0, result.getW());
+	}
 }

--- a/barghos-core/src/test/java/org/barghos/core/test/tuple4/PTup4fTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/tuple4/PTup4fTest.java
@@ -146,4 +146,22 @@ class PTup4fTest
 		assertTrue(t.equals(new Tup4f(1.1f, 2.2f, 3.3f, 4.4f)));
 		assertTrue(t.equals(PTup4f.gen(1.1f, 2.2f, 3.3f, 4.4f)));	
 	}
+	
+	/**
+	 * This test ensures, that the function {@link PTup4f#getNewInstance(float, float, float, float)}
+	 * returns a new instance of {@link PTup4f} with the given values.
+	 */
+	@Test
+	void getNewInstanceTest()
+	{
+		PTup4f t = PTup4f.gen(1.0f, 1.0f, 1.0f, 1.0f);
+
+		PTup4f result = t.getNewInstance(2.0f, 3.0f, 4.0f, 5.0f);
+		
+		assertNotSame(t, result);
+		assertEquals(2.0f, result.getX());
+		assertEquals(3.0f, result.getY());
+		assertEquals(4.0f, result.getZ());
+		assertEquals(5.0f, result.getW());
+	}
 }

--- a/barghos-core/src/test/java/org/barghos/core/test/tuple4/PTup4iTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/tuple4/PTup4iTest.java
@@ -146,4 +146,22 @@ class PTup4iTest
 		assertTrue(t.equals(new Tup4i(1, 2, 3, 4)));
 		assertTrue(t.equals(PTup4i.gen(1, 2, 3, 4)));	
 	}
+	
+	/**
+	 * This test ensures, that the function {@link PTup4i#getNewInstance(int, int, int, int)}
+	 * returns a new instance of {@link PTup4i} with the given values.
+	 */
+	@Test
+	void getNewInstanceTest()
+	{
+		PTup4i t = PTup4i.gen(1, 1, 1, 1);
+
+		PTup4i result = t.getNewInstance(2, 3, 4, 5);
+		
+		assertNotSame(t, result);
+		assertEquals(2, result.getX());
+		assertEquals(3, result.getY());
+		assertEquals(4, result.getZ());
+		assertEquals(5, result.getW());
+	}
 }

--- a/barghos-core/src/test/java/org/barghos/core/test/tuple4/PTup4lTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/tuple4/PTup4lTest.java
@@ -146,4 +146,22 @@ class PTup4lTest
 		assertTrue(t.equals(new Tup4l(1l, 2l, 3l, 4l)));
 		assertTrue(t.equals(PTup4l.gen(1l, 2l, 3l, 4l)));	
 	}
+	
+	/**
+	 * This test ensures, that the function {@link PTup4l#getNewInstance(long, long, long, long)}
+	 * returns a new instance of {@link PTup4l} with the given values.
+	 */
+	@Test
+	void getNewInstanceTest()
+	{
+		PTup4l t = PTup4l.gen(1l, 1l, 1l, 1l);
+
+		PTup4l result = t.getNewInstance(2l, 3l, 4l, 5l);
+		
+		assertNotSame(t, result);
+		assertEquals(2l, result.getX());
+		assertEquals(3l, result.getY());
+		assertEquals(4l, result.getZ());
+		assertEquals(5l, result.getW());
+	}
 }

--- a/barghos-core/src/test/java/org/barghos/core/test/tuple4/PTup4oTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/tuple4/PTup4oTest.java
@@ -129,4 +129,22 @@ class PTup4oTest
 		assertTrue(t.equals(new Tup4o<>(1, "arg2", 3.3, 'd')));
 		assertTrue(t.equals(PTup4o.gen(1, "arg2", 3.3, 'd')));	
 	}
+	
+	/**
+	 * This test ensures, that the function {@link PTup4o#getNewInstance(Object, Object, Object, Object)}
+	 * returns a new instance of {@link PTup4o} with the given values.
+	 */
+	@Test
+	void getNewInstanceTest()
+	{
+		PTup4o<Long,Long,Long,Long> t = PTup4o.gen(1l, 1l, 1l, 1l);
+
+		PTup4o<Long,Long,Long,Long> result = t.getNewInstance(2l, 3l, 4l, 5l);
+		
+		assertNotSame(t, result);
+		assertEquals(2l, (long)result.getX());
+		assertEquals(3l, (long)result.getY());
+		assertEquals(4l, (long)result.getZ());
+		assertEquals(5l, (long)result.getW());
+	}
 }

--- a/barghos-core/src/test/java/org/barghos/core/test/tuple4/PTup4objTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/tuple4/PTup4objTest.java
@@ -146,4 +146,22 @@ class PTup4objTest
 		assertTrue(t.equals(new Tup4obj(1, "arg2", 3.3, 'd')));
 		assertTrue(t.equals(PTup4obj.gen(1, "arg2", 3.3, 'd')));	
 	}
+	
+	/**
+	 * This test ensures, that the function {@link PTup4obj#getNewInstance(Object, Object, Object, Object)}
+	 * returns a new instance of {@link PTup4obj} with the given values.
+	 */
+	@Test
+	void getNewInstanceTest()
+	{
+		PTup4obj t = PTup4obj.gen(1l, 1l, 1l, 1l);
+
+		PTup4obj result = t.getNewInstance(2l, 3l, 4l, 5l);
+		
+		assertNotSame(t, result);
+		assertEquals(2l, result.getX());
+		assertEquals(3l, result.getY());
+		assertEquals(4l, result.getZ());
+		assertEquals(5l, result.getW());
+	}
 }

--- a/barghos-core/src/test/java/org/barghos/core/test/tuple4/PTup4sTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/tuple4/PTup4sTest.java
@@ -146,4 +146,22 @@ class PTup4sTest
 		assertTrue(t.equals(new Tup4s((short)1, (short)2, (short)3, (short)4)));
 		assertTrue(t.equals(PTup4s.gen((short)1, (short)2, (short)3, (short)4)));	
 	}
+	
+	/**
+	 * This test ensures, that the function {@link PTup4s#getNewInstance(short, short, short, short)}
+	 * returns a new instance of {@link PTup4s} with the given values.
+	 */
+	@Test
+	void getNewInstanceTest()
+	{
+		PTup4s t = PTup4s.gen((short)1, (short)1, (short)1, (short)1);
+
+		PTup4s result = t.getNewInstance((short)2, (short)3, (short)4, (short)5);
+		
+		assertNotSame(t, result);
+		assertEquals((short)2, result.getX());
+		assertEquals((short)3, result.getY());
+		assertEquals((short)4, result.getZ());
+		assertEquals((short)5, result.getW());
+	}
 }

--- a/barghos-core/src/test/java/org/barghos/core/test/tuple4/PTup4strTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/tuple4/PTup4strTest.java
@@ -146,4 +146,22 @@ class PTup4strTest
 		assertTrue(t.equals(new Tup4str("arg1", "arg2", "arg3", "arg4")));
 		assertTrue(t.equals(PTup4str.gen("arg1", "arg2", "arg3", "arg4")));	
 	}
+	
+	/**
+	 * This test ensures, that the function {@link PTup4str#getNewInstance(String, String, String, String)}
+	 * returns a new instance of {@link PTup4str} with the given values.
+	 */
+	@Test
+	void getNewInstanceTest()
+	{
+		PTup4str t = PTup4str.gen("a", "a", "a", "a");
+
+		PTup4str result = t.getNewInstance("b", "c", "d", "e");
+		
+		assertNotSame(t, result);
+		assertEquals("b", result.getX());
+		assertEquals("c", result.getY());
+		assertEquals("d", result.getZ());
+		assertEquals("e", result.getW());
+	}
 }

--- a/barghos-core/src/test/java/org/barghos/core/test/tuple4/Tup4bTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/tuple4/Tup4bTest.java
@@ -335,4 +335,22 @@ class Tup4bTest
 		assertTrue(t.equals(new Tup4b((byte)1, (byte)2, (byte)3, (byte)4)));
 		assertTrue(t.equals(PTup4b.gen((byte)1, (byte)2, (byte)3, (byte)4)));
 	}
+	
+	/**
+	 * This test ensures, that the function {@link Tup4b#getNewInstance(byte, byte, byte, byte)}
+	 * returns a new instance of {@link Tup4b} with the given values.
+	 */
+	@Test
+	void getNewInstanceTest()
+	{
+		Tup4b t = new Tup4b((byte)1, (byte)1, (byte)1, (byte)1);
+
+		Tup4b result = t.getNewInstance((byte)2, (byte)3, (byte)4, (byte)5);
+		
+		assertNotSame(t, result);
+		assertEquals((byte)2, result.getX());
+		assertEquals((byte)3, result.getY());
+		assertEquals((byte)4, result.getZ());
+		assertEquals((byte)5, result.getW());
+	}
 }

--- a/barghos-core/src/test/java/org/barghos/core/test/tuple4/Tup4bigdTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/tuple4/Tup4bigdTest.java
@@ -338,4 +338,22 @@ class Tup4bigdTest
 		assertTrue(t.equals(new Tup4bigd(BigDecimal.valueOf(1.1), BigDecimal.valueOf(2.2), BigDecimal.valueOf(3.3), BigDecimal.valueOf(4.4))));
 		assertTrue(t.equals(PTup4bigd.gen(BigDecimal.valueOf(1.1), BigDecimal.valueOf(2.2), BigDecimal.valueOf(3.3), BigDecimal.valueOf(4.4))));
 	}
+	
+	/**
+	 * This test ensures, that the function {@link Tup4bigd#getNewInstance(BigDecimal, BigDecimal, BigDecimal, BigDecimal)}
+	 * returns a new instance of {@link Tup4bigd} with the given values.
+	 */
+	@Test
+	void getNewInstanceTest()
+	{
+		Tup4bigd t = new Tup4bigd(BigDecimal.valueOf(1.0), BigDecimal.valueOf(1.0), BigDecimal.valueOf(1.0), BigDecimal.valueOf(1.0));
+
+		Tup4bigd result = t.getNewInstance(BigDecimal.valueOf(2.0), BigDecimal.valueOf(3.0), BigDecimal.valueOf(4.0), BigDecimal.valueOf(5.0));
+		
+		assertNotSame(t, result);
+		assertEquals(BigDecimal.valueOf(2.0), result.getX());
+		assertEquals(BigDecimal.valueOf(3.0), result.getY());
+		assertEquals(BigDecimal.valueOf(4.0), result.getZ());
+		assertEquals(BigDecimal.valueOf(5.0), result.getW());
+	}
 }

--- a/barghos-core/src/test/java/org/barghos/core/test/tuple4/Tup4bigiTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/tuple4/Tup4bigiTest.java
@@ -338,4 +338,22 @@ class Tup4bigiTest
 		assertTrue(t.equals(new Tup4bigi(BigInteger.valueOf(1), BigInteger.valueOf(2), BigInteger.valueOf(3), BigInteger.valueOf(4))));
 		assertTrue(t.equals(PTup4bigi.gen(BigInteger.valueOf(1), BigInteger.valueOf(2), BigInteger.valueOf(3), BigInteger.valueOf(4))));
 	}
+	
+	/**
+	 * This test ensures, that the function {@link Tup4bigi#getNewInstance(BigInteger, BigInteger, BigInteger, BigInteger)}
+	 * returns a new instance of {@link Tup4bigi} with the given values.
+	 */
+	@Test
+	void getNewInstanceTest()
+	{
+		Tup4bigi t = new Tup4bigi(BigInteger.valueOf(1), BigInteger.valueOf(1), BigInteger.valueOf(1), BigInteger.valueOf(1));
+
+		Tup4bigi result = t.getNewInstance(BigInteger.valueOf(2), BigInteger.valueOf(3), BigInteger.valueOf(4), BigInteger.valueOf(5));
+		
+		assertNotSame(t, result);
+		assertEquals(BigInteger.valueOf(2), result.getX());
+		assertEquals(BigInteger.valueOf(3), result.getY());
+		assertEquals(BigInteger.valueOf(4), result.getZ());
+		assertEquals(BigInteger.valueOf(5), result.getW());
+	}
 }

--- a/barghos-core/src/test/java/org/barghos/core/test/tuple4/Tup4boTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/tuple4/Tup4boTest.java
@@ -336,4 +336,22 @@ class Tup4boTest
 		assertTrue(t.equals(new Tup4bo(false, true, true, false)));
 		assertTrue(t.equals(PTup4bo.gen(false, true, true, false)));
 	}
+	
+	/**
+	 * This test ensures, that the function {@link Tup4bo#getNewInstance(boolean, boolean, boolean, boolean)}
+	 * returns a new instance of {@link Tup4bo} with the given values.
+	 */
+	@Test
+	void getNewInstanceTest()
+	{
+		Tup4bo t = new Tup4bo(false, true, false, true);
+
+		Tup4bo result = t.getNewInstance(true, false, true, false);
+		
+		assertNotSame(t, result);
+		assertEquals(true, result.getX());
+		assertEquals(false, result.getY());
+		assertEquals(true, result.getZ());
+		assertEquals(false, result.getW());
+	}
 }

--- a/barghos-core/src/test/java/org/barghos/core/test/tuple4/Tup4cTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/tuple4/Tup4cTest.java
@@ -336,4 +336,22 @@ class Tup4cTest
 		assertTrue(t.equals(new Tup4c('a', 'b', 'c', 'd')));
 		assertTrue(t.equals(PTup4c.gen('a', 'b', 'c', 'd')));
 	}
+	
+	/**
+	 * This test ensures, that the function {@link Tup4c#getNewInstance(char, char, char, char)}
+	 * returns a new instance of {@link Tup4c} with the given values.
+	 */
+	@Test
+	void getNewInstanceTest()
+	{
+		Tup4c t = new Tup4c('a', 'a', 'a', 'a');
+
+		Tup4c result = t.getNewInstance('b', 'c', 'd', 'e');
+		
+		assertNotSame(t, result);
+		assertEquals('b', result.getX());
+		assertEquals('c', result.getY());
+		assertEquals('d', result.getZ());
+		assertEquals('e', result.getW());
+	}
 }

--- a/barghos-core/src/test/java/org/barghos/core/test/tuple4/Tup4dTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/tuple4/Tup4dTest.java
@@ -336,4 +336,22 @@ class Tup4dTest
 		assertTrue(t.equals(new Tup4d(1.2, 3.4, 5.6, 7.8)));
 		assertTrue(t.equals(PTup4d.gen(1.2, 3.4, 5.6, 7.8)));
 	}
+	
+	/**
+	 * This test ensures, that the function {@link Tup4d#getNewInstance(double, double, double, double)}
+	 * returns a new instance of {@link Tup4d} with the given values.
+	 */
+	@Test
+	void getNewInstanceTest()
+	{
+		Tup4d t = new Tup4d(1.0, 1.0, 1.0, 1.0);
+
+		Tup4d result = t.getNewInstance(2.0, 3.0, 4.0, 5.0);
+		
+		assertNotSame(t, result);
+		assertEquals(2.0, result.getX());
+		assertEquals(3.0, result.getY());
+		assertEquals(4.0, result.getZ());
+		assertEquals(5.0, result.getW());
+	}
 }

--- a/barghos-core/src/test/java/org/barghos/core/test/tuple4/Tup4fTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/tuple4/Tup4fTest.java
@@ -336,4 +336,22 @@ class Tup4fTest
 		assertTrue(t.equals(new Tup4f(1.2f, 3.4f, 5.6f, 7.8f)));
 		assertTrue(t.equals(PTup4f.gen(1.2f, 3.4f, 5.6f, 7.8f)));
 	}
+	
+	/**
+	 * This test ensures, that the function {@link Tup4f#getNewInstance(float, float, float, float)}
+	 * returns a new instance of {@link Tup4f} with the given values.
+	 */
+	@Test
+	void getNewInstanceTest()
+	{
+		Tup4f t = new Tup4f(1.0f, 1.0f, 1.0f, 1.0f);
+
+		Tup4f result = t.getNewInstance(2.0f, 3.0f, 4.0f, 5.0f);
+		
+		assertNotSame(t, result);
+		assertEquals(2.0f, result.getX());
+		assertEquals(3.0f, result.getY());
+		assertEquals(4.0f, result.getZ());
+		assertEquals(5.0f, result.getW());
+	}
 }

--- a/barghos-core/src/test/java/org/barghos/core/test/tuple4/Tup4iTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/tuple4/Tup4iTest.java
@@ -335,4 +335,22 @@ class Tup4iTest
 		assertTrue(t.equals(new Tup4i(1, 2, 3, 4)));
 		assertTrue(t.equals(PTup4i.gen(1, 2, 3, 4)));
 	}
+	
+	/**
+	 * This test ensures, that the function {@link Tup4i#getNewInstance(int, int, int, int)}
+	 * returns a new instance of {@link Tup4i} with the given values.
+	 */
+	@Test
+	void getNewInstanceTest()
+	{
+		Tup4i t = new Tup4i(1, 1, 1, 1);
+
+		Tup4i result = t.getNewInstance(2, 3, 4, 5);
+		
+		assertNotSame(t, result);
+		assertEquals(2, result.getX());
+		assertEquals(3, result.getY());
+		assertEquals(4, result.getZ());
+		assertEquals(5, result.getW());
+	}
 }

--- a/barghos-core/src/test/java/org/barghos/core/test/tuple4/Tup4lTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/tuple4/Tup4lTest.java
@@ -336,4 +336,22 @@ class Tup4lTest
 		assertTrue(t.equals(new Tup4l(1l, 2l, 3l, 4l)));
 		assertTrue(t.equals(PTup4l.gen(1l, 2l, 3l, 4l)));
 	}
+	
+	/**
+	 * This test ensures, that the function {@link Tup4l#getNewInstance(long, long, long, long)}
+	 * returns a new instance of {@link Tup4l} with the given values.
+	 */
+	@Test
+	void getNewInstanceTest()
+	{
+		Tup4l t = new Tup4l(1l, 1l, 1l, 1l);
+
+		Tup4l result = t.getNewInstance(2l, 3l, 4l, 5l);
+		
+		assertNotSame(t, result);
+		assertEquals(2l, result.getX());
+		assertEquals(3l, result.getY());
+		assertEquals(4l, result.getZ());
+		assertEquals(5l, result.getW());
+	}
 }

--- a/barghos-core/src/test/java/org/barghos/core/test/tuple4/Tup4oTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/tuple4/Tup4oTest.java
@@ -301,4 +301,22 @@ class Tup4oTest
 		assertTrue(t.equals(new Tup4o<>(1, "arg2", 3.3, 'd')));
 		assertTrue(t.equals(PTup4o.gen(1, "arg2", 3.3, 'd')));
 	}
+	
+	/**
+	 * This test ensures, that the function {@link Tup4o#getNewInstance(Object, Object, Object, Object)}
+	 * returns a new instance of {@link Tup4o} with the given values.
+	 */
+	@Test
+	void getNewInstanceTest()
+	{
+		Tup4o<Long,Long,Long,Long> t = new Tup4o<>(1l, 1l, 1l, 1l);
+
+		Tup4o<Long,Long,Long,Long> result = t.getNewInstance(2l, 3l, 4l, 5l);
+		
+		assertNotSame(t, result);
+		assertEquals(2l, (long)result.getX());
+		assertEquals(3l, (long)result.getY());
+		assertEquals(4l, (long)result.getZ());
+		assertEquals(5l, (long)result.getW());
+	}
 }

--- a/barghos-core/src/test/java/org/barghos/core/test/tuple4/Tup4objTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/tuple4/Tup4objTest.java
@@ -336,4 +336,22 @@ class Tup4objTest
 		assertTrue(t.equals(new Tup4obj(1, "arg2", 3.3, 'd')));
 		assertTrue(t.equals(PTup4obj.gen(1, "arg2", 3.3, 'd')));
 	}
+	
+	/**
+	 * This test ensures, that the function {@link Tup4obj#getNewInstance(Object, Object, Object, Object)}
+	 * returns a new instance of {@link Tup4obj} with the given values.
+	 */
+	@Test
+	void getNewInstanceTest()
+	{
+		Tup4obj t = new Tup4obj(1l, 1l, 1l, 1l);
+
+		Tup4obj result = t.getNewInstance(2l, 3l, 4l, 5l);
+		
+		assertNotSame(t, result);
+		assertEquals(2l, result.getX());
+		assertEquals(3l, result.getY());
+		assertEquals(4l, result.getZ());
+		assertEquals(5l, result.getW());
+	}
 }

--- a/barghos-core/src/test/java/org/barghos/core/test/tuple4/Tup4sTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/tuple4/Tup4sTest.java
@@ -336,4 +336,22 @@ class Tup4sTest
 		assertTrue(t.equals(new Tup4s((short)1, (short)2, (short)3, (short)4)));
 		assertTrue(t.equals(PTup4s.gen((short)1, (short)2, (short)3, (short)4)));
 	}
+	
+	/**
+	 * This test ensures, that the function {@link Tup4s#getNewInstance(short, short, short, short)}
+	 * returns a new instance of {@link Tup4s} with the given values.
+	 */
+	@Test
+	void getNewInstanceTest()
+	{
+		Tup4s t = new Tup4s((short)1, (short)1, (short)1, (short)1);
+
+		Tup4s result = t.getNewInstance((short)2, (short)3, (short)4, (short)5);
+		
+		assertNotSame(t, result);
+		assertEquals((short)2, result.getX());
+		assertEquals((short)3, result.getY());
+		assertEquals((short)4, result.getZ());
+		assertEquals((short)5, result.getW());
+	}
 }

--- a/barghos-core/src/test/java/org/barghos/core/test/tuple4/Tup4strTest.java
+++ b/barghos-core/src/test/java/org/barghos/core/test/tuple4/Tup4strTest.java
@@ -336,4 +336,22 @@ class Tup4strTest
 		assertTrue(t.equals(new Tup4str("arg1", "arg2", "arg3", "arg4")));
 		assertTrue(t.equals(PTup4str.gen("arg1", "arg2", "arg3", "arg4")));
 	}
+	
+	/**
+	 * This test ensures, that the function {@link Tup4str#getNewInstance(String, String, String, String)}
+	 * returns a new instance of {@link Tup4str} with the given values.
+	 */
+	@Test
+	void getNewInstanceTest()
+	{
+		Tup4str t = new Tup4str("a", "a", "a", "a");
+
+		Tup4str result = t.getNewInstance("b", "c", "d", "e");
+		
+		assertNotSame(t, result);
+		assertEquals("b", result.getX());
+		assertEquals("c", result.getY());
+		assertEquals("d", result.getZ());
+		assertEquals("e", result.getW());
+	}
 }


### PR DESCRIPTION
Added three new functions getNewInstance to the readonly interfaces of
all tuple classes. The three functions handle the default inputs of
either a single tuple of the same data type, a single value which is
used for all components or dedicated parameters for each component. The
functions with the tuple and value parameter have a default
implementation direct in the readonly interfaces. They call the function
with the dedicated Parameters. These functions allow to create a new
instance of the original type. With this there is no need to know the
exact type for for example a clone operation. The desired behaviour of
these functions is always to return a new instance of the original type.
That means that if a function gets a parameter of the type Tup3fR passed
and the original type was a PTup3f, then if this function calls the
getNewInstance function the returned value will still be reduced to
Tup3fR but the created type will again be a PTup3f. This behaviour also
allows cloning actions in a default implementation of functions, where
before was always the question what type to return. From a logical point
this is also very important, as the behavior of any implemented function
can vary from type to type.